### PR TITLE
Fix pre-existing errors in hoisa-deploy-profile skill references

### DIFF
--- a/skills/hoisa-deploy-profile/SKILL.md
+++ b/skills/hoisa-deploy-profile/SKILL.md
@@ -190,8 +190,12 @@ Deploy in strict order. **Stack 1 (VSS) must be running before Stack 2 (Halos).*
 | Service | URL |
 |---------|-----|
 | VST UI (camera streams) | `http://<HOST_IP>:30888/vst/` |
-| Grafana (monitoring) | `http://<HOST_IP>:32900` |
-| Kibana (analytics) | `http://<HOST_IP>:5601` |
+| Grafana (monitoring) | `http://<HOST_IP>:35000` — extended profile only |
+| Kibana (analytics) | `http://<HOST_IP>:5601` — extended profile only |
+
+> **Grafana/Kibana only exist in the extended profile** (`MINIMAL_PROFILE=""`). VSS ships
+> `MINIMAL_PROFILE="true"` (minimal) by default, which excludes all monitoring — so on a
+> default deploy neither URL is reachable. Only VST UI is always up.
 
 ---
 

--- a/skills/hoisa-deploy-profile/references/model_r101.md
+++ b/skills/hoisa-deploy-profile/references/model_r101.md
@@ -54,27 +54,39 @@ bump `R101_DEPLOYABLE_RESOURCE` and `R101_TRAINABLE_RESOURCE` in `deployments/pr
 
 ---
 
-## 2. Place the files where the 3D `config.yaml` expects them
+## 2. Install the model at the bind-mount source
 
-The 3D perception `config.yaml`
-(`<wh_ops>/warehouse-3d-app/deepstream/configs/config.yaml`) references the model + anchor by
-path. Put both files at that path, and **rename to the canonical filenames** the config
-expects if the downloaded filenames differ (the config keys, not the NGC filenames, are what
-matter):
+The model reaches the perception container through a **bind mount**, not through `config.yaml`
+directly. `warehouse-3d-app.yml:259-260` mounts two specific host files onto the container paths
+that `config.yaml`'s `onnx_file` / `anchor` keys read:
+
+| `config.yaml` key | Container path (read by DeepStream) | Host file (bind-mount source) |
+|---|---|---|
+| `onnx_file` | `…/sparse4d/sparse4d_warehouse_v2.2.onnx` | `$VSS_DATA_DIR/models/sparse4d/ov/sparse4d_warehouse_v2.2.onnx` |
+| `anchor` | `…/sparse4d/_ov_kmeans900_v2.2.npy` | `$VSS_DATA_DIR/models/sparse4d/ov/_ov_kmeans900_v2.2.npy` |
+
+Install the downloaded ONNX and anchor at the **host** paths (right column), under the mount's
+exact filenames. The mount references those filenames literally, so a file under any other name
+is not mounted and the model is silently ignored.
 
 ```bash
-MODEL_DIR=<wh_ops>/warehouse-3d-app/deepstream/models   # path referenced by config.yaml
+MODEL_DIR="$VSS_DATA_DIR/models/sparse4d/ov"   # bind-mount source (warehouse-3d-app.yml:259-260)
 mkdir -p "$MODEL_DIR"
 
