### PR TITLE
chore(forklift-controller): drop unused python3-yaml apt dep

### DIFF
--- a/closed-loop-testing/forklift-controller/Dockerfile
+++ b/closed-loop-testing/forklift-controller/Dockerfile
@@ -19,7 +19,6 @@ LABEL version="1.0.0"
 RUN apt-get update && apt-get install -y \
     python3-pip \
     python3-dev \
-    python3-yaml \
     ros-jazzy-rmw-cyclonedds-cpp \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## What

Remove the `python3-yaml` apt package from the forklift-controller Dockerfile.

## Why

The controller container never uses PyYAML:
- It reads waypoints and commands as **JSON** (`import json` → `json.load` / `json.loads` in `robot_controller.py`); no `.py` imports `yaml` and no shell script invokes a yaml tool.
- `robots.yaml` is parsed on the **Isaac side** (the graph builder), not in this container.

So the dependency is dead weight — dropping it slims the image with zero behavior change.

## Test

- `grep -rniE 'yaml' closed-loop-testing/forklift-controller/` → the only remaining hit is the Dockerfile line being removed.
- Waypoint/command loading path is JSON-only (unchanged).