### PR TITLE
Clean up inert profile-env stubs and drop dead PLAYBACK_SEGMENTS_FILE

### DIFF
--- a/closed-loop-testing/comm-layer/comm-layer.yml
+++ b/closed-loop-testing/comm-layer/comm-layer.yml
@@ -9,13 +9,13 @@ services:
     network_mode: host
     environment:
       - UDP_PORT=${COMM_UDP_PORT}
-      - OPCUA_ENDPOINT=${COMM_OPCUA_ENDPOINT}
-      - ROS_TOPIC_PREFIX=${COMM_ROS_TOPIC_PREFIX}
-      - ROS_DOMAIN_ID=${ROS_DOMAIN_ID}
+      - OPCUA_ENDPOINT=${COMM_OPCUA_ENDPOINT:-opc.tcp://0.0.0.0:4840/safety/}
+      - ROS_TOPIC_PREFIX=${COMM_ROS_TOPIC_PREFIX:-/safety}
+      - ROS_DOMAIN_ID=${ROS_DOMAIN_ID:-0}
       - ROS_AUTOMATIC_DISCOVERY_RANGE=${ROS_AUTOMATIC_DISCOVERY_RANGE:-SUBNET}  # SUBNET=LAN multicast (multi-host/HIL) | LOCALHOST=single-host SIL (set in sil.env) | OFF
       - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
     volumes:
-      - ${COMM_LOG_DIR}:/app/logs:rw
+      - ${COMM_LOG_DIR:-${MDX_DATA_DIR}/comm-layer}:/app/logs:rw
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "python3", "-c", "from asyncua.sync import Client; c=Client('opc.tcp://localhost:4840/safety/'); c.connect(); c.disconnect()"]

--- a/closed-loop-testing/isaac-sim/isaac-sim.yml
+++ b/closed-loop-testing/isaac-sim/isaac-sim.yml
@@ -27,7 +27,6 @@ services:
       - ROS_DISTRO=jazzy
       - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
       - LD_LIBRARY_PATH=/isaac-sim/exts/isaacsim.ros2.core/jazzy/lib
-      - PLAYBACK_SEGMENTS_FILE=${PLAYBACK_SEGMENTS_FILE:-}
     volumes:
       - ${HOME}/.Xauthority:/isaac-sim/.Xauthority:ro
       - /tmp/.X11-unix:/tmp/.X11-unix:rw

--- a/deployments/profiles/base.env
+++ b/deployments/profiles/base.env
@@ -29,10 +29,3 @@ DOCKER_GID=999 # change me — run: getent group docker | cut -d: -f3
 # trainable kmeans anchor .npy — see references/model_r101.md. Public NGC TAO catalog; same version.
 R101_DEPLOYABLE_RESOURCE=nvidia/tao/sparse4d_rn101:deployable_v2.2  # inference ONNX
 R101_TRAINABLE_RESOURCE=nvidia/tao/sparse4d_rn101:trainable_v2.2    # checkpoint + kmeans anchor .npy
-
-# Inert in base (comm-layer/isaac-sim NOT in base profile) but required so `docker compose`
-# can interpolate ALL included service yml before profile-filtering. Single-compose constraint.
-COMM_LOG_DIR=${MDX_DATA_DIR}/comm-layer
-COMM_OPCUA_ENDPOINT=opc.tcp://0.0.0.0:4840/safety/
-COMM_ROS_TOPIC_PREFIX=/safety
-ROS_DOMAIN_ID=0

--- a/deployments/profiles/hil.env
+++ b/deployments/profiles/hil.env
@@ -38,11 +38,3 @@ ISAAC_CACHE_DIR=${MDX_DATA_DIR}/isaac-cache
 ISAAC_SIL_DIR=${MDX_SAMPLE_APPS_DIR}/closed-loop-testing/isaac-sim/sil
 
 DOCKER_GID=999 # change me — run: getent group docker | cut -d: -f3
-
-# Unused on this x86 side: safety-core is not in the hil profile — the Safety Core runs on
-# the Thor and takes its real PSF_IMAGE / PSF_CMD_RX_* from profiles/hil-thor.env. These are
-# kept here only so `docker compose` can interpolate ALL included service yml before
-# profile-filtering (single-compose constraint, same convention as base.env).
-PSF_IMAGE=nvcr.io/nvidia/halos-outside-in/outside-in-safety:nv-psf-halos-1.2.1-3041f93
-PSF_CMD_RX_IP=127.0.0.1
-PSF_LOG_DIR=${MDX_DATA_DIR}/psf-log

