### PR TITLE
docs(skill): align hoisa-deploy-profile with Isaac Sim 6.0

### DIFF
--- a/deployments/scripts/deploy_hoisa_launchable.ipynb
+++ b/deployments/scripts/deploy_hoisa_launchable.ipynb
@@ -584,7 +584,7 @@
         "Applied **before** deploying VSS — if VSS builds its TensorRT engine with the wrong config, a restart costs another ~15 min.\n",
         "\n",
         "1. **`warehouse-operations/.env`** → `bp_wh_kafka` (PSF needs Kafka), `LLM_MODE/VLM_MODE=none`, 3-cam synthetic dataset, `NUM_STREAMS=3`, extended profile, hardware profile, paths, IPs (+ Brev secure-link overrides if applicable).\n",
-        "2. **`ds-main-config.txt`** → disable SEI extraction + `attach-sys-ts-as-ntp=1` (Isaac RTSP carries no SEI; otherwise FPS stays 0 and PSF drops events as STALE).\n",
+        "2. **`ds-main-config.txt`** → `attach-sys-ts-as-ntp=1` + leave SEI sim-time off (Isaac 6.0 embeds SEI, but using its sim-time as the NTP timestamp makes PSF drop events as STALE; SEI extraction itself doesn't affect FPS).\n",
         "3. **`vst_config.json`** → `bbox_tolerance_ms=100` (reduces bbox flicker).\n"
       ]
     },

--- a/deployments/scripts/deploy_hoisa_launchable.ipynb
+++ b/deployments/scripts/deploy_hoisa_launchable.ipynb
@@ -584,7 +584,7 @@
         "Applied **before** deploying VSS — if VSS builds its TensorRT engine with the wrong config, a restart costs another ~15 min.\n",
         "\n",
         "1. **`warehouse-operations/.env`** → `bp_wh_kafka` (PSF needs Kafka), `LLM_MODE/VLM_MODE=none`, 3-cam synthetic dataset, `NUM_STREAMS=3`, extended profile, hardware profile, paths, IPs (+ Brev secure-link overrides if applicable).\n",
-        "2. **`ds-main-config.txt`** → `attach-sys-ts-as-ntp=1` + leave SEI sim-time off (Isaac 6.0 embeds SEI, but using its sim-time as the NTP timestamp makes PSF drop events as STALE; SEI extraction itself doesn't affect FPS).\n",
+        "2. **`ds-main-config.txt`** → disable SEI extraction + `attach-sys-ts-as-ntp=1` (Isaac 6.0 embeds SEI, but PSF currently doesn't support sim time, so using it as the timestamp makes PSF drop events as STALE).\n",
         "3. **`vst_config.json`** → `bbox_tolerance_ms=100` (reduces bbox flicker).\n"
       ]
     },

--- a/skills/hoisa-deploy-profile/SKILL.md
+++ b/skills/hoisa-deploy-profile/SKILL.md
@@ -26,8 +26,7 @@ Deployment has two stacks that must come up in order — do NOT skip or reorder.
 
 ## Profiles
 
-Pick one profile and activate it with `--profile <profile>` (+ `COMPOSE_PROFILES`) — see
-`halos_deploy.md` (old Compose ignores `COMPOSE_PROFILES` from `--env-file`). Services started:
+Pick one profile (set `COMPOSE_PROFILES` in the profile run-env). Services started:
 
 | Profile | Services | Use |
 |---------|----------|-----|
@@ -99,10 +98,10 @@ Each phase ends when its ready signal becomes true. Poll, don't wait by time.
 | VSS Kafka | `docker exec kafka kafka-console-consumer --bootstrap-server localhost:9092 --topic mdx-events --max-messages 1 --timeout-ms 30000` exits 0 |
 | Halos services | The profile's services are all Up (`sil` = 4: safety-core, comm-layer, isaac-sim, forklift-controller; `base` = 1) |
 | PSF wired | `<sil-data>/comm-layer/opc_server.log` exists and is non-empty |
-| **ROS link** | **Primary:** sim-driven MUTE↔UNMUTE in `<sil-data>/comm-layer/opc_server.log` proves the bridge publishes `/safety/is_muted` and Isaac acts on it. The documented `ros2 topic info /safety/is_muted -v` (`Publisher count: 1`) **often can't enumerate** from inside `comm-layer` under `ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST` (CycloneDDS loopback SPDP hides the participant from the ros2 CLI daemon) — returns `Unknown topic`/empty even when healthy, so **don't block on it**. `2+` publishers only matter on `SUBNET`/multi-host — see `troubleshooting.md`. |
-| Isaac Sim streaming | Isaac's 3 self-hosted RTSP streams are live **and** DeepStream ingested them. **Bootstrap-immune gate:** kit-log `RTSP stream started … encoding=h264` ×3 (only Isaac emits it — the VSS sample-video bootstrap also registers ~3 DeepStream streams, so a bare "net `added`−`removed` ≥3" can fire *early* on bootstrap). Then confirm DeepStream net active ≥3. Gate on this handoff, **not** a shader-log string (first-run RT compile is slow). Poll commands in `test_scenario.md`. |
-| Isaac Sim wired | Same evidence as **ROS link** above — MUTE/UNMUTE actually toggling Isaac's forklift proves its Action Graph is subscribed. `ros2 topic info … Subscription count: 1` is the documented check but usually can't enumerate under loopback discovery. |
-| Sim-driven safety | Safety transitions **after** Isaac streams came up (not sample-video bootstrap). **Authoritative:** MUTE↔UNMUTE in `<sil-data>/comm-layer/opc_server.log`. The driver may be **forklift tripwire IN/OUT** (`EVENT_0/1`) **or person restricted-area ROI** (`EVENT_4/5`) depending on the scene/segments — either counts; don't require forklift events specifically (the forklift may do a single pass then park). |
+| **ROS isolation** | `docker exec comm-layer bash -c "source /opt/ros/jazzy/setup.bash && ros2 topic info /safety/is_muted -v"` shows **`Publisher count: 1`** (if 2+, multi-machine `ROS_DOMAIN_ID` collision — see `troubleshooting.md`) |
+| Isaac Sim streaming | Isaac's 3 self-hosted RTSP streams live **and** DeepStream ingested them (the Isaac→VSS handoff). Gate on the handoff, **not** a shader-log string; a bare "3 active streams" can false-positive on VSS bootstrap — bootstrap-immune poll commands in `test_scenario.md`. |
+| Isaac Sim wired | `ros2 topic info /safety/is_muted -v` shows **`Subscription count: 1`** (Isaac forklift Action Graph connected) |
+| Sim-driven safety | forklift/trailer transitions in `<sil-data>/psf-log/pss.log` **after** Isaac streams came up (not sample-video bootstrap traffic) |
 
 The exact poll command for each signal is in the corresponding reference doc.
 
@@ -121,8 +120,7 @@ Deploy in strict order. **Stack 1 (VSS) must be running before Stack 2 (Halos).*
 - [ ] 5. Poll VSS perception + Kafka ready signals
 - [ ] 6. Configure deployments/profiles/<profile>.env, then
         deploy Halos (setup.sh + cleanup + compose up --build)   → references/halos_deploy.md
-- [ ] 7. ROS: single-host keeps ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST; verify the link
-        functionally via OPC MUTE/UNMUTE (multi-host: unique ROS_DOMAIN_ID + Publisher count=1)
+- [ ] 7. Set a unique ROS_DOMAIN_ID (0-232) + verify Publisher count=1
 - [ ] 8. (sil) Run the Isaac Sim test scenario                   → references/test_scenario.md
 - [ ] 9. Monitor until sim-driven safety transitions appear (the "complete" signal)
 ```
@@ -152,14 +150,14 @@ Deploy in strict order. **Stack 1 (VSS) must be running before Stack 2 (Halos).*
 | `VSS_DEPLOY_PROFILE` | Deploy VSS Warehouse 3.2 with the `vss-deploy-profile` skill; apply SIL overrides before its `docker compose up` | `vss_2d_overrides.md` |
 | `VSS_BEFORE_HALOS` | VSS Warehouse **must** be running and healthy before deploying Halos | `vss_2d_overrides.md` |
 | `KAFKA_BEFORE_PSF` | Kafka must be up before PSF starts — PSF connects to Kafka on startup | `troubleshooting.md` |
-| `DEEPSTREAM_SEI` | Use **system timestamps** (`attach-sys-ts-as-ntp=1`) + do **not** use SEI sim-time in DeepStream. Isaac 6.0 RTSP *does* embed SEI and DeepStream extracts it fine (FPS stays healthy), but feeding its sim-time as NTP desyncs PSF's decision window → events dropped as STALE, MUTE stops. Keep `extract-sei-sim-time`/`drop-backward-sei` off. | `vss_2d_overrides.md` |
+| `DEEPSTREAM_SEI` | **Disable** SEI extraction + use system timestamps (`attach-sys-ts-as-ntp=1`) in DeepStream. Isaac 6.0 embeds SEI, but **PSF doesn't support sim time** — using it drops events as STALE, so key off system (wall-clock) time | `vss_2d_overrides.md` |
 | `BP_PROFILE_KAFKA` | VSS must use `BP_PROFILE=bp_wh_kafka` (not `bp_wh`) for Halos integration | `vss_2d_overrides.md` |
 | `LLM_VLM_NONE` | Set `LLM_MODE=none` and `VLM_MODE=none` — not needed for safety SIL | `vss_2d_overrides.md` |
 | `HALO_SAFETY_BASE` | **`base` profile**: to render the safety overlay, set `halo_safety_udp_port` in the VSS 2D `vst_config.json` from `-1` → `12345` (must equal `COMM_UDP_PORT`), then restart VST | `halos_deploy.md`, `vss_2d_overrides.md` |
 | `THOR_BASE` | **`base`: detect the platform** (`uname -m`). `x86_64` → standard container base. **`aarch64` (IGX Thor)** → **ask the user** which SDM target before deploying — **CCPLEX** (decision-maker as host software on the Thor application cores; simpler, no firmware change) or **FSI** (decision-maker on the Functional Safety Island, the on-die safety microcontroller; needs a one-time firmware reflash) — then launch via `launch_thor_safety.sh` (hybrid container + host binaries, **not** `docker compose`) | `halos_thor.md` |
 | `HOST_IP_BOTH` | `HOST_IP` must be set in **both** the VSS and Halos run-env files | `halos_deploy.md` |
 | `SIL_DATA_PATH` | Halos `MDX_DATA_DIR` points to **sil-data** (has `collected-assets/`), not VSS app-data | `halos_deploy.md`, `ngc_artifacts.md` |
-| `ROS_DOMAIN_UNIQUE` | Single-host SIL: keep `ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST` (scopes ROS2 discovery to loopback — fixes cloud VMs blocking multicast). `ROS_DOMAIN_ID` uniqueness (0-232) only matters on `SUBNET`/multi-host; verify the link functionally via OPC MUTE/UNMUTE (the `ros2` CLI often can't enumerate under loopback) | `halos_deploy.md`, `troubleshooting.md` |
+| `ROS_DOMAIN_UNIQUE` | Assign a unique `ROS_DOMAIN_ID` (0-232) per machine; verify `Publisher count: 1` on `/safety/is_muted` | `halos_deploy.md`, `troubleshooting.md` |
 | `GPU_NOT_PERCEPTION` | Run Isaac Sim on a GPU (RT cores, >20 GB) that is **not** running VSS perception | `prerequisites.md`, `halos_deploy.md` |
 | `SETUP_BEFORE_UP` | Run `setup.sh <profile>` and `cleanup_all_datalog.sh <profile>` **before** `docker compose up` (both read `profiles/<profile>.env`) | `halos_deploy.md` |
 | `POLL_NEVER_WAIT` | First VSS startup takes 10-15 min (TensorRT build); Isaac shaders ~5-10 min — **poll** the ready signal, never `docker logs -f` or a fixed timer | (this file) |

--- a/skills/hoisa-deploy-profile/SKILL.md
+++ b/skills/hoisa-deploy-profile/SKILL.md
@@ -5,12 +5,12 @@ description: >-
   (base / sil / hil) on top of the VSS Warehouse 3.2 perception backend.
   Clone the OSS repo, pick a profile, deploy. Covers prerequisites, NGC
   artifacts (sil-data + PSF + VSS images), VSS SIL overrides, the Halos
-  stack (PSF, comm-layer, Isaac Sim, MediaMTX), test scenario, and
+  stack (PSF, comm-layer, Isaac Sim, forklift-controller), test scenario, and
   monitoring. Use when asked to deploy Halos, deploy HOISA, deploy SIL,
   set up warehouse safety simulation, or run outside-in safety testing.
 metadata:
   author: NVIDIA
-  version: 1.0.0
+  version: 1.3.0
 ---
 
 # Halos Outside-In Safety — Deploy by Profile (VSS 3.2)
@@ -31,8 +31,8 @@ Pick one profile (set `COMPOSE_PROFILES` in the profile run-env). Services start
 | Profile | Services | Use |
 |---------|----------|-----|
 | `base` | safety-core | Safety on an existing VSS feed; MUTE/UNMUTE rendered as the VST `halo_safety` overlay ("Standard"/"Efficient Mode" + proximity bubble). No Isaac Sim. |
-| `sil` | safety-core, comm-layer, isaac-sim, mediamtx | Full single-host closed loop: Isaac Sim stimulus → VSS perception → PSF → ROS → Isaac forklift. |
-| `hil` 🚧 | comm-layer, isaac-sim, mediamtx | 🚧 **Under development.** |
+| `sil` | safety-core, comm-layer, isaac-sim, forklift-controller | Full single-host closed loop: Isaac Sim stimulus → VSS perception → PSF → ROS → Isaac forklift. |
+| `hil` 🚧 | comm-layer, isaac-sim, forklift-controller | 🚧 **Under development.** |
 
 > **2D today. A 3D (Sparse4D) profile is 🚧 under development** — see
 > `references/vss_3d_overrides.md` when it lands.
@@ -45,7 +45,7 @@ Pick one profile (set `COMPOSE_PROFILES` in the profile run-env). Services start
 
 ```
 Isaac Sim (forklift + digital humans, segments-driven)
