### PR TITLE
feat: HIL profile — two-host closed loop (x86 stimulus + IGX Thor safety host)

### DIFF
--- a/closed-loop-testing/hil/README.md
+++ b/closed-loop-testing/hil/README.md
@@ -1,3 +1,16 @@
-# HIL — Hardware-in-the-Loop 🚧
+# HIL — Hardware-in-the-Loop
 
-> **Under development.** The `hil` profile runs the safety core on an NVIDIA Thor device instead of locally. Not yet available — use the `sil` profile for now.
+The `hil` profile splits the `sil` closed loop across two machines: an **x86 stimulus host**
+(Isaac Sim + comm-layer + forklift-controller, `COMPOSE_PROFILES=hil`) and an **IGX Thor
+safety host** running VSS Warehouse perception and the Thor Safety Core. The safety decision
+crosses the network back to the x86 comm-layer, closing the loop over two hosts.
+
+Runbook: [`skills/hoisa-deploy-profile/references/halos_hil.md`](../../skills/hoisa-deploy-profile/references/halos_hil.md) —
+prerequisites, deploy order (start the Isaac scenario **before** VSS on the Thor), the
+scene-clear start gate, ready signals, and hil-specific troubleshooting.
+
+Configuration:
+
+- `deployments/profiles/hil.env` — the x86 stimulus side (`docker compose --env-file profiles/hil.env up -d`)
+- `deployments/profiles/hil-thor.env` — the Thor side, consumed by `closed-loop-testing/scripts/launch_thor_safety.sh hil-thor`
+- `closed-loop-testing/scripts/hil_preflight.sh` — two-host preflight, run from the x86 host before bring-up

--- a/closed-loop-testing/isaac-sim/isaac-sim.yml
+++ b/closed-loop-testing/isaac-sim/isaac-sim.yml
@@ -23,10 +23,11 @@ services:
       - ROS_AUTOMATIC_DISCOVERY_RANGE=${ROS_AUTOMATIC_DISCOVERY_RANGE:-SUBNET}  # SUBNET=LAN multicast (multi-host/HIL) | LOCALHOST=single-host SIL (set in sil.env) | OFF
       - HOST_IP=${HOST_IP}
       - VST_BASE_URL=${VST_BASE_URL}
