### PR TITLE
docs(licenses): bump Isaac Sim 5.1.0 -> 6.0.0 in 3rdParty_Licenses

### DIFF
--- a/closed-loop-testing/3rdParty_Licenses.txt
+++ b/closed-loop-testing/3rdParty_Licenses.txt
@@ -4,7 +4,7 @@ This file contains the license texts for all dependencies used in Halos SIL (Sof
 
 Components:
 - Communication Layer (ROS 2 Jazzy)
-- Isaac Sim (Isaac Sim 5.1.0)
+- Isaac Sim (Isaac Sim 6.0.0)
 - MediaMTX (RTSP streaming server)
 - SRR Regression Reporter (srr-service, ros:jazzy-ros-base)
 
@@ -1428,7 +1428,7 @@ Isaac Sim and Omniverse are NVIDIA proprietary products governed by separate lic
 These components are proprietary NVIDIA products and do not require full license text reproduction.
 
 ===============================================================================
-Isaac Sim 5.1.0 - NVIDIA Software License Agreement
+Isaac Sim 6.0.0 - NVIDIA Software License Agreement
 ===============================================================================
 
 Licensed under NVIDIA Software License Agreement and Product-Specific Terms for NVIDIA Omniverse.


### PR DESCRIPTION
## What

Update the two `Isaac Sim 5.1.0` version strings to `6.0.0` in `closed-loop-testing/3rdParty_Licenses.txt` (the Components list + the Isaac Sim section header).

## Why

The SIL stack migrated Isaac Sim **5.1 → 6.0**, so the notices file was advertising a version we no longer ship. Isaac Sim is NVIDIA-proprietary (governed by the NVIDIA Software License Agreement), so this is a **doc-accuracy fix, not a new dependency** — no new license text is required.