-     ↓ RTSP (3 cameras, H265, via MediaMTX)
+     ↓ RTSP (3 cameras, H264, self-hosted per-camera 8554/8555/8556)
 VSS Warehouse 3.2 (AI Perception)
      ├─ vss-rtvi-cv: detection + tracking
      └─ vss-behavior-analytics: ROI / tripwire (forklift-in-trailer)
@@ -96,10 +96,10 @@ Each phase ends when its ready signal becomes true. Poll, don't wait by time.
 | NGC artifacts | sil-data extracted (`collected-assets/` present) + `PSF_IMAGE` pulled + VSS images present |
 | VSS perception | `docker logs vss-rtvi-cv 2>&1 \| grep -c "stream_name Camera"` returns ≥ 3, all non-zero FPS |
 | VSS Kafka | `docker exec kafka kafka-console-consumer --bootstrap-server localhost:9092 --topic mdx-events --max-messages 1 --timeout-ms 30000` exits 0 |
-| Halos services | The profile's services are all Up (`sil` = 4: safety-core, comm-layer, isaac-sim, mediamtx; `base` = 1) |
+| Halos services | The profile's services are all Up (`sil` = 4: safety-core, comm-layer, isaac-sim, forklift-controller; `base` = 1) |
 | PSF wired | `<sil-data>/comm-layer/opc_server.log` exists and is non-empty |
-| **ROS isolation** | `docker exec comm-layer bash -c "source /opt/ros/jazzy/setup.bash && ros2 topic info /safety/is_muted -v"` shows **`Publisher count: 1`** (if 2+, multi-machine `ROS_DOMAIN_ID` collision — see `troubleshooting.md`) |
-| Isaac Sim streaming | DeepStream `vss-rtvi-cv` has 3 active Isaac streams: count of `new stream added [` **minus** `new stream removed [` ≥ 3 (net handles re-runs). First-run RT shader compile is slow — gate on this handoff, **not** a shader-log string (absent on Isaac 5.1.0). Poll command in `test_scenario.md`. |
+| **ROS isolation** | `docker exec comm-layer bash -c "source /opt/ros/jazzy/setup.bash && ros2 topic info /safety/is_muted -v"` shows **`Publisher count: 1`**. Single-host SIL sets `ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST` (in `sil.env`) so discovery stays on loopback — required on cloud VMs that block UDP multicast. If `2+`, another host on `SUBNET` shares your `ROS_DOMAIN_ID` — see `troubleshooting.md`. (Functional fallback: sim-driven MUTE/UNMUTE reaching the OPC log already proves the ROS link.) |
+| Isaac Sim streaming | DeepStream `vss-rtvi-cv` has 3 active Isaac streams: count of `new stream added [` **minus** `new stream removed [` ≥ 3 (net handles re-runs; the sample-video bootstrap sensor is deleted and 3 Isaac H264 streams added). First-run RT shader compile is slow — gate on this handoff, **not** a shader-log string. Poll command in `test_scenario.md`. |
 | Isaac Sim wired | `ros2 topic info /safety/is_muted -v` shows **`Subscription count: 1`** (Isaac forklift Action Graph connected) |
 | Sim-driven safety | forklift/trailer transitions in `<sil-data>/psf-log/pss.log` **after** Isaac streams came up (not sample-video bootstrap traffic) |
 
@@ -150,14 +150,14 @@ Deploy in strict order. **Stack 1 (VSS) must be running before Stack 2 (Halos).*
 | `VSS_DEPLOY_PROFILE` | Deploy VSS Warehouse 3.2 with the `vss-deploy-profile` skill; apply SIL overrides before its `docker compose up` | `vss_2d_overrides.md` |
 | `VSS_BEFORE_HALOS` | VSS Warehouse **must** be running and healthy before deploying Halos | `vss_2d_overrides.md` |
 | `KAFKA_BEFORE_PSF` | Kafka must be up before PSF starts — PSF connects to Kafka on startup | `troubleshooting.md` |
-| `DEEPSTREAM_SEI` | **Disable** SEI extraction + enable system timestamps in DeepStream — Isaac Sim RTSP carries no SEI | `vss_2d_overrides.md` |
+| `DEEPSTREAM_SEI` | Use **system timestamps** (`attach-sys-ts-as-ntp=1`) + do **not** use SEI sim-time in DeepStream. Isaac 6.0 RTSP *does* embed SEI and DeepStream extracts it fine (FPS stays healthy), but feeding its sim-time as NTP desyncs PSF's decision window → events dropped as STALE, MUTE stops. Keep `extract-sei-sim-time`/`drop-backward-sei` off. | `vss_2d_overrides.md` |
 | `BP_PROFILE_KAFKA` | VSS must use `BP_PROFILE=bp_wh_kafka` (not `bp_wh`) for Halos integration | `vss_2d_overrides.md` |
 | `LLM_VLM_NONE` | Set `LLM_MODE=none` and `VLM_MODE=none` — not needed for safety SIL | `vss_2d_overrides.md` |
 | `HALO_SAFETY_BASE` | **`base` profile**: to render the safety overlay, set `halo_safety_udp_port` in the VSS 2D `vst_config.json` from `-1` → `12345` (must equal `COMM_UDP_PORT`), then restart VST | `halos_deploy.md`, `vss_2d_overrides.md` |
 | `THOR_BASE` | **`base`: detect the platform** (`uname -m`). `x86_64` → standard container base. **`aarch64` (IGX Thor)** → **ask the user** which SDM target before deploying — **CCPLEX** (decision-maker as host software on the Thor application cores; simpler, no firmware change) or **FSI** (decision-maker on the Functional Safety Island, the on-die safety microcontroller; needs a one-time firmware reflash) — then launch via `launch_thor_safety.sh` (hybrid container + host binaries, **not** `docker compose`) | `halos_thor.md` |
 | `HOST_IP_BOTH` | `HOST_IP` must be set in **both** the VSS and Halos run-env files | `halos_deploy.md` |
 | `SIL_DATA_PATH` | Halos `MDX_DATA_DIR` points to **sil-data** (has `collected-assets/`), not VSS app-data | `halos_deploy.md`, `ngc_artifacts.md` |
-| `ROS_DOMAIN_UNIQUE` | Assign a unique `ROS_DOMAIN_ID` (0-232) per machine; verify `Publisher count: 1` on `/safety/is_muted` | `halos_deploy.md`, `troubleshooting.md` |
+| `ROS_DOMAIN_UNIQUE` | Single-host SIL: keep `ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST` (scopes ROS2 discovery to loopback — fixes cloud VMs blocking multicast). `ROS_DOMAIN_ID` uniqueness (0-232) only matters on `SUBNET`/multi-host; verify `Publisher count: 1` on `/safety/is_muted` | `halos_deploy.md`, `troubleshooting.md` |
 | `GPU_NOT_PERCEPTION` | Run Isaac Sim on a GPU (RT cores, >20 GB) that is **not** running VSS perception | `prerequisites.md`, `halos_deploy.md` |
 | `SETUP_BEFORE_UP` | Run `setup.sh <profile>` and `cleanup_all_datalog.sh <profile>` **before** `docker compose up` (both read `profiles/<profile>.env`) | `halos_deploy.md` |
 | `POLL_NEVER_WAIT` | First VSS startup takes 10-15 min (TensorRT build); Isaac shaders ~5-10 min — **poll** the ready signal, never `docker logs -f` or a fixed timer | (this file) |
@@ -171,7 +171,7 @@ Deploy in strict order. **Stack 1 (VSS) must be running before Stack 2 (Halos).*
 | Stack | Services | Source |
 |-------|----------|--------|
 | VSS Warehouse 3.2 | vss-vios-*, vss-rtvi-cv, vss-behavior-analytics, vss-configurator, kafka, redis, … | `vss-deploy-profile` skill (VSS repo) |
-| Halos (profile) | safety-core, comm-layer, isaac-sim, mediamtx | this OSS repo (`deployments/compose.yaml`) + `PSF_IMAGE` from NGC |
+| Halos (profile) | safety-core, comm-layer, isaac-sim, forklift-controller | this OSS repo (`deployments/compose.yaml`) + `PSF_IMAGE` from NGC |
 
 ---
 

--- a/skills/hoisa-deploy-profile/SKILL.md
+++ b/skills/hoisa-deploy-profile/SKILL.md
@@ -26,7 +26,8 @@ Deployment has two stacks that must come up in order — do NOT skip or reorder.
 
 ## Profiles
 
-Pick one profile (set `COMPOSE_PROFILES` in the profile run-env). Services started:
+Pick one profile and activate it with `--profile <profile>` (+ `COMPOSE_PROFILES`) — see
+`halos_deploy.md` (old Compose ignores `COMPOSE_PROFILES` from `--env-file`). Services started:
 
 | Profile | Services | Use |
 |---------|----------|-----|
@@ -98,10 +99,10 @@ Each phase ends when its ready signal becomes true. Poll, don't wait by time.
 | VSS Kafka | `docker exec kafka kafka-console-consumer --bootstrap-server localhost:9092 --topic mdx-events --max-messages 1 --timeout-ms 30000` exits 0 |
 | Halos services | The profile's services are all Up (`sil` = 4: safety-core, comm-layer, isaac-sim, forklift-controller; `base` = 1) |
 | PSF wired | `<sil-data>/comm-layer/opc_server.log` exists and is non-empty |