+      - PERCEPTION_BASE_URL=${PERCEPTION_BASE_URL:-http://localhost:9000}
       - ROS_DISTRO=jazzy
       - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
       - LD_LIBRARY_PATH=/isaac-sim/exts/isaacsim.ros2.core/jazzy/lib
-      - PLAYBACK_SEGMENTS_FILE=${PLAYBACK_SEGMENTS_FILE}
+      - PLAYBACK_SEGMENTS_FILE=${PLAYBACK_SEGMENTS_FILE:-}
     volumes:
       - ${HOME}/.Xauthority:/isaac-sim/.Xauthority:ro
       - /tmp/.X11-unix:/tmp/.X11-unix:rw

--- a/closed-loop-testing/isaac-sim/sil/scripts/vst_sensor_manager.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/vst_sensor_manager.py
@@ -63,7 +63,7 @@ class VSTSensorManager:
         self.base_url = base_url or os.environ.get("VST_BASE_URL", "http://localhost:30888/vst/api")
         self.auth_token = auth_token or os.environ.get("VST_AUTH_TOKEN", "")
         self.timeout = timeout
-        self.perception_url = "http://localhost:9000"
+        self.perception_url = os.environ.get("PERCEPTION_BASE_URL", "http://localhost:9000")
 
         # Ensure base_url ends without trailing slash for consistent joining
         self.base_url = self.base_url.rstrip("/")

--- a/closed-loop-testing/scripts/hil_preflight.sh
+++ b/closed-loop-testing/scripts/hil_preflight.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# HIL preflight — run on the x86 stimulus host BEFORE bringing the hil profile up.
+# Validates the profile env, this host's tooling, and (when reachable) the Thor safety
+# host, so a two-host deploy fails here instead of half-way through the bring-up.
+#
+# Usage (from the repo root):
+#   bash closed-loop-testing/scripts/hil_preflight.sh [deployments/profiles/hil.env] [--thor <user@host>]
+#
+#   --thor   ssh target for the Thor safety host (e.g. <user>@<thor_ip>). Without it,
+#            the Thor-side checks are printed as a manual checklist instead of failing.
+
+set -u
+
+ENV_FILE="deployments/profiles/hil.env"
+THOR_SSH=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --thor) THOR_SSH="${2:?--thor needs <user@host>}"; shift 2 ;;
+        *) ENV_FILE="$1"; shift ;;
+    esac
+done
+
+FAIL=0
+warn() { printf 'WARN  %s\n' "$*"; }
+ok()   { printf 'ok    %s\n' "$*"; }
+fail() { printf 'FAIL  %s\n' "$*"; FAIL=1; }
+
+# --- 1. Env file present + placeholders filled ---
+[ -f "$ENV_FILE" ] || { fail "env file not found: $ENV_FILE"; exit 1; }
+set -a; . "$ENV_FILE"; set +a
+ok "loaded $ENV_FILE"
+
+for v in MDX_SAMPLE_APPS_DIR MDX_DATA_DIR HOST_IP PEER_HOST_IP; do
+    val="${!v:-}"
+    case "$val" in
+        ''|*'/path/to/'*|*'<'*'>'*) fail "$v not filled in (value: '${val}')" ;;
+        *) ok "$v=$val" ;;
+    esac
+done
+[ "${HOST_IP:-}" = "${PEER_HOST_IP:-}" ] && fail "HOST_IP equals PEER_HOST_IP - hil is a two-host profile (use the sil profile for single-host)"
+
+# --- 2. Cross-file invariants ---
+[ "${COMPOSE_PROFILES:-}" = "hil" ] || warn "COMPOSE_PROFILES is '${COMPOSE_PROFILES:-}' (expected hil)"
+[ -n "${COMM_UDP_PORT:-}" ] || fail "COMM_UDP_PORT not set (the Thor's PSF_CMD_RX_PORT must match it)"
+[ -d "${MDX_SAMPLE_APPS_DIR:-/nonexistent}/closed-loop-testing" ] || fail "MDX_SAMPLE_APPS_DIR does not look like the repo root"
+[ -d "${MDX_DATA_DIR:-/nonexistent}/collected-assets" ] || warn "MDX_DATA_DIR has no collected-assets/ yet (ngc_artifacts.md §1)"
+
+# --- 3. Local tooling ---
+command -v docker >/dev/null 2>&1 && ok "docker present" || fail "docker not found"
+docker compose version >/dev/null 2>&1 && ok "docker compose v2 present" || fail "docker compose v2 not found"
+if [ -n "${DOCKER_GID:-}" ]; then
+    real_gid="$(getent group docker 2>/dev/null | cut -d: -f3)"
+    [ -n "$real_gid" ] && [ "$real_gid" != "$DOCKER_GID" ] && warn "DOCKER_GID=$DOCKER_GID but host docker group is $real_gid"
+fi
+
+# --- 4. Local clock ---
+if command -v timedatectl >/dev/null 2>&1; then
+    [ "$(timedatectl show -p NTPSynchronized --value 2>/dev/null)" = "yes" ] \
+        && ok "local clock NTP-synchronized" \
+        || warn "local clock not NTP-synchronized (cross-host log correlation and latency math need synced clocks)"
+fi
+
+# --- 5. Thor safety host ---
+if [ -n "$THOR_SSH" ]; then
+    if ssh -o BatchMode=yes -o ConnectTimeout=8 "$THOR_SSH" true 2>/dev/null; then
+        ok "ssh $THOR_SSH reachable"
+        [ "$(ssh -o BatchMode=yes -o ConnectTimeout=8 "$THOR_SSH" 'timedatectl show -p NTPSynchronized --value' 2>/dev/null)" = "yes" ] \
+            && ok "Thor clock NTP-synchronized" \
+            || warn "Thor clock not NTP-synchronized"
+        thor_epoch="$(ssh -o BatchMode=yes -o ConnectTimeout=8 "$THOR_SSH" 'date +%s' 2>/dev/null)"
+        if [ -n "$thor_epoch" ]; then
+            skew=$(( $(date +%s) - thor_epoch ))
+            [ "${skew#-}" -le 2 ] && ok "clock skew x86<->Thor ${skew}s" || warn "clock skew x86<->Thor ${skew}s (>2s)"
+        else
+            warn "could not read the Thor clock for the skew check"
+        fi
+    else
+        fail "cannot ssh $THOR_SSH (key-based auth required for the orchestrated flow)"
+    fi
+    curl -s --max-time 6 -o /dev/null -w '%{response_code}' "http://${PEER_HOST_IP}:30888/vst/api/v1/sensor/list" 2>/dev/null | grep -q '^200$' \
+        && ok "Thor VST API :30888 reachable" \
+        || warn "Thor VST API :30888 not answering yet (fine if VSS is not up yet)"
+    # liveness only: any HTTP response (including 4xx on this POST-only endpoint) counts as up
+    curl -s --max-time 6 -o /dev/null "http://${PEER_HOST_IP}:9000/api/v1/stream/add" 2>/dev/null \
+        && ok "Thor perception API :9000 reachable" \
+        || warn "Thor perception API :9000 not answering yet (fine if VSS is not up yet)"
+else
+    cat <<'CHECKLIST'
+note  --thor not given; verify these on the Thor manually:
+      [ ] clock NTP-synchronized (timedatectl)
+      [ ] VSS Warehouse 2D up; camera_info.json lists this host's Isaac RTSP URLs (SENSOR_INFO_SOURCE=file)
+      [ ] VST API :30888 and perception API :9000 answering
+      [ ] profiles/hil-thor.env filled (PSF_CMD_RX_IP = this x86 host, PSF_CMD_RX_PORT = COMM_UDP_PORT)
+CHECKLIST
+fi
+
+echo ""
+if [ "$FAIL" -eq 0 ]; then
+    echo "preflight PASSED (warnings above, if any, are advisory)"
+else
+    echo "preflight FAILED - fix the FAIL lines above before compose up"
+fi
+exit "$FAIL"

