### PR TITLE
fix(regression-reporter): make pss.log slicing survive resumed runs

### DIFF
--- a/closed-loop-testing/regression-reporter/scripts/run_multi.sh
+++ b/closed-loop-testing/regression-reporter/scripts/run_multi.sh
@@ -392,6 +392,11 @@ phase_analyze() {
   if [[ -x "$snap_script" && -d "$scn_host_dir" ]]; then
     log "snapshotting pss.log (per-scn)..."
     bash "$snap_script" "$scn_host_dir" --per-scn || log "snapshot_pss WARN (non-fatal)"
+    # Refresh the run-level concat right away, not only at end-of-multi-test:
+    # if the run is aborted or resumed later, a stale run-level pss.log makes
+    # clip_logs slice every clip recorded after its last timestamp to 0 lines.
+    bash "$snap_script" "${RUNS_HOST_BASE}/multi-test-${TIMESTAMP}" \
+      || log "snapshot_pss cross-run WARN (non-fatal)"
   fi
 
   # Guard the flush-vs-read race: the recorder's writer.close() footer may not

--- a/closed-loop-testing/regression-reporter/scripts/snapshot_pss.sh
+++ b/closed-loop-testing/regression-reporter/scripts/snapshot_pss.sh
@@ -94,12 +94,20 @@ fi
 # ---- cross-run mode ----
 
 # Prefer concat of per-scn snapshots (preserves PSF data even across restarts).
-PER_SCN_FILES=( "$RUN_DIR"/*/pss.log )
-if [[ -f "${PER_SCN_FILES[0]:-}" ]]; then
-  # Concat then sort by leading ISO timestamp (line-stable sort -k1,1).
-  # Skipping dedupe is fine — sorted view is what clip_logs reads.
+# Exclude _discarded/ (aborted attempts) and drop exact-duplicate lines: when
+# the source log is NOT truncated between scenarios (stack kept up between
+# runs), each per-scn snapshot is a cumulative copy of the same source — a
+# plain concat would then repeat every line once per overlapping snapshot.
+PER_SCN_FILES=()
+for f in "$RUN_DIR"/*/pss.log; do
+  [[ "$f" == *"_discarded"* ]] && continue
+  [[ -f "$f" ]] && PER_SCN_FILES+=( "$f" )
+done
+if [[ ${#PER_SCN_FILES[@]} -gt 0 ]]; then
+  # Concat, sort by leading ISO timestamp (line-stable sort -k1,1), dedupe
+  # exact lines (first occurrence wins; output stays timestamp-sorted).
   TMP=$(mktemp)
-  cat "${PER_SCN_FILES[@]}" | sort -s -k1,1 > "$TMP"
+  cat "${PER_SCN_FILES[@]}" | sort -s -k1,1 | awk '!seen[$0]++' > "$TMP"
   write_out "$TMP" "$OUT"
   LINES=$(wc -l < "$TMP")
   SIZE=$(du -h "$TMP" | awk '{print $1}')

--- a/closed-loop-testing/regression-reporter/srr-service/srr/clip_logs.py
+++ b/closed-loop-testing/regression-reporter/srr-service/srr/clip_logs.py
@@ -510,6 +510,11 @@ def _emit_clip(parquet_path: Path, out_dir: Path, roi: Polygon, tw_x: float,
     if video_src.exists() and copy_mp4:
         shutil.copy2(video_src, out_dir / "video.mp4")
         video_dst_name = "video.mp4"
+    elif (out_dir / "video.mp4").exists():
+        # Re-export over an existing bundle (e.g. --no-mp4): the clip already
+        # has its video — keep the manifest pointing at it instead of blanking
+        # the reference and disconnecting the viewer.
+        video_dst_name = "video.mp4"
 
     verdict = _load_verdict(parquet_path)
     gt_sum = _gt_summary(gt_csv)


### PR DESCRIPTION
Found while debugging two multi-test runs whose per-clip `pss.log` panels came up empty in the debug viewer.

**Root cause:** the run-level `pss.log` concat is only written at end-of-multi-test. Both runs were aborted and resumed hours later — every clip recorded after the stale concat's last timestamp sliced to 0 lines, while the data sat intact in the per-scenario snapshots the whole time.

**Fixes:**
1. `run_multi.sh` — refresh the run-level concat after every per-scenario snapshot, so it is never stale regardless of aborts/resumes.
2. `snapshot_pss.sh` — cross-run concat now excludes `_discarded/` snapshots and dedupes exact lines. When the source log is not truncated between scenarios, per-scenario snapshots are cumulative copies; the plain concat inflated per-clip slices 3-5x with duplicate lines.
3. `clip_logs.py` — re-exporting an existing bundle with `--no-mp4` wrote `"video": ""` into the manifest even though `video.mp4` was already present, disconnecting the clip from the viewer. The reference is now kept when the file exists.

**Tested:** bash -n / py_compile clean; cross-run concat verified against a fixture with overlapping snapshots + a `_discarded/` decoy (5 input lines → 3 unique, timestamp order preserved, decoy excluded). The dedupe output was also validated against real run data: `sort -u` of the previously inflated slices is byte-identical to the clean single-source slice.