-| **ROS isolation** | `docker exec comm-layer bash -c "source /opt/ros/jazzy/setup.bash && ros2 topic info /safety/is_muted -v"` shows **`Publisher count: 1`**. Single-host SIL sets `ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST` (in `sil.env`) so discovery stays on loopback — required on cloud VMs that block UDP multicast. If `2+`, another host on `SUBNET` shares your `ROS_DOMAIN_ID` — see `troubleshooting.md`. (Functional fallback: sim-driven MUTE/UNMUTE reaching the OPC log already proves the ROS link.) |
-| Isaac Sim streaming | DeepStream `vss-rtvi-cv` has 3 active Isaac streams: count of `new stream added [` **minus** `new stream removed [` ≥ 3 (net handles re-runs; the sample-video bootstrap sensor is deleted and 3 Isaac H264 streams added). First-run RT shader compile is slow — gate on this handoff, **not** a shader-log string. Poll command in `test_scenario.md`. |
-| Isaac Sim wired | `ros2 topic info /safety/is_muted -v` shows **`Subscription count: 1`** (Isaac forklift Action Graph connected) |
-| Sim-driven safety | forklift/trailer transitions in `<sil-data>/psf-log/pss.log` **after** Isaac streams came up (not sample-video bootstrap traffic) |
+| **ROS link** | **Primary:** sim-driven MUTE↔UNMUTE in `<sil-data>/comm-layer/opc_server.log` proves the bridge publishes `/safety/is_muted` and Isaac acts on it. The documented `ros2 topic info /safety/is_muted -v` (`Publisher count: 1`) **often can't enumerate** from inside `comm-layer` under `ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST` (CycloneDDS loopback SPDP hides the participant from the ros2 CLI daemon) — returns `Unknown topic`/empty even when healthy, so **don't block on it**. `2+` publishers only matter on `SUBNET`/multi-host — see `troubleshooting.md`. |
+| Isaac Sim streaming | Isaac's 3 self-hosted RTSP streams are live **and** DeepStream ingested them. **Bootstrap-immune gate:** kit-log `RTSP stream started … encoding=h264` ×3 (only Isaac emits it — the VSS sample-video bootstrap also registers ~3 DeepStream streams, so a bare "net `added`−`removed` ≥3" can fire *early* on bootstrap). Then confirm DeepStream net active ≥3. Gate on this handoff, **not** a shader-log string (first-run RT compile is slow). Poll commands in `test_scenario.md`. |
+| Isaac Sim wired | Same evidence as **ROS link** above — MUTE/UNMUTE actually toggling Isaac's forklift proves its Action Graph is subscribed. `ros2 topic info … Subscription count: 1` is the documented check but usually can't enumerate under loopback discovery. |
+| Sim-driven safety | Safety transitions **after** Isaac streams came up (not sample-video bootstrap). **Authoritative:** MUTE↔UNMUTE in `<sil-data>/comm-layer/opc_server.log`. The driver may be **forklift tripwire IN/OUT** (`EVENT_0/1`) **or person restricted-area ROI** (`EVENT_4/5`) depending on the scene/segments — either counts; don't require forklift events specifically (the forklift may do a single pass then park). |
 
 The exact poll command for each signal is in the corresponding reference doc.
 
@@ -120,7 +121,8 @@ Deploy in strict order. **Stack 1 (VSS) must be running before Stack 2 (Halos).*
 - [ ] 5. Poll VSS perception + Kafka ready signals
 - [ ] 6. Configure deployments/profiles/<profile>.env, then
         deploy Halos (setup.sh + cleanup + compose up --build)   → references/halos_deploy.md
-- [ ] 7. Set a unique ROS_DOMAIN_ID (0-232) + verify Publisher count=1
+- [ ] 7. ROS: single-host keeps ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST; verify the link
+        functionally via OPC MUTE/UNMUTE (multi-host: unique ROS_DOMAIN_ID + Publisher count=1)
 - [ ] 8. (sil) Run the Isaac Sim test scenario                   → references/test_scenario.md
 - [ ] 9. Monitor until sim-driven safety transitions appear (the "complete" signal)
 ```
@@ -157,7 +159,7 @@ Deploy in strict order. **Stack 1 (VSS) must be running before Stack 2 (Halos).*
 | `THOR_BASE` | **`base`: detect the platform** (`uname -m`). `x86_64` → standard container base. **`aarch64` (IGX Thor)** → **ask the user** which SDM target before deploying — **CCPLEX** (decision-maker as host software on the Thor application cores; simpler, no firmware change) or **FSI** (decision-maker on the Functional Safety Island, the on-die safety microcontroller; needs a one-time firmware reflash) — then launch via `launch_thor_safety.sh` (hybrid container + host binaries, **not** `docker compose`) | `halos_thor.md` |
 | `HOST_IP_BOTH` | `HOST_IP` must be set in **both** the VSS and Halos run-env files | `halos_deploy.md` |
 | `SIL_DATA_PATH` | Halos `MDX_DATA_DIR` points to **sil-data** (has `collected-assets/`), not VSS app-data | `halos_deploy.md`, `ngc_artifacts.md` |
-| `ROS_DOMAIN_UNIQUE` | Single-host SIL: keep `ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST` (scopes ROS2 discovery to loopback — fixes cloud VMs blocking multicast). `ROS_DOMAIN_ID` uniqueness (0-232) only matters on `SUBNET`/multi-host; verify `Publisher count: 1` on `/safety/is_muted` | `halos_deploy.md`, `troubleshooting.md` |
+| `ROS_DOMAIN_UNIQUE` | Single-host SIL: keep `ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST` (scopes ROS2 discovery to loopback — fixes cloud VMs blocking multicast). `ROS_DOMAIN_ID` uniqueness (0-232) only matters on `SUBNET`/multi-host; verify the link functionally via OPC MUTE/UNMUTE (the `ros2` CLI often can't enumerate under loopback) | `halos_deploy.md`, `troubleshooting.md` |
 | `GPU_NOT_PERCEPTION` | Run Isaac Sim on a GPU (RT cores, >20 GB) that is **not** running VSS perception | `prerequisites.md`, `halos_deploy.md` |
 | `SETUP_BEFORE_UP` | Run `setup.sh <profile>` and `cleanup_all_datalog.sh <profile>` **before** `docker compose up` (both read `profiles/<profile>.env`) | `halos_deploy.md` |
 | `POLL_NEVER_WAIT` | First VSS startup takes 10-15 min (TensorRT build); Isaac shaders ~5-10 min — **poll** the ready signal, never `docker logs -f` or a fixed timer | (this file) |

--- a/skills/hoisa-deploy-profile/references/halos_deploy.md
+++ b/skills/hoisa-deploy-profile/references/halos_deploy.md
@@ -23,8 +23,7 @@ fill the `# change me` placeholders (keep your filled copy local — don't commi
 | `MDX_DATA_DIR` | the **sil-data** dir (contains `collected-assets/`) | NOT the VSS app-data dir — see `ngc_artifacts.md` |
 | `DOCKER_GID` | run `getent group docker \| cut -d: -f3` (default `999` may not match this host) | the `safety-core` container mounts `docker.sock`, so it needs the host's docker group |
 | `ISAAC_GPU_DEVICE` | a GPU with RT cores + >20 GB **not** running VSS perception | see GPU selection below |
-| `ROS_DOMAIN_ID` | a **unique** number per machine (0-232) — matters on multi-host `SUBNET` only | prevents cross-machine `/safety/is_muted` collisions; single-host verifies the link functionally (OPC MUTE/UNMUTE) |
-| `ROS_AUTOMATIC_DISCOVERY_RANGE` | `LOCALHOST` for single-host SIL (default in `sil.env`); leave unset/`SUBNET` for multi-host HIL | scopes ROS2 discovery to loopback. **Required on cloud VMs (e.g. Brev)** that block UDP multicast — without it Isaac ⇄ forklift-controller ⇄ comm-layer can't find each other over cyclonedds |
+| `ROS_DOMAIN_ID` | a **unique** number per machine (0-232) | prevents cross-machine `/safety/is_muted` collisions — verify `Publisher count: 1` after deploy |
 
 `PSF_IMAGE` and `ISAAC_SIM_IMAGE` are pre-set in the template.
 
@@ -50,10 +49,8 @@ cd <repo>/deployments
 # Clean previous run logs (same profile)
 ../closed-loop-testing/scripts/cleanup_all_datalog.sh <profile>
 
-# --build: comm-layer / isaac-sim build from local Dockerfiles.
-# --profile: old Compose (<2.39) ignores COMPOSE_PROFILES from --env-file → "no service selected".
-export COMPOSE_PROFILES=<profile>
-docker compose --profile <profile> --env-file profiles/<profile>.env up -d --build
+# Start — --build because comm-layer / isaac-sim build from local Dockerfiles
+docker compose --env-file profiles/<profile>.env up -d --build
 ```
 
 ---
@@ -91,21 +88,11 @@ until [ -s "$MDX_DATA_DIR/comm-layer/opc_server.log" ]; do sleep 5; done
 echo "PSF → comm-layer wired"
 ```
 
-### ROS link (`sil` / `hil`)
-
-**Primary — functional.** Sim-driven MUTE/UNMUTE in the OPC log proves the bridge publishes
-`/safety/is_muted` and Isaac acts on it:
-```bash
-grep -E "MUTE|UNMUTE" "$MDX_DATA_DIR/comm-layer/opc_server.log" | tail -5
-```
-
-**CLI check (often can't enumerate — don't block on it).** Under
-`ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST`, CycloneDDS loopback discovery hides the bridge
-from the `ros2` daemon, so this returns `Unknown topic`/empty even when healthy:
+### ROS isolation (`sil` / `hil`) — MUST be 1
 ```bash
 docker exec comm-layer bash -c \
   "source /opt/ros/jazzy/setup.bash && ros2 topic info /safety/is_muted -v" | grep "Publisher count"
-# 1 = healthy; 2+ = another host shares ROS_DOMAIN_ID on SUBNET; empty/Unknown = loopback, not a failure.
+# Publisher count: 1 expected. If 2+, another machine shares your ROS_DOMAIN_ID — see troubleshooting.md.
 ```
 
 ---

--- a/skills/hoisa-deploy-profile/references/halos_deploy.md
+++ b/skills/hoisa-deploy-profile/references/halos_deploy.md
@@ -6,8 +6,8 @@ Services and config differ per profile:
 | Profile | Services | Notes |
 |---------|----------|-------|
 | `base` | safety-core | Safety on an existing VSS feed; MUTE/UNMUTE shown as the VST `halo_safety` overlay. No Isaac Sim. |
-| `sil` | safety-core, comm-layer, isaac-sim, mediamtx | Full single-host closed loop. |
-| `hil` 🚧 | comm-layer, isaac-sim, mediamtx | 🚧 Under development — see `halos_hil.md`. |
+| `sil` | safety-core, comm-layer, isaac-sim, forklift-controller | Full single-host closed loop. |
+| `hil` 🚧 | comm-layer, isaac-sim, forklift-controller | 🚧 Under development — see `halos_hil.md`. |
 
 ---
 