--- a/deployments/profiles/hil-thor.env
+++ b/deployments/profiles/hil-thor.env
@@ -1,0 +1,24 @@
+# HIL profile — Thor safety-host side (the x86 stimulus side uses profiles/hil.env).
+# Not a compose profile: `launch_thor_safety.sh hil-thor` reads this file and starts the
+# Safety Core = the nv-psf container (event integration + decision gateway) plus the host
+# SDM (`atl_sdm` for ccplex, or the `fsicom-agent` bridge for fsi). Same launch path as
+# base-thor; the one difference is the command sink: decisions go to the x86 comm-layer
+# (PEER_HOST_IP:12346), not the local VST overlay (:12345).
+# VSS prerequisites on this Thor before launching: see references/halos_hil.md.
+# Usage:  bash closed-loop-testing/scripts/launch_thor_safety.sh hil-thor
+
+HOST_IP='' # change me — this Thor's IP
+PEER_HOST_IP='' # change me — the x86 stimulus host (comm-layer)
+
+# nv-psf container (multi-arch; Docker selects arm64 on Thor — same tag as the x86 profiles)
+PSF_IMAGE=nvcr.io/nvidia/halos-outside-in/outside-in-safety:nv-psf-halos-1.2.1-3041f93
+# Thor host packages (install per ngc_artifacts.md §4; keep the SAME build tag as PSF_IMAGE)
+PSF_TEGRA_RESOURCE=nvidia/halos-outside-in/outside-in-safety:nv-psf-halos-1.2.1-aarch64-release-3041f93-psf-tegra         # host binaries .deb (atl_sdm, launch_hoisa, safety_monitor) for CCPLEX + FSI host side
+PSF_TEGRA_FSI_RESOURCE=nvidia/outside-in-safety/outside-in-safety:nv-psf-halos-1.2.1-aarch64-release-3041f93-psf-tegra-fsi  # FSI firmware + fsicom-agent .deb (SDM_TARGET=fsi only)
+
+SDM_TARGET=ccplex        # ccplex (host SDM, start here) | fsi (SDM on the Functional Safety Island — halos_thor.md §5B)
+PSF_LAUNCH_MODE=skip     # skip (no AI monitor — recommended for hil) | active (full stack incl. AI monitor)
+PSF_CMD_RX_IP=${PEER_HOST_IP}
+PSF_CMD_RX_PORT=12346    # the x86 comm-layer COMM_UDP_PORT (hil.env) — NOT the VST overlay port
+KAFKA_BROKER=localhost:9092                                    # VSS Kafka on this Thor
+PSF_SENSOR_CONFIG=/opt/nvidia/psf/bin/sensor_config_thor.conf  # copy from closed-loop-testing/safety-core/configs/, fill the VST re-serve URLs (or use refresh_thor_sensor_config.sh)

--- a/deployments/profiles/hil.env
+++ b/deployments/profiles/hil.env
@@ -1,5 +1,9 @@
-# HIL profile — under development. Not yet supported; use sil.env.
-# x86 stimulus side (isaac-sim + comm-layer + forklift-controller); the safety core runs on a Thor device, launched separately.
+# HIL profile — hardware-in-the-loop across two hosts. This env drives the x86 stimulus
+# side only: compose starts isaac-sim + comm-layer + forklift-controller (no local
+# safety-core; that service is gated to the base/sil profiles). The Safety Core runs on an
+# IGX Thor safety host instead, launched there with `launch_thor_safety.sh hil-thor`
+# (profiles/hil-thor.env), and sends its decisions back to this host's comm-layer.
+# Usage:  cd deployments && docker compose --env-file profiles/hil.env up -d
 
 COMPOSE_PROFILES=hil
 
@@ -9,21 +13,36 @@ MDX_DATA_RESOURCE=nvidia/halos-outside-in/sample-sil-data:v1.2.1 # NGC resource 
 HOST_IP='' # change me — this x86 stimulus host
 PEER_HOST_IP='' # change me — Thor safety host
 
+# Thor-side endpoints the x86 side talks to: VST (sensor registry / WebUI) and the
+# perception stream API (nvmultiurisrcbin REST; consumed by vst_sensor_manager when used).
 VST_BASE_URL=http://${PEER_HOST_IP}:30888/vst/api
+PERCEPTION_BASE_URL=http://${PEER_HOST_IP}:9000
 
 COMM_UDP_PORT=12346
 COMM_OPCUA_ENDPOINT=opc.tcp://0.0.0.0:4840/safety/
 COMM_ROS_TOPIC_PREFIX=/safety
 COMM_LOG_DIR=${MDX_DATA_DIR}/comm-layer
-ROS_DOMAIN_ID=0
+ROS_DOMAIN_ID=0 # change me if other ROS hosts share the subnet (default 0 collides)
 