-# from the deployable package
-cp <deployable_download>/*.onnx  "$MODEL_DIR/"           # rename to the config's ONNX filename if needed
+# Back up any model already installed, then place the R101 files under the canonical names.
+ts=$(date +%Y%m%d-%H%M%S)
+for f in sparse4d_warehouse_v2.2.onnx _ov_kmeans900_v2.2.npy; do
+  [ -e "$MODEL_DIR/$f" ] && cp -a "$MODEL_DIR/$f" "$MODEL_DIR/$f.bak-$ts"
+done
 
-# from the trainable package — the kmeans anchor
-cp <trainable_download>/**/*.npy "$MODEL_DIR/"           # rename to the config's anchor filename if needed
+cp <deployable_download>/*.onnx   "$MODEL_DIR/sparse4d_warehouse_v2.2.onnx"   # deployable package (ONNX)
+cp <trainable_download>/**/*.npy  "$MODEL_DIR/_ov_kmeans900_v2.2.npy"         # trainable package (kmeans anchor)
 ```
 
-Then confirm `config.yaml` points `num_sensors`, the ONNX path, and the anchor `.npy` path
-at these files (see `vss_3d_overrides.md` for the other `config.yaml` keys).
+> **Using a different filename.** The filenames are fixed by the bind mount, so renaming means
+> updating all three references together: both mount lines in `warehouse-3d-app.yml` (host **and**
+> container side) and the matching `onnx_file` / `anchor` in `config.yaml`. Installing in place
+> under the canonical names above avoids that — nothing else needs to change.
 
 ---
 

--- a/skills/hoisa-deploy-profile/references/vss_2d_overrides.md
+++ b/skills/hoisa-deploy-profile/references/vss_2d_overrides.md
@@ -97,6 +97,17 @@ File: `<wh_ops>/warehouse-2d-app/vst/configs/vst_config.json` (several copies of
   agree on wall-clock arrival time rather than the (drifting) sim-time.
 - Recording off: SIL is a live closed loop, not a capture run — leaving recording on wastes
   disk and I/O.
+- **⚠ `always_recording` is configurator-managed — a pre-`up` edit here is silently reverted.**
+  The blueprint-configurator runs a `json_update` op that hard-writes `data.always_recording: true`
+  into this exact file on every `up` (VSS `.../blueprint-configurator/blueprint_config.yml`,
+  the `warehouse-2d-app/.../vst/configs/vst_config.json` op ~line 407 — identical in 3.2.0 and 3.2.1),
+  so a `false` set before `up` is overwritten before the VST container (`vss-vios-streamprocessing`,
+  which mounts this file) reads it. To make `false` stick, do ONE of:
+    - **(preferred)** edit `blueprint_config.yml` too: change `data.always_recording: true` → `false`
+      in that op before `up`; or
+    - after the configurator has finished, edit this file and `docker restart vss-vios-streamprocessing`.
+  The other keys above (`rtsp_streaming_over_tcp`, `use_sensor_ntp_time`, `bbox_tolerance_ms`) are
+  NOT touched by the configurator, so those pre-`up` edits survive as written.
 - `bbox_tolerance_ms: 100`: widens the metadata-to-frame matching tolerance window, reducing
   bounding-box flickering.
 
@@ -111,9 +122,14 @@ File: `<wh_ops>/warehouse-2d-app/vst/configs/vst_config.json` (several copies of
 The TensorRT engine builds on first deploy (~10-15 min). Poll until ready:
 
 ```bash
