### PR TITLE
fix(sil): bump PSF timeWindowSize to 6000ms and correct bypassFusionE…

### DIFF
--- a/closed-loop-testing/safety-core/configs/nvpss.conf
+++ b/closed-loop-testing/safety-core/configs/nvpss.conf
@@ -7,8 +7,9 @@ max_hb_failures = 50
 
 # Time window for correlation (in milliseconds)
 # Also controls STALE event threshold - events older than this are dropped
-# Default: 200ms, increased to 900ms to handle perception pipeline latency
-timeWindowSize = 900
+# Default: 200ms. SIL sets 6000ms (6 s) to cover perception / EventsParser transport
+# skew so PSF does not drop tripwire events as STALE.
+timeWindowSize = 6000
 
 # Minimum similarity threshold for fusion (0.0 to 1.0)
 fusionThreshold = 0.4
@@ -32,8 +33,23 @@ trajectoryCount = 4
 #Maximum number of pipelines supported
 maxPipelines=3
 
-# List of safety event types that bypass fusion and are sent directly for decision
-bypassFusionEvents = SW_FAIL, EVENT_6, EVENT_7
+# List of safety event types that bypass fusion and are sent directly for decision.
+#
+# ATL event map — source of truth: safety-core/adapters/vss/event-mappings/atl/event_mapping_atl.pb.txt
+# (packaged into the PSF image at /opt/nvidia/psf/apps/atl/event_mapping_atl.pb.txt; all severity HIGH).
+# Tripwire = trailer entry line: OUT = crossed INTO the trailer, IN = crossed OUT of the trailer.
+#   EVENT_0  Forklift tripwire OUT  (mdx-events, tripwire-id-1) -> forkliftInTrailer=true  -> MUTE if no person
+#   EVENT_1  Forklift tripwire IN   (mdx-events, tripwire-id-1) -> forkliftInTrailer=false -> UNMUTE
+#   EVENT_2  Person   tripwire OUT  (mdx-events, tripwire-id-1) -> personsInTrailerCount++ -> UNMUTE
+#   EVENT_3  Person   tripwire IN   (mdx-events, tripwire-id-1) -> personsInTrailerCount--
+#   EVENT_4  Person restricted-area ROI violation  (mdx-frames, roi-id-1) -> UNMUTE
+#   EVENT_5  Person ROI violation CLEARED          (mdx-frames, roi-id-1) -> clear flag
+#   (EVENT_6/EVENT_7 belong to the proximity app mapping — not used by ATL.)
+# rule_id values (tripwire-id-1 / roi-id-1) must match the ids in the VSS calibration.json.
+# Other valid names: SW_FAIL, SENSOR_INVALID/VALID, AI_PIPELINE_INVALID/VALID,
+# ROI_ENTRY/EXIT, TW_CROSSING_ENTRY/EXIT. WARNING: an unknown/misspelled name
+# silently falls back to EVENT_0. Keep SW_FAIL in the list always.
+bypassFusionEvents = SW_FAIL, EVENT_0, EVENT_1, EVENT_2, EVENT_3, EVENT_4, EVENT_5
 
 # Select PSS Daemon to PSD communication channel between POSIX_SOCKET & POSIX_MSG_QUE
 PSSDToPSDComBackend = POSIX_MSG_QUE

--- a/skills/hoisa-deploy-profile/references/test_scenario.md
+++ b/skills/hoisa-deploy-profile/references/test_scenario.md
@@ -143,7 +143,7 @@ tail -n 30 "$MDX_DATA_DIR/psf-log/pss.log"
 ... nv_mdx_client[59]: ... Endpoint: NVPSB_PSS_SOURCE Data: Safety event reported: EVENT_1 (rule: Forklift tripwire IN)
 ... NVPSB_PSD_CLIENT[34]: ... Data: PSD-Gateway: received DecisionRequest id=1 with 1 events
 ```
-- **EVENT_0 / EVENT_1**: tripwire crossings reported by perception (forklift OUT / IN the trailer).
+- **EVENT_0 / EVENT_1**: tripwire crossings reported by perception (forklift OUT / IN the trailer). The full ATL event map (`EVENT_0`–`EVENT_5` → forklift/person tripwire + person ROI) is documented in `closed-loop-testing/safety-core/configs/nvpss.conf` (the `bypassFusionEvents` block).
 - **DecisionRequest**: the PSF decision-maker is invoked — it produces the corresponding MUTE/UNMUTE command shown in the OPC log above.
 
 ---

--- a/skills/hoisa-deploy-profile/references/troubleshooting.md
+++ b/skills/hoisa-deploy-profile/references/troubleshooting.md
@@ -29,7 +29,7 @@ cd <repo>/deployments && docker compose --env-file profiles/<profile>.env down &
 **Symptom**: PSF log floods with `Dropping STALE event`; safety decisions lag or don't trigger.
 
 **First — some STALE is normal.** Events reaching PSF older than `timeWindowSize`
-(default 900 ms) are dropped. Measure the **steady-state** rate **after the loop has
+(6000 ms / 6 s in the SIL `nvpss.conf`; code fallback 200 ms) are dropped. Measure the **steady-state** rate **after the loop has
 run a while** — startup / bootstrap STALE before Isaac streams stabilise is expected.
 A persistent high rate (tens of % while running) indicates real pipeline latency.
 
@@ -43,7 +43,7 @@ timestamp and nearly everything is dropped as STALE.
 # 1. Confirm the DeepStream SEI override is applied (see vss_2d_overrides.md)
 # 2. If STALE is still high once running, widen the window:
 nano <repo>/closed-loop-testing/safety-core/configs/nvpss.conf
-# Increase timeWindowSize (e.g. 900 -> 1200)
+# Increase timeWindowSize (e.g. 6000 -> 8000)
 cd <repo>/deployments && docker compose --env-file profiles/<profile>.env restart safety-core
 ```
 


### PR DESCRIPTION
…vents to the ATL events

- nvpss.conf: timeWindowSize 900 -> 6000 (6 s) so PSF does not drop tripwire events as STALE (matches the deployed SIL decision window; code fallback stays 200 ms).
- nvpss.conf: bypassFusionEvents was `SW_FAIL, EVENT_6, EVENT_7`, but EVENT_6/7 are proximity-app events ATL never emits or subscribes (dead for ATL). Set it to the actual ATL tripwire/ROI events `SW_FAIL, EVENT_0..EVENT_5` and document the full event map inline (source of truth: safety-core/adapters/vss/event-mappings/atl/event_mapping_atl.pb.txt).
- skill docs: align the timeWindowSize numbers to 6000ms and point the event-map explanation at nvpss.conf instead of duplicating it.