-SDM_TARGET=ccplex
-PSF_LAUNCH_MODE=active
+# ROS 2 discovery scope (all ROS services stay on this x86 host; the Thor link is UDP, not DDS):
+#   LOCALHOST = discover only on this host's loopback -- REQUIRED on cloud VMs (e.g. Brev)
+#               that block UDP multicast, which otherwise breaks cyclonedds peer discovery
+#               (Isaac <-> forklift-controller <-> comm-layer can't find each other).
+#   SUBNET    = default (unset) behaviour: LAN-wide multicast discovery -- use for multi-host / HIL.
+#   OFF       = disable automatic discovery entirely.
+ROS_AUTOMATIC_DISCOVERY_RANGE=SUBNET
 
-ISAAC_SIM_IMAGE=nvcr.io/nvidia/isaac-sim:5.1.0
+ISAAC_SIM_IMAGE=nvcr.io/nvidia/isaac-sim:6.0.0
 ISAAC_GPU_DEVICE=0
 ISAAC_CACHE_DIR=${MDX_DATA_DIR}/isaac-cache
 ISAAC_SIL_DIR=${MDX_SAMPLE_APPS_DIR}/closed-loop-testing/isaac-sim/sil
-PLAYBACK_SEGMENTS_FILE=/isaac-sim/sil/playback/segments.json
 
 DOCKER_GID=999 # change me — run: getent group docker | cut -d: -f3
+
+# Unused on this x86 side: safety-core is not in the hil profile — the Safety Core runs on
+# the Thor and takes its real PSF_IMAGE / PSF_CMD_RX_* from profiles/hil-thor.env. These are
+# kept here only so `docker compose` can interpolate ALL included service yml before
+# profile-filtering (single-compose constraint, same convention as base.env).
+PSF_IMAGE=nvcr.io/nvidia/halos-outside-in/outside-in-safety:nv-psf-halos-1.2.1-3041f93
+PSF_CMD_RX_IP=127.0.0.1
+PSF_LOG_DIR=${MDX_DATA_DIR}/psf-log

--- a/skills/hoisa-deploy-profile/SKILL.md
+++ b/skills/hoisa-deploy-profile/SKILL.md
@@ -32,7 +32,7 @@ Pick one profile (set `COMPOSE_PROFILES` in the profile run-env). Services start
 |---------|----------|-----|
 | `base` | safety-core | Safety on an existing VSS feed; MUTE/UNMUTE rendered as the VST `halo_safety` overlay ("Standard"/"Efficient Mode" + proximity bubble). No Isaac Sim. |
 | `sil` | safety-core, comm-layer, isaac-sim, forklift-controller | Full single-host closed loop: Isaac Sim stimulus → VSS perception → PSF → ROS → Isaac forklift. |
-| `hil` 🚧 | comm-layer, isaac-sim, forklift-controller | 🚧 **Under development.** |
+| `hil` | comm-layer, isaac-sim, forklift-controller | Two-host closed loop: this x86 stimulus stack + an IGX Thor safety host running VSS perception and the Thor Safety Core — `references/halos_hil.md`. |
 
 > **The `sil` profile runs against either a 2D or a 3D perception backend.** 2D
 > (RT-DETR detect + track) is the default — `references/vss_2d_overrides.md`. For **3D
@@ -145,7 +145,8 @@ Deploy in strict order. **Stack 1 (VSS) must be running before Stack 2 (Halos).*
 | [references/calibration_3d.md](references/calibration_3d.md) | **3D** — the 3-camera BEV calibration (`group` / `rois` / `tripwires`) |
 | [references/halos_deploy.md](references/halos_deploy.md) | Configuring and deploying the Halos stack by profile |
 | [references/halos_thor.md](references/halos_thor.md) | Deploying `base` on IGX Thor (aarch64) — SDM on CCPLEX or FSI |
-| [references/halos_hil.md](references/halos_hil.md) | 🚧 **Under development** — HIL profile |
+| [references/vss_hil_overrides.md](references/vss_hil_overrides.md) | **HIL** — VSS deltas for a remote Isaac source: stream URLs, sensor-registration ownership, fresh state |
+| [references/halos_hil.md](references/halos_hil.md) | **HIL profile** — the two-host closed loop runbook (x86 stimulus + IGX Thor safety host) |
 | [references/test_scenario.md](references/test_scenario.md) | Running the simulation, monitoring safety commands, viewing camera streams |
 | [references/troubleshooting.md](references/troubleshooting.md) | Fixing deployment errors |
 
