### PR TITLE
chore(deploy): bump PSF image + Thor .deb tags to 3041f93-2026-06-15_

### DIFF
--- a/deployments/profiles/base-thor.env
+++ b/deployments/profiles/base-thor.env
@@ -10,12 +10,12 @@ HOST_IP='' # change me — this Thor's IP
 
 # === Safety Core image (nv-psf container, multi-arch arm64+amd64, one tag) ===
 # TODO swap nv-metropolis-dev (dev) path/tag to prod (nvidia/outside-in-safety) once 1.2.1 propagates.
-PSF_IMAGE=nvcr.io/nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.2.1-release-c37ad41-2026-06-15_09-25  # multi-arch; Docker auto-selects arm64 on Thor (same tag as x86 base.env)
+PSF_IMAGE=nvcr.io/nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.2.1-release-3041f93-2026-06-15_14-39  # multi-arch; Docker auto-selects arm64 on Thor (same tag as x86 base.env)
 
 # === Thor Safety Core packages (NGC resources, downloaded once at setup; ngc_artifacts.md §4) ===
 # TODO swap nv-metropolis-dev (dev) paths/tags to prod (nvidia/outside-in-safety) once 1.2.1 propagates.
-PSF_TEGRA_RESOURCE=nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.2.1-aarch64-release-c37ad41-2026-06-15_09-25-psf-tegra          # host binaries .deb (atl_sdm, launch_hoisa, safety_monitor) for CCPLEX + FSI host side
-PSF_TEGRA_FSI_RESOURCE=nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.2.1-aarch64-release-c37ad41-2026-06-15_09-25-psf-tegra-fsi  # FSI firmware + fsicom-agent .deb (SDM_TARGET=fsi only)
+PSF_TEGRA_RESOURCE=nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.2.1-aarch64-release-3041f93-2026-06-15_14-39-psf-tegra          # host binaries .deb (atl_sdm, launch_hoisa, safety_monitor) for CCPLEX + FSI host side
+PSF_TEGRA_FSI_RESOURCE=nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.2.1-aarch64-release-3041f93-2026-06-15_14-39-psf-tegra-fsi  # FSI firmware + fsicom-agent .deb (SDM_TARGET=fsi only)
 
 # === SDM placement / launch mode ===
 SDM_TARGET=ccplex        # ccplex (host SDM, start here) | fsi (SDM on the Functional Safety Island — halos_thor.md §5B)

--- a/deployments/profiles/base.env
+++ b/deployments/profiles/base.env
@@ -18,7 +18,7 @@ MDX_DATA_DIR=/path/to/data # change me
 HOST_IP='' # change me
 
 COMM_UDP_PORT=12345   # PSF cmd target = VST halo_safety_udp_port (NOT comm-layer in base)
-PSF_IMAGE=nvcr.io/nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.2.1-release-c37ad41-2026-06-15_09-25  # TODO swap to prod path/tag (nvidia/outside-in-safety) once 1.2.1 propagates from dev
+PSF_IMAGE=nvcr.io/nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.2.1-release-3041f93-2026-06-15_14-39  # TODO swap to prod path/tag (nvidia/outside-in-safety) once 1.2.1 propagates from dev
 PSF_CMD_RX_IP=127.0.0.1
 PSF_LOG_DIR=${MDX_DATA_DIR}/psf-log
 DOCKER_GID=999 # change me — run: getent group docker | cut -d: -f3

--- a/deployments/profiles/sil.env
+++ b/deployments/profiles/sil.env
@@ -21,7 +21,7 @@ COMM_LOG_DIR=${MDX_DATA_DIR}/comm-layer
 ROS_DOMAIN_ID=0
 
 # === PSF ===
-PSF_IMAGE=nvcr.io/nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.2.1-release-c37ad41-2026-06-15_09-25  # TODO swap to prod path/tag (nvidia/outside-in-safety) once 1.2.1 propagates from dev
+PSF_IMAGE=nvcr.io/nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.2.1-release-3041f93-2026-06-15_14-39  # TODO swap to prod path/tag (nvidia/outside-in-safety) once 1.2.1 propagates from dev
 PSF_CMD_RX_IP=127.0.0.1
 PSF_LOG_DIR=${MDX_DATA_DIR}/psf-log
 


### PR DESCRIPTION
Update PSF_IMAGE (base/sil/base-thor) and the Thor PSF_TEGRA_RESOURCE / PSF_TEGRA_FSI_RESOURCE tags to the current dev build 3041f93-2026-06-15_14-39 (verified against the HOISA User Guide download commands).