@@ -24,6 +24,7 @@ fill the `# change me` placeholders (keep your filled copy local — don't commi
 | `DOCKER_GID` | run `getent group docker \| cut -d: -f3` (default `999` may not match this host) | the `safety-core` container mounts `docker.sock`, so it needs the host's docker group |
 | `ISAAC_GPU_DEVICE` | a GPU with RT cores + >20 GB **not** running VSS perception | see GPU selection below |
 | `ROS_DOMAIN_ID` | a **unique** number per machine (0-232) | prevents cross-machine `/safety/is_muted` collisions — verify `Publisher count: 1` after deploy |
+| `ROS_AUTOMATIC_DISCOVERY_RANGE` | `LOCALHOST` for single-host SIL (default in `sil.env`); leave unset/`SUBNET` for multi-host HIL | scopes ROS2 discovery to loopback. **Required on cloud VMs (e.g. Brev)** that block UDP multicast — without it Isaac ⇄ forklift-controller ⇄ comm-layer can't find each other over cyclonedds |
 
 `PSF_IMAGE` and `ISAAC_SIM_IMAGE` are pre-set in the template.
 
@@ -60,8 +61,8 @@ docker compose --env-file profiles/<profile>.env up -d --build
 Poll until the profile's services are Up (first run builds local images — takes minutes):
 
 ```bash
-docker ps --format 'table {{.Names}}\t{{.Status}}' | grep -E "safety-core|comm-layer|isaac-sim|mediamtx"
-# base = safety-core ; sil = + comm-layer + isaac-sim + mediamtx (4 total)
+docker ps --format 'table {{.Names}}\t{{.Status}}' | grep -E "safety-core|comm-layer|isaac-sim|forklift-controller"
+# base = safety-core ; sil = + comm-layer + isaac-sim + forklift-controller (4 total)
 ```
 
 ### Safety overlay (`base`) — enable on the VSS side
@@ -92,7 +93,10 @@ echo "PSF → comm-layer wired"
 ```bash
 docker exec comm-layer bash -c \
   "source /opt/ros/jazzy/setup.bash && ros2 topic info /safety/is_muted -v" | grep "Publisher count"
-# Publisher count: 1 expected. If 2+, another machine shares your ROS_DOMAIN_ID — see troubleshooting.md.
+# Publisher count: 1 expected. Single-host SIL uses ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST (loopback only),
+# so a 2+ count means another host shares your ROS_DOMAIN_ID on SUBNET — see troubleshooting.md.
+# If this CLI query times out (ros2 daemon discovery), fall back to the functional check:
+# sim-driven MUTE/UNMUTE reaching the OPC log already proves the comm-layer ⇄ Isaac ROS link.
 ```
 
 ---

--- a/skills/hoisa-deploy-profile/references/halos_deploy.md
+++ b/skills/hoisa-deploy-profile/references/halos_deploy.md
@@ -23,7 +23,7 @@ fill the `# change me` placeholders (keep your filled copy local — don't commi
 | `MDX_DATA_DIR` | the **sil-data** dir (contains `collected-assets/`) | NOT the VSS app-data dir — see `ngc_artifacts.md` |
 | `DOCKER_GID` | run `getent group docker \| cut -d: -f3` (default `999` may not match this host) | the `safety-core` container mounts `docker.sock`, so it needs the host's docker group |
 | `ISAAC_GPU_DEVICE` | a GPU with RT cores + >20 GB **not** running VSS perception | see GPU selection below |
-| `ROS_DOMAIN_ID` | a **unique** number per machine (0-232) | prevents cross-machine `/safety/is_muted` collisions — verify `Publisher count: 1` after deploy |
+| `ROS_DOMAIN_ID` | a **unique** number per machine (0-232) — matters on multi-host `SUBNET` only | prevents cross-machine `/safety/is_muted` collisions; single-host verifies the link functionally (OPC MUTE/UNMUTE) |
 | `ROS_AUTOMATIC_DISCOVERY_RANGE` | `LOCALHOST` for single-host SIL (default in `sil.env`); leave unset/`SUBNET` for multi-host HIL | scopes ROS2 discovery to loopback. **Required on cloud VMs (e.g. Brev)** that block UDP multicast — without it Isaac ⇄ forklift-controller ⇄ comm-layer can't find each other over cyclonedds |
 
 `PSF_IMAGE` and `ISAAC_SIM_IMAGE` are pre-set in the template.
@@ -50,8 +50,10 @@ cd <repo>/deployments
 # Clean previous run logs (same profile)
 ../closed-loop-testing/scripts/cleanup_all_datalog.sh <profile>
 
-# Start — --build because comm-layer / isaac-sim build from local Dockerfiles
-docker compose --env-file profiles/<profile>.env up -d --build
+# --build: comm-layer / isaac-sim build from local Dockerfiles.
+# --profile: old Compose (<2.39) ignores COMPOSE_PROFILES from --env-file → "no service selected".
+export COMPOSE_PROFILES=<profile>
+docker compose --profile <profile> --env-file profiles/<profile>.env up -d --build
 ```
 
 ---
@@ -89,14 +91,21 @@ until [ -s "$MDX_DATA_DIR/comm-layer/opc_server.log" ]; do sleep 5; done
 echo "PSF → comm-layer wired"
 ```
 
-### ROS isolation (`sil` / `hil`) — MUST be 1
+### ROS link (`sil` / `hil`)
+
+**Primary — functional.** Sim-driven MUTE/UNMUTE in the OPC log proves the bridge publishes
+`/safety/is_muted` and Isaac acts on it:
+```bash
+grep -E "MUTE|UNMUTE" "$MDX_DATA_DIR/comm-layer/opc_server.log" | tail -5
+```
+
+**CLI check (often can't enumerate — don't block on it).** Under
+`ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST`, CycloneDDS loopback discovery hides the bridge
+from the `ros2` daemon, so this returns `Unknown topic`/empty even when healthy:
 ```bash
 docker exec comm-layer bash -c \
   "source /opt/ros/jazzy/setup.bash && ros2 topic info /safety/is_muted -v" | grep "Publisher count"
-# Publisher count: 1 expected. Single-host SIL uses ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST (loopback only),
-# so a 2+ count means another host shares your ROS_DOMAIN_ID on SUBNET — see troubleshooting.md.
-# If this CLI query times out (ros2 daemon discovery), fall back to the functional check:
-# sim-driven MUTE/UNMUTE reaching the OPC log already proves the comm-layer ⇄ Isaac ROS link.
+# 1 = healthy; 2+ = another host shares ROS_DOMAIN_ID on SUBNET; empty/Unknown = loopback, not a failure.
 ```
 
 ---

--- a/skills/hoisa-deploy-profile/references/test_scenario.md
+++ b/skills/hoisa-deploy-profile/references/test_scenario.md
@@ -28,32 +28,31 @@ profile env; `run_sdg.sh` sets the ROS2 environment and launches the scene.
 **First-run note**: Isaac Sim goes quiet for ~5-10 min on first run (scene load + RT
 shader compile, cached afterwards). **Do not gate on a shader-log string** (it does not
 appear in the Isaac 6.0 kit log → poll hangs forever). Gate on the Isaac→VSS stream
-handoff completing — poll DeepStream (`vss-rtvi-cv`) for 3 active Isaac streams (the end
-of the chain, most authoritative):
+handoff completing. **Gotcha:** the VSS sample-video bootstrap also registers ~3 DeepStream
+streams *before* Isaac, so a bare "3 active streams" can fire early. Bootstrap-immune signal:
+the Isaac kit log — only Isaac emits `RTSP stream started … encoding=h264`. Gate on that
+first, then confirm DeepStream ingested them.
 
 ```bash
-# net = added - removed: docker logs accumulate across runs, so a raw count is a
-# re-run false-positive. Net active sources is correct.
+# 1) PRIMARY (bootstrap-immune): Isaac started its 3 self-hosted RTSP streams (H264)
+while :; do
+  n=$(docker exec isaac-sim bash -lc 'KL=$(ls -t /isaac-sim/kit/logs/Kit/*/*/kit_*.log | head -1); \
+        grep -c "RTSP stream started" "$KL"' 2>/dev/null)
+  [ "${n:-0}" -ge 3 ] && break
+  printf '[%s] waiting: Isaac RTSP streams=%s/3\n' "$(date +%H:%M:%S)" "${n:-0}"; sleep 20
+done
+echo "Isaac streaming 3 RTSP cams (H264: 8554/camera, 8555/camera_01, 8556/camera_02)"
+
+# 2) CONFIRM: DeepStream ingested them. net = added - removed (logs accumulate across runs)
 while :; do
   added=$(docker logs vss-rtvi-cv 2>&1 | grep -c 'new stream added \[')
   removed=$(docker logs vss-rtvi-cv 2>&1 | grep -c 'new stream removed \[')
   [ "$((added - removed))" -ge 3 ] && break
   printf '[%s] waiting: DeepStream active=%s/3 (added=%s removed=%s)\n' \
-    "$(date +%H:%M:%S)" "$((added - removed))" "$added" "$removed"
-  sleep 20
+    "$(date +%H:%M:%S)" "$((added - removed))" "$added" "$removed"; sleep 20
 done
 echo "DeepStream ingesting 3 Isaac streams — handoff complete"
 ```
-
-> **Secondary** — Isaac 6.0 self-hosted RTSP, straight from the kit log (there is no
-> `mediamtx` container in 6.0). Expect 3 `RTSP stream started ... encoding=h264` lines
-> (ports 8554/8555/8556). Filter the `Client (connected|disconnected)` reader-spam that
-> the RTSP server also logs:
-> ```bash
-> docker exec isaac-sim bash -lc 'KL=$(ls -t /isaac-sim/kit/logs/Kit/*/*/kit_*.log | head -1); \
->   grep "RTSP stream started" "$KL" | grep -oE "rtsp://localhost:[0-9]+/[a-z_0-9]+" | sort -u'
-> # expect 3: rtsp://localhost:8554/camera, :8555/camera_01, :8556/camera_02
-> ```
 
 > **`--start` auto-stops** after `simulation_length` frames (set in the IRA config
 > `default_config_ros.yaml`), and on exit it removes the VST sensors it added. For a
@@ -142,9 +141,15 @@ tail -n 30 "$MDX_DATA_DIR/psf-log/pss.log"
 ```
 ... nv_mdx_client[59]: ... Endpoint: NVPSB_PSS_SOURCE Data: Safety event reported: EVENT_0 (rule: Forklift tripwire OUT)
 ... nv_mdx_client[59]: ... Endpoint: NVPSB_PSS_SOURCE Data: Safety event reported: EVENT_1 (rule: Forklift tripwire IN)
+... nv_mdx_client[59]: ... Endpoint: NVPSB_PSS_SOURCE Data: Safety event reported: EVENT_4 (rule: Person restricted area ROI violation)
+... nv_mdx_client[59]: ... Endpoint: NVPSB_PSS_SOURCE Data: Safety event reported: EVENT_5 (rule: Person restricted area ROI violation cleared)
 ... NVPSB_PSD_CLIENT[34]: ... Data: PSD-Gateway: received DecisionRequest id=1 with 1 events
 ```
-- **EVENT_0 / EVENT_1**: tripwire crossings reported by perception (forklift OUT / IN the trailer).
+- **EVENT_0 / EVENT_1**: forklift tripwire crossings (OUT / IN the trailer).
+- **EVENT_4 / EVENT_5**: person restricted-area ROI violation / cleared (digital humans).
+- The loop can be driven by **either** family depending on the scene/segments — e.g. if the
+  forklift does a single pass then parks, MUTE/UNMUTE is driven by the person-ROI events.
+  Don't expect only forklift events.
 - **DecisionRequest**: the PSF decision-maker is invoked — it produces the corresponding MUTE/UNMUTE command shown in the OPC log above.
 
 ---
@@ -163,26 +168,28 @@ The system is working when:
 1. `vss-rtvi-cv` shows non-zero, **stable** FPS for **all 3** cameras — gate on "non-zero
    & steady", not an exact number. In SIL expect ~14 FPS/cam (the perception GPU is shared
    with Isaac Sim); the ~30 in NVIDIA's docs assumes a dedicated perception GPU
-2. `ros2 topic info /safety/is_muted -v` shows **`Publisher count: 1`** (see ROS isolation below)
-3. The OPC server log shows MUTE↔UNMUTE transitions (≥10) **after** Isaac started streaming
-4. The PSF log shows ATL decision changes tied to the forklift entering / leaving the trailer
-5. The VST UI shows the camera streams with bounding boxes
+2. **The OPC server log shows MUTE↔UNMUTE transitions after Isaac started streaming** — this
+   is the authoritative end-to-end signal (it proves perception → PSF → comm-layer → ROS →
+   Isaac all work). The documented `ros2 topic info … Publisher count: 1` is a *nice-to-have*
+   that often can't enumerate under loopback discovery — see ROS wiring below; don't block on it
+3. The PSF log shows ATL decision changes driven by **forklift tripwire (EVENT_0/1) or person
+   restricted-area ROI (EVENT_4/5)** — whichever the scene produces
+4. The VST UI shows the camera streams with bounding boxes
 
-> "Working" means **sim-driven** transitions (the forklift cycle) — not the VSS
-> sample-video bootstrap traffic that appears before Isaac streams come up.
+> "Working" means **sim-driven** transitions (from the Isaac scene — forklift cycle and/or
+> digital-human ROI) — not the VSS sample-video bootstrap traffic that appears before Isaac
+> streams come up.
 
-### ROS wiring (check once per host)
+### ROS wiring (best-effort — the functional OPC check above is authoritative)
 ```bash
 docker exec comm-layer bash -c \
   "source /opt/ros/jazzy/setup.bash && ros2 topic info /safety/is_muted -v" \
   | grep -E "Publisher count|Subscription count"
 ```
-- **`Publisher count: 1`** — exactly one (comm-layer). Single-host SIL scopes discovery
-  with `ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST` (loopback only), so `2+` means another
-  host on `SUBNET` shares your `ROS_DOMAIN_ID` — see `troubleshooting.md` → "Safety
-  Indicator Flickering (Multi-Machine)". If this `ros2 topic info` query times out (daemon
-  discovery), fall back to the functional check: sim-driven MUTE/UNMUTE in the OPC log
-  already proves the comm-layer ⇄ Isaac ROS link is live.
-- **`Subscription count: 1`** — the Isaac Sim forklift Action Graph has connected and
-  is receiving safety state. `0` means Isaac isn't subscribed yet (scene not fully up,
-  or a `ROS_DOMAIN_ID` mismatch between `isaac-sim` and `comm-layer`).
+> **Often can't enumerate under loopback.** With `ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST`,
+> CycloneDDS hides the bridge from the `ros2` daemon → `Unknown topic`/empty even when
+> healthy. **Not a failure** — the OPC MUTE/UNMUTE evidence above is authoritative.
+- **`Publisher count: 1`** — one (comm-layer). `2+` = another host shares your `ROS_DOMAIN_ID`
+  on `SUBNET` (multi-host only) — see `troubleshooting.md`.
+- **`Subscription count: 1`** — Isaac's forklift Action Graph is subscribed. `0` usually just
+  means the CLI can't see it over loopback; confirm via MUTE/UNMUTE changing forklift state.