@@ -204,3 +205,9 @@ docker volume prune -f
 
 # Stop VSS Warehouse — see the vss-deploy-profile skill
 ```
+
+> ⚠️ `docker volume prune -f` deletes **every** dangling volume on the host. Safe while VSS
+> is still running (its volumes are in-use), but if the VSS stack is already down it also
+> deletes the perception TensorRT engine cache (a 15-20 min rebuild on the next deploy) and
+> the sensor database. **Ask the user before running it**; to clear only Halos state, skip
+> the prune — the `down` + datalog cleanup above already remove the per-run state.

--- a/skills/hoisa-deploy-profile/references/halos_deploy.md
+++ b/skills/hoisa-deploy-profile/references/halos_deploy.md
@@ -7,7 +7,7 @@ Services and config differ per profile:
 |---------|----------|-------|
 | `base` | safety-core | Safety on an existing VSS feed; MUTE/UNMUTE shown as the VST `halo_safety` overlay. No Isaac Sim. |
 | `sil` | safety-core, comm-layer, isaac-sim, forklift-controller | Full single-host closed loop. |
-| `hil` 🚧 | comm-layer, isaac-sim, forklift-controller | 🚧 Under development — see `halos_hil.md`. |
+| `hil` | comm-layer, isaac-sim, forklift-controller | Two-host closed loop: x86 stimulus + IGX Thor safety host — see `halos_hil.md`. |
 
 ---
 

--- a/skills/hoisa-deploy-profile/references/halos_hil.md
+++ b/skills/hoisa-deploy-profile/references/halos_hil.md
@@ -1,3 +1,125 @@
-# Halos HIL Profile 🚧
+# Halos `hil` - Hardware-in-the-Loop across two hosts
 
-> **Under development.** The `hil` profile runs the safety core on an NVIDIA Thor device instead of as a local container. Not yet available — use the `sil` profile for now.
+The `hil` profile is the `sil` closed loop split across two machines: an **x86 stimulus host** (`COMPOSE_PROFILES=hil`: isaac-sim + comm-layer + forklift-controller - no local safety-core) and an **IGX Thor safety host** (VSS Warehouse perception + the Thor Safety Core). The safety decision drives the simulation, so the loop closes across the network.
+
+```
+x86 stimulus host                          IGX Thor safety host
+─────────────────                          ────────────────────
+isaac-sim (3 cams, RTSP :8554-8556) ──────▶ VST + DS perception (pull the Isaac streams)
+forklift-controller ─ROS─▶ isaac-sim              │ BA events → Kafka → Safety Core
+comm-layer ◀────────────── UDP :12346 ──── atl_sdm (ccplex) or FSI
+     └─ROS─▶ /safety/is_muted ─▶ isaac-sim indicator / consumers
+```
+
+Only two flows cross hosts: the camera RTSP (Thor pulls from the x86) and the 64-byte safety command UDP (Thor sends to the x86 comm-layer on `COMM_UDP_PORT`, default 12346 - NOT the VST overlay port used by `base`). ROS 2 never crosses hosts; it stays on the x86.
+
+Run the deployment (and this skill) from the **x86 host**; ssh access to the Thor makes the whole flow drivable from one seat, and `hil_preflight.sh` can then check both ends. Both hosts need a clone of this repo.
+
+## 0. Prerequisites
+
+- x86 host: per `prerequisites.md` (GPU for Isaac Sim), plus the NGC artifacts from `ngc_artifacts.md` §1 (sil-data).
+- Thor host: IGX Thor on a current GA release with VSS Warehouse 3.2 deployable, plus the Safety Core packages from `ngc_artifacts.md` §4 (`psf-tegra`, and `psf-tegra-fsi` for the FSI target).
+- Network: the two hosts must reach each other (Isaac RTSP ports 8554-8556 toward the x86; UDP `COMM_UDP_PORT` toward the x86; VST :30888 and perception :9000 toward the Thor for orchestration).
+
+## 1. x86: configure and start the stimulus stack
+
+Fill `deployments/profiles/hil.env` (`HOST_IP` = this x86 host, `PEER_HOST_IP` = the Thor), then:
+
+```bash
+bash closed-loop-testing/scripts/hil_preflight.sh deployments/profiles/hil.env --thor <user>@<PEER_HOST_IP>
+cd deployments && docker compose --env-file profiles/hil.env up -d
+```
+
+Ready when all three services are up (`isaac-sim`, `comm-layer` healthy, `forklift-controller`).
+
+## 2. x86: start the scenario
+
+```bash
+docker exec -d isaac-sim bash -lc 'cd /isaac-sim/sil/scripts && ./run_sdg.sh \
+  -c /isaac-sim/sil/configs/default_config_ros.yaml --start --headless \
+  --cameras-config /isaac-sim/sil/configs/cameras.yaml'
+```
+
+Do NOT pass `--enable-vst`: the Thor-side configurator owns sensor registration (one owner only, see `vss_hil_overrides.md` §2). Forklift and clock graphs read `configs/robots.yaml` automatically; the forklift-controller then drives the forklift in a continuous loop.
+
+Scenario behavior is shared with `sil`: the first run goes quiet for ~5-10 min (scene load + shader compile, cached afterwards), and `--start` auto-stops after `simulation_length` frames - details in `test_scenario.md`. Take only the behavior notes from that file; its launch command carries `--enable-vst`, which must not be used in this flow.
+
+Ready when the forklift-controller log advances (`pose=` lines with changing coordinates) and all three streams DELIVER FRAMES - a listening port is not enough, since a cold Isaac accepts RTSP clients before the encoder produces its first frame:
+
+```bash
+for s in 8554/camera 8555/camera_01 8556/camera_02; do
+  ffprobe -v error -rtsp_transport tcp -count_frames -read_intervals "%+2" \
+    -select_streams v:0 -show_entries stream=nb_read_frames -of default=noprint_wrappers=1 \
+    "rtsp://localhost:${s%/*}/${s#*/}"
+done
+```
+
+## 3. Thor: deploy VSS Warehouse for the Isaac source
+
+Only once the streams above deliver frames, deploy VSS Warehouse on the Thor per `vss_hil_overrides.md`, applying all overrides BEFORE the first `up`. That file chains the rest: the 2D or 3D profile overrides (`vss_2d_overrides.md` / `vss_3d_overrides.md`), the `halos_thor.md` §2 IGX-Thor workarounds, sensor registration ownership, and the fresh-state teardown for a previously-used Thor. The order matters: the file-mode sensor registration has no stream-readiness gate, so deploying VSS against a cold Isaac triggers the "no caps" race (`vss_hil_overrides.md` §2; recovery in `troubleshooting.md`, RTSP Streams "no caps").
+
+Ready when the three sensors are `online` in VST pointing at the x86 host's IP, and perception shows `Active sources : 3` with non-zero fps (low fps that tracks the Isaac render rate is normal, not a network fault - `vss_hil_overrides.md` §4).
+
+## 4. Gate: start the Safety Core only on a clear scene
+
+The safety decision logic initializes its internal state from the events it sees at startup. Start it on a clear scene: launching while the forklift is inside the trailer tripwire (or the scene is otherwise mid-action) can initialize it into an inconsistent state, and it should then be restarted at a clear moment. This mirrors the safety concept: a human operator clears the space, then the outside-in system starts.
+
+Practical gate: watch the forklift-controller log for a `FORWARD -> REVERSE` segment transition (the forklift leaving the trailer) and launch the Safety Core within about 10 seconds.
+
+## 5. Thor: launch the Safety Core
+
+Fill `deployments/profiles/hil-thor.env` on the Thor (`PSF_CMD_RX_IP` = the x86 host, `PSF_CMD_RX_PORT` = the x86 `COMM_UDP_PORT`), then, inside a `tmux` session (the launcher runs in the foreground; an ssh drop would tear the Safety Core down):
+
+```bash
+tmux new -s safety
+bash closed-loop-testing/scripts/launch_thor_safety.sh hil-thor
+```
+
+Verify per `halos_thor.md` §5A (ccplex) or §5B (FSI): `nv-psf` up, and `atl_sdm` running (ccplex) or `fsicom-agent` with the relay flags (FSI); then confirm decisions are actually flowing per §5C. Both SDM targets work with this profile; start with ccplex.
+
+## 6. Verify the closed loop
+
+On the x86:
+
+```bash
+docker logs --tail 30 comm-layer   # re-run to poll; never a blocking `docker logs -f`
+```
+
+Healthy loop: a heartbeat line every ~5 s, `UNMUTE (PREVENT OPERATION)` bursts when a person enters a restricted area, and `MUTE (ALLOW OPERATION)` when the forklift is inside the trailer with the area clear - each followed by a `ROS2: ... is_muted=...` line. Decisions are event-driven: a quiet scene produces only heartbeats. The full `Seq#N | <description> | <symbol>` line format and command meanings are in `test_scenario.md`, Monitor Safety Commands.
+
+```bash
+docker exec comm-layer bash -lc "source /opt/ros/jazzy/setup.bash && ros2 topic echo --once /safety/is_muted"
+```
+
+The Isaac scene's safety indicator follows `is_muted`, and the VST WebUI on the Thor (`http://<PEER_HOST_IP>:30888/vst/`) shows the live streams for visual confirmation.
+
+## Ready signals (hil)
+
+| Phase | Signal |
+|---|---|
+| x86 stack | 3 services up; comm-layer healthy; UDP `COMM_UDP_PORT` bound |
+| Scenario | All 3 RTSP streams deliver frames (ffprobe, §2); forklift-controller `pose=` lines advancing |
+| Thor VSS | 3 sensors `online` in VST with the x86 IP; `Active sources : 3`, fps > 0 |
+| Safety Core | `nv-psf` up on the Thor; SDM process present (`atl_sdm` or `fsicom-agent`) |
+| Closed loop | comm-layer receives heartbeats + decisions; `/safety/is_muted` updates; sim-driven MUTE/UNMUTE transitions observed |
+
+## Troubleshooting (hil-specific)
+
+| Symptom | Fix |
+|---|---|
+| `no caps` / `could not create SDP` on the Isaac streams | Sensors were registered against a cold Isaac (deploy order, §3) - probe and recovery in `troubleshooting.md`, RTSP Streams "no caps" |
+| VST sensors `online` but perception 0 fps, no errors | RTSP-over-UDP delivering no media (`vss_2d_overrides.md` VST Config); after an Isaac restart, re-add the streams - if it recurs after every restart it is stale sensor history on a previously-used Thor (`troubleshooting.md`, Stale Sensor History Replay) |
+| Forklift never moves | ROS discovery: all three x86 containers must see each other (`ros2 topic info -v /odom` from the forklift-controller must show a publisher; on multi-interface hosts LOCALHOST discovery scoping can isolate the containers - use SUBNET). Also confirm `configs/robots.yaml` exists |
+| Decisions flow but MUTE never fires | The forklift tripwire events need the forklift actually crossing the trailer tripwire; confirm the forklift moves on camera, then check the Safety Core was started on a clear scene (§4) - restart it at a clear moment otherwise |
+| comm-layer receives nothing | UDP path x86:`COMM_UDP_PORT` unreachable from the Thor, or `PSF_CMD_RX_IP/PORT` wrong in `hil-thor.env` |
+| Safety Core dies when the ssh session drops | Launch under `tmux`/`setsid` (§5) |
+
+## Stop
+
+```bash
+# Thor:
+bash closed-loop-testing/scripts/stop_thor_safety.sh
+# x86:
+cd deployments && docker compose --env-file profiles/hil.env down
+bash ../closed-loop-testing/scripts/cleanup_all_datalog.sh hil
+```