-until [ "$(docker logs vss-rtvi-cv 2>&1 | grep -c 'stream_name Camera')" -ge 3 ]; do
-  printf '[%s] vss-rtvi-cv not ready yet...\n' "$(date +%H:%M:%S)"
-  docker logs --tail 3 vss-rtvi-cv 2>&1
+# Ready = 3 cameras each reporting a current FPS > 0. Read each camera's latest PERF value;
+# a plain log line-count would false-pass on a 0-FPS zombie source.
+while :; do
+  live=$(docker logs --tail 800 vss-rtvi-cv 2>&1 | grep 'stream_name Camera' | awk '
+    { fps=$1+0; for(i=1;i<=NF;i++) if($i=="stream_name") n=$(i+1); last[n]=fps }
+    END{ c=0; for(k in last) if(last[k]>0) c++; print c }')
+  [ "${live:-0}" -ge 3 ] && break
+  printf '[%s] vss-rtvi-cv live cameras=%s/3 (current FPS > 0)...\n' "$(date +%H:%M:%S)" "${live:-0}"
   sleep 30
 done
 echo "vss-rtvi-cv READY:"

--- a/skills/hoisa-deploy-profile/references/vss_3d_overrides.md
+++ b/skills/hoisa-deploy-profile/references/vss_3d_overrides.md
@@ -84,31 +84,28 @@ Keep SEI extraction off for SIL — comment these out (the app config ships them
 
 ```ini
 [source-list]
-# extract-sei-type5-data=1    # SEI off — use system timestamps (see rationale above)
+# extract-sei-type5-data=1    # SEI off for SIL — use system timestamps (see rationale above)
 # sei-uuid=NVDS_CUSTOMMETA    # comment out
-num-sources=3                 # = camera count (NUM_STREAMS)
+low-latency-mode=0            # prioritise throughput over latency for 3D multi-view inference
 ```
 
 ### `[streammux]`
 
 ```ini
 [streammux]
-attach-sys-ts-as-ntp=1        # tag each frame with the host arrival (wall-clock) time
-# extract-sei-sim-time=1      # comment out — do NOT use Isaac SEI sim-time as the timestamp
-# drop-backward-sei=1         # comment out — moot with SEI extraction off (2D style)
-sync-inputs-ntp=0             # NTP input-sync stalls on the Isaac RTSP feed -> zero Kafka output
+attach-sys-ts-as-ntp=1        # timestamp each frame with host arrival (wall-clock) time
+# extract-sei-sim-time=1      # SEI off — do not use Isaac SEI sim-time as the timestamp
+# drop-backward-sei=1         # moot with SEI extraction off
+sync-inputs-ntp=0             # avoid NTP input-sync stalling on the Isaac RTSP feed (zero Kafka output)
 align-first-buffer=0          # do not gate the batch on first-buffer alignment (multi-cam start)
 batched-push-timeout=75000    # looser batch timeout — 3D runs at a lower FPS than 2D
-low-latency-mode=0            # prioritise throughput over latency for 3D inference
-latency=2000                  # tolerate multi-view arrival skew across the 3 cameras
-drop-pipeline-eos=1           # a single stream EOS must not tear down the batched pipeline
-batch-size=3                  # = camera count (see note below)
+drop-pipeline-eos=1           # one stream's EOS must not tear down the batched pipeline
 ```
 
-> **Batch size:** set `batch-size` (and any `max-batch-size`) to the camera count (3). If
-> the 3D configurator auto-derives batch sizes from `NUM_STREAMS` at startup, let it — do
-> not hand-edit values it manages; only the SEI / timestamp / timeout keys above are set
-> here.
+> **Section placement matters** — DeepStream reads each key only from its own section:
+> `low-latency-mode` belongs to `[source-list]`, the timing keys to `[streammux]`. Leave
+> `num-sources`, `latency`, and `batch-size` to the shipped config — the configurator derives
+> them from `NUM_STREAMS` / `max-batch-size` at startup.
 
 **Why these differ from a latency-first default:** 3D (Sparse4D) multi-view inference is
 heavier than 2D per-camera detection, so it runs at a **lower frame rate**. The looser
@@ -173,6 +170,17 @@ File: `<wh_ops>/warehouse-3d-app/vst/configs/vst_config.json`
   agree on wall-clock arrival time rather than the (drifting) sim-time.
 - Recording off: SIL is a live closed loop, not a capture run — leaving recording on wastes
   disk and I/O.
+- **⚠ `always_recording` is configurator-managed — a pre-`up` edit here is silently reverted.**
+  The blueprint-configurator runs a `json_update` op that hard-writes `data.always_recording: true`
+  into this exact file on every `up` (VSS `.../blueprint-configurator/blueprint_config.yml`,
+  the `warehouse-3d-app/.../vst/configs/vst_config.json` op ~line 494 — identical in 3.2.0 and 3.2.1),
+  so a `false` set before `up` is overwritten before the VST container (`vss-vios-streamprocessing`,
+  which mounts this file) reads it. To make `false` stick, do ONE of:
+    - **(preferred)** edit `blueprint_config.yml` too: change `data.always_recording: true` → `false`
+      in that op before `up`; or
+    - after the configurator has finished, edit this file and `docker restart vss-vios-streamprocessing`.
+  The configurator does NOT touch `event_recording`, `rtsp_streaming_over_tcp`, `use_sensor_ntp_time`,
+  or `bbox_tolerance_ms`, so those pre-`up` edits survive as written.
 - `bbox_tolerance_ms: 100`: widens the metadata-to-frame matching window, reducing
   bounding-box flicker at the lower 3D frame rate.
 
@@ -188,9 +196,14 @@ The Sparse4D TensorRT engine builds on first deploy (~10-15 min). Poll the perce
 container until all 3 sources report FPS:
 
 ```bash
-until [ "$(docker logs vss-rtvi-cv 2>&1 | grep -c 'stream_name Camera')" -ge 3 ]; do
-  printf '[%s] 3D perception not ready yet...\n' "$(date +%H:%M:%S)"
-  docker logs --tail 3 vss-rtvi-cv 2>&1
+# Ready = 3 cameras each reporting a current FPS > 0. Read each camera's latest PERF value;
+# a plain log line-count would false-pass on a 0-FPS zombie source.
+while :; do
+  live=$(docker logs --tail 800 vss-rtvi-cv 2>&1 | grep 'stream_name Camera' | awk '
+    { fps=$1+0; for(i=1;i<=NF;i++) if($i=="stream_name") n=$(i+1); last[n]=fps }
+    END{ c=0; for(k in last) if(last[k]>0) c++; print c }')
+  [ "${live:-0}" -ge 3 ] && break
+  printf '[%s] 3D perception live cameras=%s/3 (current FPS > 0)...\n' "$(date +%H:%M:%S)" "${live:-0}"
   sleep 30
 done
 echo "3D perception READY:"


### PR DESCRIPTION
## Summary

Fixes five pre-existing documentation bugs in the `hoisa-deploy-profile` skill references, surfaced by a recent audit. None are tied to a VSS version — they are wrong in both 3.2.0 and 3.2.1 — so they are split out from the VSS 3.2.1 version bump.

## Fixes

- **`references/model_r101.md`** — the 3D model install path pointed at `warehouse-3d-app/deepstream/models`, which is never bind-mounted, so a model placed there was silently ignored. Corrected to the real bind-mount source `$VSS_DATA_DIR/models/sparse4d/ov/` with the canonical filenames (`sparse4d_warehouse_v2.2.onnx`, `_ov_kmeans900_v2.2.npy`). Added a filename/rename note and a backup-then-install step.
- **`references/vss_3d_overrides.md`** — DeepStream config keys were in the wrong INI sections (DeepStream reads each key only from its own section): `low-latency-mode` moved to `[source-list]`. Dropped `num-sources` / `latency` / `batch-size`, which the configurator derives from `NUM_STREAMS` / `max-batch-size`.
- **`references/vss_2d_overrides.md` + `vss_3d_overrides.md`** — documented that `always_recording` is rewritten to `true` by the blueprint-configurator on every `up`, so a pre-`up` `false` edit is silently reverted; added the two ways to make it stick.
- **`references/vss_2d_overrides.md` + `vss_3d_overrides.md`** — the perception ready-signal now gates on current per-camera FPS > 0 instead of a cumulative log line-count, which false-passes on a 0-FPS zombie source (aligning with `SKILL.md` and `test_scenario.md`).
- **`SKILL.md`** — Grafana URL port `32900` → `35000`, plus a note that Grafana/Kibana only run in the extended profile (`MINIMAL_PROFILE=""`).

## Verification

Each value was checked against the shipped VSS compose/config on-host: `warehouse-3d-app.yml` model mounts, `ds-main-config.txt` section layout, and `services/monitoring/compose.yml` Grafana port.