--- a/skills/hoisa-deploy-profile/references/test_scenario.md
+++ b/skills/hoisa-deploy-profile/references/test_scenario.md
@@ -21,8 +21,8 @@ profile env; `run_sdg.sh` sets the ROS2 environment and launches the scene.
 2. Spawns the forklift + digital humans
 3. Initializes the ROS2 Action Graph (the forklift safety disc subscribes `/safety/is_muted`)
 4. Runs the forklift playback (`segments.json`: forward into trailer → idle → backward → idle)
-5. Starts RTSP streaming — Isaac 6.0 **self-hosts** RTSP per camera (H264), no external
-   `mediamtx`: `rtsp://localhost:8554/camera`, `:8555/camera_01`, `:8556/camera_02`
+5. Starts RTSP streaming — Isaac 6.0 **self-hosts** RTSP per camera (H264):
+   `rtsp://localhost:8554/camera`, `:8555/camera_01`, `:8556/camera_02`
 6. Registers the 3 cameras with VST — `--enable-vst` deletes existing sensors, then adds the Isaac cameras
 
 **First-run note**: Isaac Sim goes quiet for ~5-10 min on first run (scene load + RT
@@ -110,7 +110,7 @@ run's MUTE/UNMUTE transition summary.
 ```bash
 docker logs vss-rtvi-cv     2>&1 | grep -E 'new stream (added|removed) \['
 docker logs vss-vios-sensor 2>&1 | grep -E '"change" : "camera_(add|remove)"'
-# Isaac 6.0 self-hosted RTSP (no mediamtx): stream-start lines from the kit log
+# Isaac 6.0 self-hosted RTSP: stream-start lines from the kit log
 docker exec isaac-sim bash -lc 'KL=$(ls -t /isaac-sim/kit/logs/Kit/*/*/kit_*.log | head -1); grep -E "RTSP stream started|Started RTSP server" "$KL" | grep -v "Client "'
 ```
 
@@ -141,15 +141,9 @@ tail -n 30 "$MDX_DATA_DIR/psf-log/pss.log"
 ```
 ... nv_mdx_client[59]: ... Endpoint: NVPSB_PSS_SOURCE Data: Safety event reported: EVENT_0 (rule: Forklift tripwire OUT)
 ... nv_mdx_client[59]: ... Endpoint: NVPSB_PSS_SOURCE Data: Safety event reported: EVENT_1 (rule: Forklift tripwire IN)
-... nv_mdx_client[59]: ... Endpoint: NVPSB_PSS_SOURCE Data: Safety event reported: EVENT_4 (rule: Person restricted area ROI violation)
-... nv_mdx_client[59]: ... Endpoint: NVPSB_PSS_SOURCE Data: Safety event reported: EVENT_5 (rule: Person restricted area ROI violation cleared)
 ... NVPSB_PSD_CLIENT[34]: ... Data: PSD-Gateway: received DecisionRequest id=1 with 1 events
 ```
-- **EVENT_0 / EVENT_1**: forklift tripwire crossings (OUT / IN the trailer).
-- **EVENT_4 / EVENT_5**: person restricted-area ROI violation / cleared (digital humans).
-- The loop can be driven by **either** family depending on the scene/segments — e.g. if the
-  forklift does a single pass then parks, MUTE/UNMUTE is driven by the person-ROI events.
-  Don't expect only forklift events.
+- **EVENT_0 / EVENT_1**: tripwire crossings reported by perception (forklift OUT / IN the trailer).
 - **DecisionRequest**: the PSF decision-maker is invoked — it produces the corresponding MUTE/UNMUTE command shown in the OPC log above.
 
 ---
@@ -165,31 +159,24 @@ in headless mode.
 ## Verify End-to-End
 
 The system is working when:
-1. `vss-rtvi-cv` shows non-zero, **stable** FPS for **all 3** cameras — gate on "non-zero
-   & steady", not an exact number. In SIL expect ~14 FPS/cam (the perception GPU is shared
-   with Isaac Sim); the ~30 in NVIDIA's docs assumes a dedicated perception GPU
-2. **The OPC server log shows MUTE↔UNMUTE transitions after Isaac started streaming** — this
-   is the authoritative end-to-end signal (it proves perception → PSF → comm-layer → ROS →
-   Isaac all work). The documented `ros2 topic info … Publisher count: 1` is a *nice-to-have*
-   that often can't enumerate under loopback discovery — see ROS wiring below; don't block on it
-3. The PSF log shows ATL decision changes driven by **forklift tripwire (EVENT_0/1) or person
-   restricted-area ROI (EVENT_4/5)** — whichever the scene produces
-4. The VST UI shows the camera streams with bounding boxes
+1. `vss-rtvi-cv` shows ~30 FPS for **all 3** cameras
+2. `ros2 topic info /safety/is_muted -v` shows **`Publisher count: 1`** (see ROS isolation below)
+3. The OPC server log shows MUTE↔UNMUTE transitions (≥10) **after** Isaac started streaming
+4. The PSF log shows ATL decision changes tied to the forklift entering / leaving the trailer
+5. The VST UI shows the camera streams with bounding boxes
 
-> "Working" means **sim-driven** transitions (from the Isaac scene — forklift cycle and/or
-> digital-human ROI) — not the VSS sample-video bootstrap traffic that appears before Isaac
-> streams come up.
+> "Working" means **sim-driven** transitions (the forklift cycle) — not the VSS
+> sample-video bootstrap traffic that appears before Isaac streams come up.
 
-### ROS wiring (best-effort — the functional OPC check above is authoritative)
+### ROS wiring (check once per host)
 ```bash
 docker exec comm-layer bash -c \
   "source /opt/ros/jazzy/setup.bash && ros2 topic info /safety/is_muted -v" \
   | grep -E "Publisher count|Subscription count"
 ```
-> **Often can't enumerate under loopback.** With `ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST`,
-> CycloneDDS hides the bridge from the `ros2` daemon → `Unknown topic`/empty even when
-> healthy. **Not a failure** — the OPC MUTE/UNMUTE evidence above is authoritative.
-- **`Publisher count: 1`** — one (comm-layer). `2+` = another host shares your `ROS_DOMAIN_ID`
-  on `SUBNET` (multi-host only) — see `troubleshooting.md`.
-- **`Subscription count: 1`** — Isaac's forklift Action Graph is subscribed. `0` usually just
-  means the CLI can't see it over loopback; confirm via MUTE/UNMUTE changing forklift state.
+- **`Publisher count: 1`** — exactly one (comm-layer). If `2+`, another machine on the
+  network shares your `ROS_DOMAIN_ID` — see `troubleshooting.md` → "Safety Indicator
+  Flickering (Multi-Machine)".
+- **`Subscription count: 1`** — the Isaac Sim forklift Action Graph has connected and
+  is receiving safety state. `0` means Isaac isn't subscribed yet (scene not fully up,
+  or a `ROS_DOMAIN_ID` mismatch between `isaac-sim` and `comm-layer`).

--- a/skills/hoisa-deploy-profile/references/test_scenario.md
+++ b/skills/hoisa-deploy-profile/references/test_scenario.md
@@ -21,12 +21,13 @@ profile env; `run_sdg.sh` sets the ROS2 environment and launches the scene.
 2. Spawns the forklift + digital humans
 3. Initializes the ROS2 Action Graph (the forklift safety disc subscribes `/safety/is_muted`)
 4. Runs the forklift playback (`segments.json`: forward into trailer → idle → backward → idle)
-5. Starts RTSP streaming (3 cameras, H265, via MediaMTX)
+5. Starts RTSP streaming — Isaac 6.0 **self-hosts** RTSP per camera (H264), no external
+   `mediamtx`: `rtsp://localhost:8554/camera`, `:8555/camera_01`, `:8556/camera_02`
 6. Registers the 3 cameras with VST — `--enable-vst` deletes existing sensors, then adds the Isaac cameras
 
 **First-run note**: Isaac Sim goes quiet for ~5-10 min on first run (scene load + RT
 shader compile, cached afterwards). **Do not gate on a shader-log string** (it does not
-appear in the Isaac 5.1.0 kit log → poll hangs forever). Gate on the Isaac→VSS stream
+appear in the Isaac 6.0 kit log → poll hangs forever). Gate on the Isaac→VSS stream
 handoff completing — poll DeepStream (`vss-rtvi-cv`) for 3 active Isaac streams (the end
 of the chain, most authoritative):
 
@@ -44,15 +45,15 @@ done
 echo "DeepStream ingesting 3 Isaac streams — handoff complete"
 ```
 
-> **Secondary** — mediamtx publishers for the **current** run (`--since`, and filter the
-> `no one is publishing` reader-spam, which otherwise always matches ≥3):
+> **Secondary** — Isaac 6.0 self-hosted RTSP, straight from the kit log (there is no
+> `mediamtx` container in 6.0). Expect 3 `RTSP stream started ... encoding=h264` lines
+> (ports 8554/8555/8556). Filter the `Client (connected|disconnected)` reader-spam that
+> the RTSP server also logs:
 > ```bash