--- a/skills/hoisa-deploy-profile/references/troubleshooting.md
+++ b/skills/hoisa-deploy-profile/references/troubleshooting.md
@@ -246,6 +246,42 @@ curl -s -X POST http://localhost:9000/api/v1/stream/add -H 'Content-Type: applic
 
 ---
 
+## Perception 0 FPS With Sensors Online (Stale Sensor History Replay)
+
+**Symptom**: on a host that ran VSS **before**, sensors show `online` in VST, perception
+logs show the right stream names, no errors anywhere — and the sources sit at 0 fps.
+Re-adding the streams helps, but they die again after the next perception restart.
+
+**Cause**: the sensor distribution service (`sdr-controller`) (re)provisions perception by
+replaying the **Kafka sensor history**. On a previously-used deploy the topics hold the whole
+add/remove history — including stale stream URLs from earlier runs — and every perception
+restart replays it, pushing the stale URLs back in over the live ones.
+
+**Fix** — fresh state before redeploy: tear the VSS stack down and clear the Kafka state.
+
+```bash
+# From the VSS deploy dir: down WITHOUT -v (keeps the TensorRT engine cache + sensor DB)
+docker compose --env-file industry-profiles/warehouse-operations/.env down --remove-orphans
+
+# Remove ONLY the kafka volumes — targeted, NOT `docker volume prune`: with the stack down,
+# prune also deletes the dangling perception engine cache (a 15-20 min rebuild) and the
+# sensor database.
+docker volume ls | grep -i kafka
+docker volume rm <the kafka volumes>
+
+# then bring VSS back up
+```
+
+Related state rules:
+
+- Replacing sensors mints new VST UUIDs; refresh anything that embeds the old stream URLs
+  (e.g. the safety-core sensor config).
+- If a source stalls at 0 fps once after an Isaac restart, just re-add the stream (or restart
+  the perception container and let the configurator re-provision). If it recurs after **every**
+  perception restart, it is this replay issue — wipe the Kafka state.
+
+---
+
 ## Cameras Not Showing in VST
 
 **Symptom**: VST UI at `http://<HOST_IP>:30888/vst/` shows no cameras.