--- a/deployments/profiles/sil.env
+++ b/deployments/profiles/sil.env
@@ -30,7 +30,6 @@ ISAAC_SIM_IMAGE=nvcr.io/nvidia/isaac-sim:6.0.0
 ISAAC_GPU_DEVICE=0
 ISAAC_CACHE_DIR=${MDX_DATA_DIR}/isaac-cache
 ISAAC_SIL_DIR=${MDX_SAMPLE_APPS_DIR}/closed-loop-testing/isaac-sim/sil
-PLAYBACK_SEGMENTS_FILE=/isaac-sim/sil/playback/segments.json
 
 # === Perception model — 3D (Sparse4D) profile ONLY ===
 # R101 Sparse4D: a VSS-side perception artifact (not consumed by this compose; pulled as a

--- a/skills/hoisa-deploy-profile/references/vss_3d_overrides.md
+++ b/skills/hoisa-deploy-profile/references/vss_3d_overrides.md
@@ -109,7 +109,7 @@ drop-pipeline-eos=1           # one stream's EOS must not tear down the batched 
 
 **Why these differ from a latency-first default:** 3D (Sparse4D) multi-view inference is
 heavier than 2D per-camera detection, so it runs at a **lower frame rate**. The looser
-`batched-push-timeout`, `latency`, and `low-latency-mode=0` let the muxer wait long enough
+`batched-push-timeout` and `low-latency-mode=0` let the muxer wait long enough
 to assemble a complete 3-camera batch instead of pushing partial batches (which produce
 gaps / zero Kafka output); `sync-inputs-ntp=0` keeps the muxer from stalling on the Isaac
 RTSP feed's timing.
@@ -249,5 +249,5 @@ echo "mdx-events READY"
 | `batched-push-timeout` | (default) | **`75000`** |
 | `low-latency-mode` | (default `1`) | **`0`** |
 | `config.yaml` | n/a | `num_sensors=3`, `num_torch_threads=8`, `gpu_postprocess: False` |
-| VST | `bbox_tolerance_ms=100` | + `rtsp_streaming_over_tcp`, `use_sensor_ntp_time=false`, recording off |
+| VST | `bbox_tolerance_ms=100`, `rtsp_streaming_over_tcp`, `use_sensor_ntp_time=false`, recording off | **same** |
 | Isaac launch | `--enable-vst` | **same** — `--enable-vst` (`test_scenario.md`) |


### PR DESCRIPTION
## Summary

Cleanup of the inert profile-env stub blocks and one dead variable in the HOISA closed-loop deploy, plus two 3D-override doc fixes. All independent of any VSS version. `docker compose config` verified to pass for base / sil / hil.

## Changes

- **`comm-layer.yml`** — inline defaults for `COMM_LOG_DIR` / `COMM_OPCUA_ENDPOINT` / `COMM_ROS_TOPIC_PREFIX` / `ROS_DOMAIN_ID`. `COMM_LOG_DIR` is a volume source, so leaving it unset produced `invalid spec: :/app/logs:rw: empty section between colons` at compose-parse time (compose interpolates and validates the whole merged file **before** profile filtering). The default keeps the source valid; the others silence the unset-variable warnings.
- **`base.env` / `hil.env`** — remove the "inert" stub blocks that existed only to silence those interpolation warnings. `base` no longer needs the comm-layer stubs (the yml default covers the one real error); `hil`'s safety-core PSF stubs were warning-only (safety-core runs on the Thor peer, filtered out of the x86 `hil` profile).
- **`sil.env` + `isaac-sim.yml`** — drop `PLAYBACK_SEGMENTS_FILE`. Dead since the forklift moved to FL control (`robots.yaml` / Twist action graphs): nothing reads the variable or `segments.json`, and `Old_Playback_Graph` is stripped from the scene by `forklift_common.py`.
- **`vss_3d_overrides.md`** — drop `latency` from the "why these differ" note (it is ship/configurator-managed, not hand-set) and fix the 2D-vs-3D quick-diff VST row (the 2D overrides also set `rtsp_streaming_over_tcp` / `use_sensor_ntp_time` / recording-off).

## Verification

`docker compose config` passes for base / sil / hil with these changes (no `invalid spec` errors, only pre-existing unset-var warnings for the isaac-sim stubs base never set). `PLAYBACK_SEGMENTS_FILE` confirmed to have zero consumers across the tree.