-> docker logs --since 3m mediamtx 2>&1 \
->   | grep "is publishing to path 'RTSPWriter_World_Cameras_Camera" | grep -v 'no one' \
->   | grep -oE 'Camera[_0-9]*_rgb' | sort -u | wc -l        # expect 3
+> docker exec isaac-sim bash -lc 'KL=$(ls -t /isaac-sim/kit/logs/Kit/*/*/kit_*.log | head -1); \
+>   grep "RTSP stream started" "$KL" | grep -oE "rtsp://localhost:[0-9]+/[a-z_0-9]+" | sort -u'
+> # expect 3: rtsp://localhost:8554/camera, :8555/camera_01, :8556/camera_02
 > ```
-> A bare `grep -c RTSPWriter...` on mediamtx is wrong on both counts (matches the
-> reader-spam **and** counts across runs).
 
 > **`--start` auto-stops** after `simulation_length` frames (set in the IRA config
 > `default_config_ros.yaml`), and on exit it removes the VST sensors it added. For a
@@ -71,8 +72,7 @@ detect when it finishes. All signals below were verified on a live VSS 3.2 + Hal
 | Component | Container | ADD — scene streaming | REMOVE — scene done / teardown |
 |-----------|-----------|-----------------------|--------------------------------|
 | DeepStream (perception) | `vss-rtvi-cv` | `new stream added [<idx>:<uuid>:<Camera>]` ×3 | `new stream removed [<idx>:...]` + `gstnvtracker: Successfully removed stream <idx>` |
-| mediamtx | `mediamtx` | `is publishing to path 'RTSPWriter_World_Cameras_<Camera>_rgb'` ×3 | `session ... destroyed` |
-| Isaac Sim (kit log) | `isaac-sim` | `"rgb" of "/World/Cameras/<Camera>" will be published to "rtsp://..."` ×3 | `Subprocess on "/World/Cameras/<Camera>" has been terminated` ×3 |
+| Isaac RTSP self-hosted (6.0) | `isaac-sim` (kit log) | `[isaacsim.streaming.rtsp.impl.rtsp_writer] RTSP stream started on rtsp://localhost:{8554/camera, 8555/camera_01, 8556/camera_02} (…, encoding=h264)` ×3 (each preceded by `[omni.kit.livestream.rtsp.plugin] Started RTSP server at …`) | no dedicated teardown line (RTSP clients just log `Client disconnected`) — use DeepStream `new stream removed` (row 1) as the authoritative teardown |
 | VST sensor mgr | `vss-vios-sensor` | `"change" : "camera_add"` · `addSensor completed: <Camera>` | `"change" : "camera_remove"` · `delete sensor: <uuid>` |
 
 `<Camera>` = `Camera`, `Camera_01`, `Camera_02`.
@@ -110,9 +110,9 @@ run's MUTE/UNMUTE transition summary.
 ### Per-component handoff trace (debug)
 ```bash
 docker logs vss-rtvi-cv     2>&1 | grep -E 'new stream (added|removed) \['
-docker logs mediamtx        2>&1 | grep -E "is publishing to path 'RTSPWriter|destroyed:"
 docker logs vss-vios-sensor 2>&1 | grep -E '"change" : "camera_(add|remove)"'
-docker exec isaac-sim bash -lc 'KL=$(ls -t /isaac-sim/kit/logs/Kit/*/*/kit_*.log | head -1); grep -E "will be published|Subprocess on .* has been terminated" "$KL"'
+# Isaac 6.0 self-hosted RTSP (no mediamtx): stream-start lines from the kit log
+docker exec isaac-sim bash -lc 'KL=$(ls -t /isaac-sim/kit/logs/Kit/*/*/kit_*.log | head -1); grep -E "RTSP stream started|Started RTSP server" "$KL" | grep -v "Client "'
 ```
 
 ---
@@ -160,7 +160,9 @@ in headless mode.
 ## Verify End-to-End
 
 The system is working when:
-1. `vss-rtvi-cv` shows ~30 FPS for **all 3** cameras
+1. `vss-rtvi-cv` shows non-zero, **stable** FPS for **all 3** cameras — gate on "non-zero
+   & steady", not an exact number. In SIL expect ~14 FPS/cam (the perception GPU is shared
+   with Isaac Sim); the ~30 in NVIDIA's docs assumes a dedicated perception GPU
 2. `ros2 topic info /safety/is_muted -v` shows **`Publisher count: 1`** (see ROS isolation below)
 3. The OPC server log shows MUTE↔UNMUTE transitions (≥10) **after** Isaac started streaming
 4. The PSF log shows ATL decision changes tied to the forklift entering / leaving the trailer
@@ -175,9 +177,12 @@ docker exec comm-layer bash -c \
   "source /opt/ros/jazzy/setup.bash && ros2 topic info /safety/is_muted -v" \
   | grep -E "Publisher count|Subscription count"
 ```
-- **`Publisher count: 1`** — exactly one (comm-layer). If `2+`, another machine on the
-  network shares your `ROS_DOMAIN_ID` — see `troubleshooting.md` → "Safety Indicator
-  Flickering (Multi-Machine)".
+- **`Publisher count: 1`** — exactly one (comm-layer). Single-host SIL scopes discovery
+  with `ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST` (loopback only), so `2+` means another
+  host on `SUBNET` shares your `ROS_DOMAIN_ID` — see `troubleshooting.md` → "Safety
+  Indicator Flickering (Multi-Machine)". If this `ros2 topic info` query times out (daemon
+  discovery), fall back to the functional check: sim-driven MUTE/UNMUTE in the OPC log
+  already proves the comm-layer ⇄ Isaac ROS link is live.
 - **`Subscription count: 1`** — the Isaac Sim forklift Action Graph has connected and
   is receiving safety state. `0` means Isaac isn't subscribed yet (scene not fully up,
   or a `ROS_DOMAIN_ID` mismatch between `isaac-sim` and `comm-layer`).

--- a/skills/hoisa-deploy-profile/references/troubleshooting.md
+++ b/skills/hoisa-deploy-profile/references/troubleshooting.md
@@ -70,7 +70,8 @@ shows up as **STALE events** (see above), not low FPS.
   wrong RTSP URL, or the TensorRT engine still building (first run 15-20 min). Confirm the
   3 Isaac RTSP streams are up (see `test_scenario.md` → handoff signals), then
   `docker restart vss-rtvi-cv` if needed.
-- **Flickering bounding boxes** — set `bbox_tolerance_ms=100` in `vst_config.json`.
+
+(Flickering bounding boxes are a separate issue — see "Bounding Box Flickering" below.)
 
 ---
 
@@ -280,11 +281,49 @@ using the same domain ID.
 
 ---
 
+## `no service selected` on Halos deploy
+
+**Symptom**: `docker compose --env-file profiles/<profile>.env up -d --build` exits with
+**`no service selected`** — nothing starts.
+
+**Cause**: Halos services are gated by `profiles:` in `compose.yaml`. `<profile>.env` sets
+`COMPOSE_PROFILES=<profile>`, but Docker Compose **< 2.39 does not read `COMPOSE_PROFILES`
+from `--env-file`** — so no profile is active and `up` matches zero services.
+
+**Fix**: activate the profile explicitly (works on every version):
+```bash
+export COMPOSE_PROFILES=<profile>
+docker compose --profile <profile> --env-file profiles/<profile>.env up -d --build
+```
+
+---
+
+## `ros2 topic info` returns "Unknown topic" / `ros2 topic list` empty
+
+**Symptom**: inside `comm-layer`, `ros2 topic info /safety/is_muted -v` says the topic is
+unknown and `ros2 topic list` is empty — yet MUTE/UNMUTE **is** flowing to the OPC log and
+the forklift reacts.
+
+**Cause**: this is **not** a failure. Single-host SIL sets
+`ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST`; CycloneDDS loopback SPDP discovery does not
+expose the bridge participant to the `ros2` CLI daemon, so the CLI can't enumerate topics
+it isn't itself part of. The pub/sub link between comm-layer and Isaac is unaffected.
+
+**Fix**: don't rely on the CLI here. Verify **functionally** — sim-driven MUTE/UNMUTE in
+`$MDX_DATA_DIR/comm-layer/opc_server.log` proves the ROS link end-to-end:
+```bash
+grep -E "MUTE|UNMUTE" "$MDX_DATA_DIR/comm-layer/opc_server.log" | tail -5
+```
+
+---
+
 ## Quick Reference
 
 | Error | Fix |
 |-------|-----|
 | PSF Kafka connection | Deploy VSS Warehouse first |
+| `no service selected` | `export COMPOSE_PROFILES=<profile>` + `--profile <profile>` (Compose <2.39) |
+| `ros2 topic info` empty / Unknown topic | Not a failure under LOCALHOST discovery — verify via OPC MUTE/UNMUTE |
 | STALE events / MUTE stops | System ts (`attach-sys-ts-as-ntp=1`), not SEI sim-time; then widen `timeWindowSize` |
 | Low FPS (~14) in SIL | Expected on shared GPU (not SEI); `0.00000` = stream not arriving |
 | Isaac Sim crash (VRAM) | Check GPU VRAM, ISAAC_GPU_DEVICE |

--- a/skills/hoisa-deploy-profile/references/troubleshooting.md
+++ b/skills/hoisa-deploy-profile/references/troubleshooting.md
@@ -29,49 +29,38 @@ cd <repo>/deployments && docker compose --env-file profiles/<profile>.env down &
 **Symptom**: PSF log floods with `Dropping STALE event`; safety decisions lag or don't trigger.
 
 **First — some STALE is normal.** Events reaching PSF older than `timeWindowSize`
-(`6000` ms / 6 s in the SIL `nvpss.conf`) are dropped. Measure the **steady-state** rate
-**after the loop has run a while** — startup / bootstrap STALE before Isaac streams
-stabilise is expected. A persistent high rate (tens of % while running) points to a real
-problem — most often the DeepStream timestamp source (below), not raw latency.
+(default 900 ms) are dropped. Measure the **steady-state** rate **after the loop has
+run a while** — startup / bootstrap STALE before Isaac streams stabilise is expected.
+A persistent high rate (tens of % while running) indicates real pipeline latency.
 
-**Cause** (most common first):
-1. **Wrong DeepStream timestamp source** — if `extract-sei-sim-time=1` (Isaac's SEI
-   sim-time fed in as the NTP timestamp), the sim clock drifts outside the 6 s window and
-   **nearly everything is dropped as STALE** (A/B tested on Isaac 6.0: ~100 STALE + MUTE
-   stops toggling). Fix by using **system time**: `attach-sys-ts-as-ntp=1`, with
-   `extract-sei-sim-time` / `drop-backward-sei` commented out (see `vss_2d_overrides.md`).
-2. perception→Kafka→PSF latency occasionally exceeds `timeWindowSize` (slow or shared GPU,
-   frame-timing jitter, multi-camera fusion).
+**Cause**: perception→Kafka→PSF latency occasionally exceeds `timeWindowSize` (slow or
+shared GPU, frame-timing jitter, multi-camera fusion); or the DeepStream override is
+missing — without `attach-sys-ts-as-ntp=1`, frames don't get a proper (wall-clock) NTP
+timestamp and nearly everything is dropped as STALE.
 
 **Fix**:
 ```bash
-# 1. Confirm DeepStream uses system timestamps: attach-sys-ts-as-ntp=1, SEI sim-time off (see vss_2d_overrides.md)
+# 1. Confirm the DeepStream SEI override is applied (see vss_2d_overrides.md)
 # 2. If STALE is still high once running, widen the window:
 nano <repo>/closed-loop-testing/safety-core/configs/nvpss.conf