--- a/skills/hoisa-deploy-profile/references/vss_2d_overrides.md
+++ b/skills/hoisa-deploy-profile/references/vss_2d_overrides.md
@@ -81,14 +81,24 @@ residual VST bbox flicker.)
 
 ## VST Config
 
-File: `<wh_ops>/warehouse-2d-app/vst/configs/vst_config.json`
+File: `<wh_ops>/warehouse-2d-app/vst/configs/vst_config.json` (several copies of
+`vst_config.json` exist in the deploy tree; edit the one the VST container actually mounts)
 
-```json
-"bbox_tolerance_ms": 100
+```jsonc
+"rtsp_streaming_over_tcp": true,    // ingest Isaac's RTSP over TCP (not UDP)
+"use_sensor_ntp_time": false,       // use arrival time, consistent with attach-sys-ts-as-ntp
+"always_recording": false,          // recording off — SIL does not need clips
+"bbox_tolerance_ms": 100            // default 0; widen metadata-to-frame match to reduce bbox flicker
 ```
 
-Default is `0`. Increasing to 100 ms reduces bounding-box flickering by widening
-the metadata-to-frame matching tolerance window.
+- `rtsp_streaming_over_tcp: true`: Isaac's self-hosted RTSP is served over TCP; forcing TCP
+  ingest avoids UDP packet loss / jitter.
+- `use_sensor_ntp_time: false`: pair with `attach-sys-ts-as-ntp=1` so VST and DeepStream
+  agree on wall-clock arrival time rather than the (drifting) sim-time.
+- Recording off: SIL is a live closed loop, not a capture run — leaving recording on wastes
+  disk and I/O.
+- `bbox_tolerance_ms: 100`: widens the metadata-to-frame matching tolerance window, reducing
+  bounding-box flickering.
 
 ---
 

--- a/skills/hoisa-deploy-profile/references/vss_hil_overrides.md
+++ b/skills/hoisa-deploy-profile/references/vss_hil_overrides.md
@@ -1,0 +1,48 @@
+# VSS Warehouse - HIL Overrides
+
+For the `hil` profile, VSS Warehouse runs on the IGX Thor safety host and ingests the Isaac Sim streams from the remote x86 stimulus host. The VSS-side configuration is the SAME as single-host SIL: apply `vss_2d_overrides.md` (2D, the default) or `vss_3d_overrides.md` (3D) unchanged, plus `halos_thor.md` §2 for the IGX-Thor workarounds. This file adds only what differs for hil.
+
+## 1. Remote stream URLs
+
+The registered sensor URLs must point at the x86 stimulus host, not localhost:
+
+```
+rtsp://<x86_host_ip>:8554/camera
+rtsp://<x86_host_ip>:8555/camera_01
+rtsp://<x86_host_ip>:8556/camera_02
+```
+
+The camera names must stay `Camera` / `Camera_01` / `Camera_02`: behavior analytics calibration and the safety-core event matching key on them.
+
+## 2. Sensor registration: exactly one owner
+
+Two things can register the Isaac cameras into VST; pick exactly one per deployment. Never enable both: two writers race on the same sensor names, the adds fail with name collisions, and perception can end up running on the wrong source.
+
+**Configurator file mode** (the flow `halos_hil.md` uses):
+
+- In the warehouse profile `.env`: `SENSOR_INFO_SOURCE=file`
+- Fill `<wh_ops>/camera_configs/camera_info.json` with the Isaac cameras:
+
+```json
+{
+    "sensors": [
+      { "camera_name": "Camera",    "rtsp_url": "rtsp://<x86_host_ip>:8554/camera" },
+      { "camera_name": "Camera_01", "rtsp_url": "rtsp://<x86_host_ip>:8555/camera_01" },
+      { "camera_name": "Camera_02", "rtsp_url": "rtsp://<x86_host_ip>:8556/camera_02" }
+    ]
+}
+```
+
+The VSS configurator reads this file and POSTs each entry to the VST `/sensor/add` API on startup (VST itself never reads the file); the sensor distribution service then provisions the sensors into perception. Launch Isaac WITHOUT `--enable-vst`.
+
+> ⚠ **File mode has no stream-readiness gate.** It registers the URLs as soon as VSS comes up, and VST then DESCRIBEs each of them eagerly. Registering against a cold or not-yet-streaming Isaac is exactly the "no caps" race - see `troubleshooting.md` (RTSP Streams "no caps"). Deploy order matters: bring the Isaac scenario up and confirm the streams deliver frames BEFORE deploying VSS with `camera_info.json` in place.
+
+**Isaac-side registration** (the single-host `sil` flow, run cross-host): launch with `--enable-vst` and point the x86 profile env at the Thor (`VST_BASE_URL` and `PERCEPTION_BASE_URL` in `profiles/hil.env`). This path has the built-in warm-up gate (it registers only once the render is warm, avoiding the cold-DESCRIBE race) but requires VSS to already be up when the scenario starts. Leave `SENSOR_INFO_SOURCE` at its default (not `file`).
+
+## 3. Fresh state on a previously-used Thor
+
+On a Thor that ran VSS before, tear the stack down and wipe the Kafka volumes before redeploying - otherwise the sensor distribution service replays the old sensor history and perception sticks at 0 fps after every restart. Symptom, cause and the exact commands: `troubleshooting.md`, "Perception 0 FPS With Sensors Online (Stale Sensor History Replay)".
+
+## 4. Verify
+
+Use the profile doc's "Verification After Deploy" (`vss_2d_overrides.md` / `vss_3d_overrides.md`) plus the FPS-based poll in `test_scenario.md`. Expect the delivered fps to track the Isaac render rate (well below the nominal stream rate) - that is the simulation, not a network fault.


### PR DESCRIPTION
## What

Makes the `hil` profile available: the `sil` closed loop split across two machines — an x86 stimulus host (`COMPOSE_PROFILES=hil`: isaac-sim + comm-layer + forklift-controller) and an IGX Thor safety host running VSS Warehouse perception and the Thor Safety Core. Only two flows cross hosts: the camera RTSP (Thor pulls from the x86) and the 64-byte safety command UDP back to the x86 comm-layer.

## Changes

- **`feat(sil)`** — `vst_sensor_manager.py` reads the perception REST endpoint from `PERCEPTION_BASE_URL` (default unchanged), so Isaac-side sensor registration also works against a remote VSS host; compose passthrough included.
- **`feat(hil)`** — `profiles/hil.env` (x86) + `profiles/hil-thor.env` (Thor, consumed by `launch_thor_safety.sh`), `hil_preflight.sh` (single-seat preflight from the x86 host), and the `hil/README.md`.
- **`docs(hoisa-deploy-profile)`** — the `halos_hil.md` runbook (deploy order: scenario streams must deliver frames before VSS registers them; scene-clear start gate for the Safety Core; ready signals; troubleshooting), new `vss_hil_overrides.md` (remote stream URLs, exactly-one sensor-registration owner, fresh state), Isaac-source VST knobs added to `vss_2d_overrides.md`, a new troubleshooting entry for stale sensor-history replay, and SKILL.md updated (hil available + cleanup warning).

## Validation

Brought up end-to-end on hardware, both perception backends (2D and 3D/Sparse4D): 3/3 cameras in DeepStream tracking the Isaac render rate, sim-driven MUTE/UNMUTE transitions at the comm-layer with no state latch, preflight passing on a fresh host. Both SDM targets exercised.