-# Increase timeWindowSize (e.g. 6000 -> 8000)
+# Increase timeWindowSize (e.g. 900 -> 1200)
 cd <repo>/deployments && docker compose --env-file profiles/<profile>.env restart safety-core
 ```
 
 ---
 
-## Low / Zero FPS on `vss-rtvi-cv`
+## Low FPS / Flickering Bounding Boxes
 
-**Symptom**: `vss-rtvi-cv` shows low FPS, or a camera stuck at `0.00000`.
+**Symptom**: `vss-rtvi-cv` shows low FPS (<30), VST shows flickering boxes.
 
-**On Isaac 6.0, SEI extraction does *not* cause low FPS** (A/B tested — FPS held ~14/cam
-with SEI on or off). The old "disable SEI to fix FPS" advice is obsolete; an SEI mis-config
-shows up as **STALE events** (see above), not low FPS.
+**Cause**: the DeepStream SIL override isn't applied (no system timestamps) — bboxes flicker and events drop as STALE. A source stuck at `0.00000` isn't arriving at all (Isaac not streaming yet, wrong RTSP URL, or TensorRT still building).
 
-**Cause / fix by symptom**:
-- **~14 FPS/cam (not ~30)** — expected in SIL: the perception GPU is shared with Isaac
-  Sim. Gate on "non-zero & stable", not an exact number. NVIDIA's ~30 assumes a dedicated
-  perception GPU. Not a bug.
-- **A source stuck at `0.00000`** — that stream isn't arriving: Isaac not streaming yet,
-  wrong RTSP URL, or the TensorRT engine still building (first run 15-20 min). Confirm the
-  3 Isaac RTSP streams are up (see `test_scenario.md` → handoff signals), then
-  `docker restart vss-rtvi-cv` if needed.
+**Fix**: Apply DeepStream config changes (see `vss_2d_overrides.md`):
+- Comment out `extract-sei-type5-data` and `sei-uuid` in `[source-list]`
+- Set `attach-sys-ts-as-ntp=1` in `[streammux]`
+- Comment out `extract-sei-sim-time` and `drop-backward-sei`
 
-(Flickering bounding boxes are a separate issue — see "Bounding Box Flickering" below.)
+Restart perception: `docker restart vss-rtvi-cv`
 
 ---
 
@@ -241,20 +230,11 @@ docker compose up -d vss-rtvi-cv   # run from the VSS Warehouse deploy dir (see 
 **Symptom**: The safety colored disc in Isaac Sim flickers between MUTE/UNMUTE
 randomly, or one machine's safety state affects another machine on the same network.
 
-**Cause**: Multiple SIL systems on the same network share the default `ROS_DOMAIN_ID=0`,
-and ROS2 discovery reaches across the LAN via UDP multicast. Nodes from different machines
-then publish to the same `/safety/is_muted` topic, causing cross-machine interference.
+**Cause**: Multiple SIL systems on the same network share the default
+`ROS_DOMAIN_ID=0`. ROS2 nodes from different machines publish to the same
+`/safety/is_muted` topic, causing cross-machine interference.
 
-**Fix (single-host SIL — preferred)**: scope discovery to loopback so it can never see
-another host. `sil.env` ships this by default:
-
-```bash
-# In deployments/profiles/<profile>.env
-ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST   # discover only on this host — also fixes cloud VMs (e.g. Brev) that block multicast
-```
-
-**Fix (multi-host / HIL, where nodes *must* span machines)**: keep discovery on `SUBNET`
-and give each machine a unique `ROS_DOMAIN_ID` (0-232):
+**Fix**: Assign each machine a unique `ROS_DOMAIN_ID` (0-232) in the Halos `.env`:
 
 ```bash
 # In deployments/profiles/<profile>.env — a unique number per machine
@@ -275,45 +255,8 @@ docker exec comm-layer bash -c \
 Should show `Publisher count: 1`. If it shows 2+, another machine is still
 using the same domain ID.
 
-> Single-host SIL is already isolated by `ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST`, so the
-> default `ROS_DOMAIN_ID=0` is fine. This section only matters if you switch discovery to
-> `SUBNET` for multi-host / HIL.
-
----
-
-## `no service selected` on Halos deploy
-
-**Symptom**: `docker compose --env-file profiles/<profile>.env up -d --build` exits with
-**`no service selected`** — nothing starts.
-
-**Cause**: Halos services are gated by `profiles:` in `compose.yaml`. `<profile>.env` sets
-`COMPOSE_PROFILES=<profile>`, but Docker Compose **< 2.39 does not read `COMPOSE_PROFILES`
-from `--env-file`** — so no profile is active and `up` matches zero services.
-
-**Fix**: activate the profile explicitly (works on every version):
-```bash
-export COMPOSE_PROFILES=<profile>
-docker compose --profile <profile> --env-file profiles/<profile>.env up -d --build
-```
-
----
-
-## `ros2 topic info` returns "Unknown topic" / `ros2 topic list` empty
-
-**Symptom**: inside `comm-layer`, `ros2 topic info /safety/is_muted -v` says the topic is
-unknown and `ros2 topic list` is empty — yet MUTE/UNMUTE **is** flowing to the OPC log and
-the forklift reacts.
-
-**Cause**: this is **not** a failure. Single-host SIL sets
-`ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST`; CycloneDDS loopback SPDP discovery does not
-expose the bridge participant to the `ros2` CLI daemon, so the CLI can't enumerate topics
-it isn't itself part of. The pub/sub link between comm-layer and Isaac is unaffected.
-
-**Fix**: don't rely on the CLI here. Verify **functionally** — sim-driven MUTE/UNMUTE in
-`$MDX_DATA_DIR/comm-layer/opc_server.log` proves the ROS link end-to-end:
-```bash
-grep -E "MUTE|UNMUTE" "$MDX_DATA_DIR/comm-layer/opc_server.log" | tail -5
-```
+> This only affects multi-machine setups on the same network. Single-machine
+> deployments can safely use the default `ROS_DOMAIN_ID=0`.
 
 ---
 
@@ -322,10 +265,8 @@ grep -E "MUTE|UNMUTE" "$MDX_DATA_DIR/comm-layer/opc_server.log" | tail -5
 | Error | Fix |
 |-------|-----|
 | PSF Kafka connection | Deploy VSS Warehouse first |
-| `no service selected` | `export COMPOSE_PROFILES=<profile>` + `--profile <profile>` (Compose <2.39) |
-| `ros2 topic info` empty / Unknown topic | Not a failure under LOCALHOST discovery — verify via OPC MUTE/UNMUTE |
-| STALE events / MUTE stops | System ts (`attach-sys-ts-as-ntp=1`), not SEI sim-time; then widen `timeWindowSize` |
-| Low FPS (~14) in SIL | Expected on shared GPU (not SEI); `0.00000` = stream not arriving |
+| STALE events | Increase `timeWindowSize` in nvpss.conf |
+| Low FPS / flickering | Apply DeepStream SIL override — see `vss_2d_overrides.md` |
 | Isaac Sim crash (VRAM) | Check GPU VRAM, ISAAC_GPU_DEVICE |
 | Isaac Sim Vulkan crash | Update driver >= 580.95.05, or restart (cached shaders) |
 | No cameras in VST | Use `--enable-vst` flag |

--- a/skills/hoisa-deploy-profile/references/troubleshooting.md
+++ b/skills/hoisa-deploy-profile/references/troubleshooting.md
@@ -29,37 +29,48 @@ cd <repo>/deployments && docker compose --env-file profiles/<profile>.env down &
 **Symptom**: PSF log floods with `Dropping STALE event`; safety decisions lag or don't trigger.
 
 **First — some STALE is normal.** Events reaching PSF older than `timeWindowSize`
-(default 900 ms) are dropped. Measure the **steady-state** rate **after the loop has
-run a while** — startup / bootstrap STALE before Isaac streams stabilise is expected.
-A persistent high rate (tens of % while running) indicates real pipeline latency.
+(`6000` ms / 6 s in the SIL `nvpss.conf`) are dropped. Measure the **steady-state** rate
+**after the loop has run a while** — startup / bootstrap STALE before Isaac streams
+stabilise is expected. A persistent high rate (tens of % while running) points to a real
+problem — most often the DeepStream timestamp source (below), not raw latency.
 
-**Cause**: perception→Kafka→PSF latency occasionally exceeds `timeWindowSize` (slow or
-shared GPU, frame-timing jitter, multi-camera fusion); or the SEI override is missing —
-without it, frames carry no NTP timestamp and nearly everything is dropped as STALE.
+**Cause** (most common first):
+1. **Wrong DeepStream timestamp source** — if `extract-sei-sim-time=1` (Isaac's SEI
+   sim-time fed in as the NTP timestamp), the sim clock drifts outside the 6 s window and
+   **nearly everything is dropped as STALE** (A/B tested on Isaac 6.0: ~100 STALE + MUTE
+   stops toggling). Fix by using **system time**: `attach-sys-ts-as-ntp=1`, with
+   `extract-sei-sim-time` / `drop-backward-sei` commented out (see `vss_2d_overrides.md`).
+2. perception→Kafka→PSF latency occasionally exceeds `timeWindowSize` (slow or shared GPU,
+   frame-timing jitter, multi-camera fusion).
 
 **Fix**:
 ```bash
-# 1. Confirm the DeepStream SEI override is applied (see vss_2d_overrides.md)
+# 1. Confirm DeepStream uses system timestamps: attach-sys-ts-as-ntp=1, SEI sim-time off (see vss_2d_overrides.md)
 # 2. If STALE is still high once running, widen the window:
 nano <repo>/closed-loop-testing/safety-core/configs/nvpss.conf
-# Increase timeWindowSize (e.g. 900 -> 1200)
+# Increase timeWindowSize (e.g. 6000 -> 8000)
 cd <repo>/deployments && docker compose --env-file profiles/<profile>.env restart safety-core
 ```
 
 ---
 
-## Low FPS / Flickering Bounding Boxes
+## Low / Zero FPS on `vss-rtvi-cv`
 
-**Symptom**: `vss-rtvi-cv` shows low FPS (<30), VST shows flickering boxes.
+**Symptom**: `vss-rtvi-cv` shows low FPS, or a camera stuck at `0.00000`.
 
-**Cause**: DeepStream SEI extraction enabled — incompatible with Isaac Sim RTSP.
+**On Isaac 6.0, SEI extraction does *not* cause low FPS** (A/B tested — FPS held ~14/cam
+with SEI on or off). The old "disable SEI to fix FPS" advice is obsolete; an SEI mis-config
+shows up as **STALE events** (see above), not low FPS.
 
-**Fix**: Apply DeepStream config changes (see `vss_2d_overrides.md`):
-- Comment out `extract-sei-type5-data` and `sei-uuid` in `[source-list]`
-- Set `attach-sys-ts-as-ntp=1` in `[streammux]`
-- Comment out `extract-sei-sim-time` and `drop-backward-sei`
-
-Restart perception: `docker restart vss-rtvi-cv`
+**Cause / fix by symptom**:
+- **~14 FPS/cam (not ~30)** — expected in SIL: the perception GPU is shared with Isaac
+  Sim. Gate on "non-zero & stable", not an exact number. NVIDIA's ~30 assumes a dedicated
+  perception GPU. Not a bug.
+- **A source stuck at `0.00000`** — that stream isn't arriving: Isaac not streaming yet,
+  wrong RTSP URL, or the TensorRT engine still building (first run 15-20 min). Confirm the
+  3 Isaac RTSP streams are up (see `test_scenario.md` → handoff signals), then
+  `docker restart vss-rtvi-cv` if needed.
+- **Flickering bounding boxes** — set `bbox_tolerance_ms=100` in `vst_config.json`.
 
 ---
 
@@ -229,11 +240,20 @@ docker compose up -d vss-rtvi-cv   # run from the VSS Warehouse deploy dir (see 
 **Symptom**: The safety colored disc in Isaac Sim flickers between MUTE/UNMUTE
 randomly, or one machine's safety state affects another machine on the same network.
 
-**Cause**: Multiple SIL systems on the same network share the default
-`ROS_DOMAIN_ID=0`. ROS2 nodes from different machines publish to the same
-`/safety/is_muted` topic, causing cross-machine interference.
+**Cause**: Multiple SIL systems on the same network share the default `ROS_DOMAIN_ID=0`,
+and ROS2 discovery reaches across the LAN via UDP multicast. Nodes from different machines
+then publish to the same `/safety/is_muted` topic, causing cross-machine interference.
 
-**Fix**: Assign each machine a unique `ROS_DOMAIN_ID` (0-232) in the Halos `.env`:
+**Fix (single-host SIL — preferred)**: scope discovery to loopback so it can never see
+another host. `sil.env` ships this by default:
+
+```bash
+# In deployments/profiles/<profile>.env
+ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST   # discover only on this host — also fixes cloud VMs (e.g. Brev) that block multicast
+```
+
+**Fix (multi-host / HIL, where nodes *must* span machines)**: keep discovery on `SUBNET`
+and give each machine a unique `ROS_DOMAIN_ID` (0-232):
 
 ```bash
 # In deployments/profiles/<profile>.env — a unique number per machine
@@ -254,8 +274,9 @@ docker exec comm-layer bash -c \
 Should show `Publisher count: 1`. If it shows 2+, another machine is still
 using the same domain ID.
 
-> This only affects multi-machine setups on the same network. Single-machine
-> deployments can safely use the default `ROS_DOMAIN_ID=0`.
+> Single-host SIL is already isolated by `ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST`, so the
+> default `ROS_DOMAIN_ID=0` is fine. This section only matters if you switch discovery to
+> `SUBNET` for multi-host / HIL.
 
 ---
 
@@ -264,8 +285,8 @@ using the same domain ID.
 | Error | Fix |
 |-------|-----|
 | PSF Kafka connection | Deploy VSS Warehouse first |
-| STALE events | Increase `timeWindowSize` in nvpss.conf |
-| Low FPS / flickering | Disable SEI in DeepStream config |
+| STALE events / MUTE stops | System ts (`attach-sys-ts-as-ntp=1`), not SEI sim-time; then widen `timeWindowSize` |
+| Low FPS (~14) in SIL | Expected on shared GPU (not SEI); `0.00000` = stream not arriving |
 | Isaac Sim crash (VRAM) | Check GPU VRAM, ISAAC_GPU_DEVICE |
 | Isaac Sim Vulkan crash | Update driver >= 580.95.05, or restart (cached shaders) |
 | No cameras in VST | Use `--enable-vst` flag |

--- a/skills/hoisa-deploy-profile/references/vss_2d_overrides.md
+++ b/skills/hoisa-deploy-profile/references/vss_2d_overrides.md
@@ -15,13 +15,10 @@ standard deploy flow — this file specifies only what must be **different** for
 > `--env-file industry-profiles/warehouse-operations/.env`. Edit the override files
 > below in place, then let `vss-deploy-profile` bring VSS up.
 
-These overrides exist because of **how Isaac Sim's timestamps reach PSF** — not because
-SEI is missing. Isaac 6.0 RTSP *does* embed SEI (including a simulation-time value) and
-DeepStream extracts it fine; FPS is healthy either way. The real issue is the *timestamp
-source*: if DeepStream feeds Isaac's SEI **sim-time** in as the NTP timestamp, the sim
-clock lands outside PSF's decision window and events get dropped as **STALE**. So these
-overrides force **system timestamps** instead of SEI sim-time. (Verified on a live VSS 3.2
-+ Isaac 6.0 SIL run — see the A/B results below.)
+Isaac 6.0 RTSP *does* embed SEI, but **PSF currently doesn't support sim time** — so these
+overrides **disable SEI extraction** and use **system (wall-clock) timestamps**. Feeding
+Isaac's SEI sim-time as the frame timestamp makes PSF drop events as STALE; system time
+keeps decisions flowing.
 
 ---
 
@@ -55,11 +52,9 @@ File:
 <wh_ops>/warehouse-2d-app/deepstream/configs/ds-main-config.txt
 ```
 
-### Leave SEI type-5 extraction commented in `[source-list]`
+### Disable SEI extraction in `[source-list]`
 
-Keep these commented (matches NVIDIA's official SIL config). Isaac 6.0 *does* send SEI,
-and A/B testing showed extracting the type-5 metadata on its own is harmless (FPS and
-STALE unaffected) — but it buys nothing for SIL, so leave it off:
+Keep SEI extraction off for SIL (comment these out; default = enabled):
 
 ```ini
 [source-list]
@@ -67,29 +62,20 @@ STALE unaffected) — but it buys nothing for SIL, so leave it off:
 # sei-uuid=NVDS_CUSTOMMETA
 ```
 
-### Use system timestamp in `[streammux]` — the critical setting
+### Use system timestamp in `[streammux]`
 
 ```ini
 [streammux]
-attach-sys-ts-as-ntp=1       # change from 0 to 1 — tag frames with system (wall-clock) time
-# extract-sei-sim-time=1     # comment out — do NOT use Isaac's SEI sim-time as the timestamp
-# drop-backward-sei=1        # comment out — only relevant when driving off SEI sim-time
+attach-sys-ts-as-ntp=1       # change from 0 to 1
+# extract-sei-sim-time=1     # comment out
+# drop-backward-sei=1        # comment out
 ```
 
-**Why (A/B tested on Isaac 6.0):**
-
-| DeepStream config | FPS/cam | PSF STALE | MUTE/UNMUTE |
-|-------------------|---------|-----------|-------------|
-| system ts (this config: `attach-sys-ts-as-ntp=1`, SEI sim-time off) | ~14, stable | 0 | normal |
-| SEI type-5 extract **on**, still system ts | ~14, stable | 0 | normal |
-| SEI **sim-time** as NTP (`extract-sei-sim-time=1`, `attach-sys-ts-as-ntp=0`) | ~14, stable | ~100 | degraded / stalls |
-
-The takeaway: **the timestamp source is what matters, not SEI extraction.** Isaac's
-sim-time drifts relative to PSF's ~6 s decision window, so using it as the NTP timestamp
-makes PSF drop events as STALE and MUTE stops toggling. Extracting SEI does **not** hurt
-FPS — the old "SEI → 0 FPS" claim did not reproduce on 6.0. Tag frames with **system
-time** and safety decisions flow correctly. (`bbox_tolerance_ms` below handles residual
-VST bbox flicker.)
+**Why**: `attach-sys-ts-as-ntp=1` tags each frame with the host's system (wall-clock) time.
+Isaac 6.0 RTSP embeds SEI (which carries a sim-time value), but **PSF currently doesn't
+support sim time** — using it as the frame timestamp makes PSF drop events as STALE, so
+system time keeps the perception → PSF decisions flowing. (`bbox_tolerance_ms` below handles
+residual VST bbox flicker.)
 
 ---
 
@@ -124,11 +110,8 @@ echo "vss-rtvi-cv READY:"
 docker logs vss-rtvi-cv 2>&1 | grep 'PERF' | tail -3
 ```
 
-> All 3 sources must show **non-zero**, stable FPS (~14/cam in SIL — the GPU is shared
-> with Isaac; NVIDIA's ~30 assumes a dedicated perception GPU). A source stuck at
-> `0.00000` means that stream isn't arriving (Isaac not streaming yet, wrong RTSP URL, or
-> the TensorRT engine still building) — **not** an SEI issue; SEI extraction does not
-> affect FPS on Isaac 6.0.
+> All 3 sources must show **non-zero** FPS. If one stays at `0.00000`, that stream
+> isn't arriving yet (Isaac not streaming, wrong RTSP URL, or the TensorRT engine still building).
 
 ### Ready signal 2: Kafka `mdx-events` topic has data
 

--- a/skills/hoisa-deploy-profile/references/vss_2d_overrides.md
+++ b/skills/hoisa-deploy-profile/references/vss_2d_overrides.md
@@ -15,8 +15,13 @@ standard deploy flow — this file specifies only what must be **different** for
 > `--env-file industry-profiles/warehouse-operations/.env`. Edit the override files
 > below in place, then let `vss-deploy-profile` bring VSS up.
 
-These overrides exist because **Isaac Sim RTSP streams carry no SEI metadata**,
-while the VSS defaults assume SEI is present.
+These overrides exist because of **how Isaac Sim's timestamps reach PSF** — not because
+SEI is missing. Isaac 6.0 RTSP *does* embed SEI (including a simulation-time value) and
+DeepStream extracts it fine; FPS is healthy either way. The real issue is the *timestamp
+source*: if DeepStream feeds Isaac's SEI **sim-time** in as the NTP timestamp, the sim
+clock lands outside PSF's decision window and events get dropped as **STALE**. So these
+overrides force **system timestamps** instead of SEI sim-time. (Verified on a live VSS 3.2
++ Isaac 6.0 SIL run — see the A/B results below.)
 
 ---
 
@@ -50,9 +55,11 @@ File:
 <wh_ops>/warehouse-2d-app/deepstream/configs/ds-main-config.txt
 ```
 
-### Disable SEI extraction in `[source-list]`
+### Leave SEI type-5 extraction commented in `[source-list]`
 
-Isaac Sim RTSP carries no SEI metadata — comment these out (default = enabled):
+Keep these commented (matches NVIDIA's official SIL config). Isaac 6.0 *does* send SEI,
+and A/B testing showed extracting the type-5 metadata on its own is harmless (FPS and
+STALE unaffected) — but it buys nothing for SIL, so leave it off:
 
 ```ini
 [source-list]
@@ -60,20 +67,29 @@ Isaac Sim RTSP carries no SEI metadata — comment these out (default = enabled)
 # sei-uuid=NVDS_CUSTOMMETA
 ```
 
-### Use system timestamp in `[streammux]`
+### Use system timestamp in `[streammux]` — the critical setting
 
 ```ini
 [streammux]
-attach-sys-ts-as-ntp=1       # change from 0 to 1
-# extract-sei-sim-time=1     # comment out
-# drop-backward-sei=1        # comment out
+attach-sys-ts-as-ntp=1       # change from 0 to 1 — tag frames with system (wall-clock) time
+# extract-sei-sim-time=1     # comment out — do NOT use Isaac's SEI sim-time as the timestamp
+# drop-backward-sei=1        # comment out — only relevant when driving off SEI sim-time
 ```
 
-**Why**: with SEI extraction left enabled, perception waits for SEI that Isaac
-never sends → it reports **low / 0 FPS** (a camera can stay stuck at `0.00000`),
-and PSF drops most events as **STALE** because the frames carry no proper NTP
-timestamp. `attach-sys-ts-as-ntp=1` fixes the timestamps; disabling SEI fixes the
-FPS. Bounding boxes also stop flickering on VST.
+**Why (A/B tested on Isaac 6.0):**
+
+| DeepStream config | FPS/cam | PSF STALE | MUTE/UNMUTE |
+|-------------------|---------|-----------|-------------|
+| system ts (this config: `attach-sys-ts-as-ntp=1`, SEI sim-time off) | ~14, stable | 0 | normal |
+| SEI type-5 extract **on**, still system ts | ~14, stable | 0 | normal |
+| SEI **sim-time** as NTP (`extract-sei-sim-time=1`, `attach-sys-ts-as-ntp=0`) | ~14, stable | ~100 | degraded / stalls |
+
+The takeaway: **the timestamp source is what matters, not SEI extraction.** Isaac's
+sim-time drifts relative to PSF's ~6 s decision window, so using it as the NTP timestamp
+makes PSF drop events as STALE and MUTE stops toggling. Extracting SEI does **not** hurt
+FPS — the old "SEI → 0 FPS" claim did not reproduce on 6.0. Tag frames with **system
+time** and safety decisions flow correctly. (`bbox_tolerance_ms` below handles residual
+VST bbox flicker.)
 
 ---
 
@@ -108,8 +124,11 @@ echo "vss-rtvi-cv READY:"
 docker logs vss-rtvi-cv 2>&1 | grep 'PERF' | tail -3
 ```
 
-> All 3 sources must show **non-zero** FPS. If one stays at `0.00000`, the SEI
-> override above was not applied (or the deploy started before it).
+> All 3 sources must show **non-zero**, stable FPS (~14/cam in SIL — the GPU is shared
+> with Isaac; NVIDIA's ~30 assumes a dedicated perception GPU). A source stuck at
+> `0.00000` means that stream isn't arriving (Isaac not streaming yet, wrong RTSP URL, or
+> the TensorRT engine still building) — **not** an SEI issue; SEI extraction does not
+> affect FPS on Isaac 6.0.
 
 ### Ready signal 2: Kafka `mdx-events` topic has data
 


### PR DESCRIPTION
Update the deploy skill docs from live SIL 2D + Isaac 6.0 findings:
- RTSP: mediamtx -> Isaac self-hosted per-camera H264 (8554/8555/8556); refresh kit-log handoff signals, drop Isaac 5.1 references
- SEI: 6.0 embeds SEI and DeepStream extracts it fine; the STALE/MUTE failure is the timestamp source (SEI sim-time as NTP), not extraction. Keep attach-sys-ts-as-ntp=1; rewrite SEI rationale + A/B table
- Fix STALE timeWindowSize doc (900ms -> 6000ms) and the obsolete "SEI -> low FPS" troubleshooting; note ~14 FPS/cam on shared GPU
- ROS: document ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST for single-host SIL
- mediamtx -> forklift-controller in service tables; bump skill to 1.3.0