### PR TITLE
Add restart_isaac.sh: safely restart the Isaac scenario on a live stack

### DIFF
--- a/closed-loop-testing/scripts/restart_isaac.sh
+++ b/closed-loop-testing/scripts/restart_isaac.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Restart the Isaac Sim scenario on a LIVE SIL stack without wedging its RTSP mounts.
+#
+# Why this exists: Isaac Sim 6.0's in-process RTSP media fails SDP creation when
+# >=2 clients DESCRIBE a stream during its cold bind window (right after Play,
+# before the first frame). A live VST holds two such clients per mount (the
+# proxy ingest client + the liveness prober) and reconnects within milliseconds
+# of the port opening, so restarting Isaac under a running VST wedges mounts
+# ("has no caps", no self-recovery). Pausing the VST streamprocessing container
+# for the boot window avoids the race deterministically. The sensor registry
+# (vss-vios-sensor + its database) stays up throughout, so the driver's normal
+# registration at render-warm proceeds: it deletes and re-adds the cameras
+# (fresh sensor uuids each restart) and SDR re-provisions DeepStream.
+#
+# Usage (from the host):
+#   ./restart_isaac.sh                     # relaunch with the running driver's own args
+#   ./restart_isaac.sh -c /isaac-sim/... --start --headless --enable-vst ...   # explicit args
+#
+# Env overrides: ISAAC_CONTAINER (isaac-sim), VST_CONTAINER (vss-vios-streamprocessing),
+#                WARM_TIMEOUT_SEC (1200), DS_CONTAINER (vss-rtvi-cv, optional check)
+set -u
+
+ISAAC_CONTAINER="${ISAAC_CONTAINER:-isaac-sim}"
+VST_CONTAINER="${VST_CONTAINER:-vss-vios-streamprocessing}"
+DS_CONTAINER="${DS_CONTAINER:-vss-rtvi-cv}"
+WARM_TIMEOUT_SEC="${WARM_TIMEOUT_SEC:-1200}"
+
+DOCKER="docker"
+$DOCKER ps >/dev/null 2>&1 || DOCKER="sudo docker"
+
+log() { printf '[%s] %s\n' "$(date +%H:%M:%S)" "$*"; }
+
+# ---- 1. Resolve the driver command ------------------------------------------
+if [ "$#" -gt 0 ]; then
+    DRIVER_ARGS="$*"
+else
+    # Read args from the python process itself (not the bash -lc wrapper, whose
+    # argv carries the whole quoted command including shell redirections).
+    DRIVER_ARGS=$($DOCKER exec "$ISAAC_CONTAINER" bash -c \
+        "ps -eo args | grep 'run_actor_sdg.py' | grep -v grep | grep -v 'bash' | head -1" \
+        | sed -E 's|^.*run_actor_sdg\.py ||; s| *[0-9]?>.*$||')
+    if [ -z "$DRIVER_ARGS" ]; then
+        echo "ERROR: no running run_actor_sdg.py to copy args from — pass the driver args explicitly." >&2
+        exit 1
+    fi
+fi
+log "driver args: $DRIVER_ARGS"
+
+# ---- 2. Mounts to warm-check, from cameras.yaml if present -------------------
+CAMS_YAML="$(dirname "$0")/../isaac-sim/sil/configs/cameras.yaml"
+MOUNTS=""
+if [ -f "$CAMS_YAML" ]; then
+    MOUNTS=$(awk '/^\s*port:/ {p=$2} /^\s*mount_path:/ {print p $2}' "$CAMS_YAML")
+fi
+[ -n "$MOUNTS" ] || MOUNTS=$'8554/camera\n8555/camera_01\n8556/camera_02'
+N_MOUNTS=$(echo "$MOUNTS" | wc -l | tr -d ' ')
+log "will wait for $N_MOUNTS mount(s) to deliver"
+
+# ---- 3. Pause VST (kills the DESCRIBE churn; registry persists in the DB) ----
+log "stopping $VST_CONTAINER for the Isaac boot window..."
+$DOCKER stop "$VST_CONTAINER" >/dev/null
+
+# ---- 4. Restart the driver ---------------------------------------------------
+$DOCKER exec "$ISAAC_CONTAINER" bash -c "pgrep -f run_actor_sdg.py | xargs -r kill -9" || true
+sleep 5
+TS=$(date +%Y%m%d-%H%M%S)
+$DOCKER exec -d "$ISAAC_CONTAINER" bash -lc \
+    "cd /isaac-sim && ./python.sh /isaac-sim/sil/scripts/run_actor_sdg.py $DRIVER_ARGS > /tmp/run-restart-$TS.log 2>&1"
+log "driver relaunched (log: /tmp/run-restart-$TS.log in the container)"
+
+# ---- 5. Wait until every mount delivers frames (encoder warm) ----------------
+log "waiting for mounts to warm (timeout ${WARM_TIMEOUT_SEC}s; first boot compiles shaders)..."
+DEADLINE=$(( $(date +%s) + WARM_TIMEOUT_SEC ))
+while :; do
+    GOOD=0
+    while IFS= read -r m; do
+        $DOCKER exec "$ISAAC_CONTAINER" timeout 6 ffprobe -v error -rtsp_transport tcp \
+            -show_entries stream=codec_name -of csv "rtsp://localhost:$m" >/dev/null 2>&1 \
+            && GOOD=$((GOOD + 1))
+    done <<< "$MOUNTS"
+    [ "$GOOD" -eq "$N_MOUNTS" ] && break
+    if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+        log "ERROR: only $GOOD/$N_MOUNTS mounts delivering after ${WARM_TIMEOUT_SEC}s."
+        log "Restarting $VST_CONTAINER anyway so the stack is not left half-paused."
+        $DOCKER start "$VST_CONTAINER" >/dev/null
+        exit 1
+    fi
+    sleep 10
+done
+log "all $N_MOUNTS mounts delivering — encoder warm"
+
+# ---- 6. Resume VST: its clients now DESCRIBE warm mounts ----------------------
+$DOCKER start "$VST_CONTAINER" >/dev/null
+log "$VST_CONTAINER restarted"
+
+# ---- 7. DeepStream: recover it if the source drain crashed it, then wait -----
+# Draining a live DeepStream's sources to zero (e.g. the driver's own
+# delete-all at re-registration, or organic sensor churn) can
+# trigger a known intermittent DeepStream abort (std::logic_error /
+# "basic_string: construction from null", exit 134). A (re)started DeepStream
+# comes back as an EMPTY REST pipeline and nothing replays its sources, so a
+# bare `docker start` is not enough — the sensors must be re-registered to emit
+# fresh camera_add events, which SDR then pushes into DeepStream (measured:
+# 3/3 in ~10 s).
+
+ds_active() {
+    # Only trust "Active sources" lines from the CURRENT container run:
+    # `docker logs --tail` happily serves pre-restart values.
+    local started
+    started=$($DOCKER inspect -f '{{.State.StartedAt}}' "$DS_CONTAINER" 2>/dev/null) || { echo 0; return; }
+    $DOCKER logs --since "$started" "$DS_CONTAINER" 2>&1 \
+        | grep -a "Active sources" | tail -1 | grep -oE '[0-9]+' | tail -1
+}
+
+reprovision_sensors() {
+    # Deterministic recovery: a (re)started DeepStream always comes back as an
+    # EMPTY REST pipeline (all slots freed), so restart it first, then run ONE
+    # clean registration round — fresh camera_add events that SDR pushes into
+    # the empty pipeline. Never re-register into a possibly-polluted pipeline:
+    # the per-source :9000 purges are best-effort only (provisioned urls drift
+    # across streamprocessing restarts), and leftovers steal batch slots.
+    log "restarting $DS_CONTAINER (guarantees an empty pipeline)..."
+    $DOCKER restart "$DS_CONTAINER" >/dev/null
+    sleep 15
+    log "one clean sensor registration round..."
+    $DOCKER exec "$ISAAC_CONTAINER" bash -lc \
+        "cd /isaac-sim && ./python.sh /isaac-sim/sil/scripts/vst_sensor_manager.py --delete-all && sleep 3 && \
+         ./python.sh /isaac-sim/sil/scripts/vst_sensor_manager.py --add-from-config /isaac-sim/sil/configs/cameras.yaml" \
+        2>&1 | tail -2 | while IFS= read -r l; do log "  $l"; done
+}
+
+if ! $DOCKER ps --format '{{.Names}}' | grep -qx "$DS_CONTAINER"; then
+    if $DOCKER ps -a --format '{{.Names}}' | grep -qx "$DS_CONTAINER"; then
+        log "WARNING: $DS_CONTAINER is not running (known DeepStream abort when its sources drain) — recovering"
+        reprovision_sensors
+    else
+        log "done ($DS_CONTAINER not deployed — skipped the DeepStream check)"
+        exit 0
+    fi
+fi
+log "waiting for DeepStream to reconnect (up to 5 min)..."
+REPROVISIONED_LATE=0
+for _ in $(seq 1 30); do
+    ACTIVE=$(ds_active)
+    [ "${ACTIVE:-0}" -eq "$N_MOUNTS" ] && { log "DeepStream back at $ACTIVE/$N_MOUNTS active sources"; exit 0; }
+    # It can also die mid-wait — catch that too instead of timing out silently.
+    if ! $DOCKER ps --format '{{.Names}}' | grep -qx "$DS_CONTAINER"; then
+        log "WARNING: $DS_CONTAINER died while reconnecting — recovering"
+        reprovision_sensors
+    fi
+    sleep 10
+done
+# Still short: it may have restarted (empty pipeline) without us seeing the
+# death, e.g. Docker's on-failure policy revived it. Re-provision once.
+if [ "$REPROVISIONED_LATE" -eq 0 ]; then
+    log "WARNING: DeepStream not at $N_MOUNTS/$N_MOUNTS after 5 min — re-provisioning once"
+    REPROVISIONED_LATE=1
+    reprovision_sensors
+    for _ in $(seq 1 18); do
+        ACTIVE=$(ds_active)
+        [ "${ACTIVE:-0}" -eq "$N_MOUNTS" ] && { log "DeepStream back at $ACTIVE/$N_MOUNTS active sources"; exit 0; }
+        sleep 10
+    done
+fi
+log "WARNING: DeepStream not at $N_MOUNTS/$N_MOUNTS yet — check '$DS_CONTAINER' logs."

--- a/skills/hoisa-deploy-profile/references/halos_deploy.md
+++ b/skills/hoisa-deploy-profile/references/halos_deploy.md
@@ -120,3 +120,51 @@ docker exec isaac-sim sh -c 'tail -5 /isaac-sim/kit/logs/Kit/*/*/kit_*.log'
 ```
 Don't gate on a shader-log string — readiness = the Isaac→VSS stream handoff completing,
 polled via DeepStream net active streams (`vss-rtvi-cv`). See `test_scenario.md`.
+
+---
+
+## Reset to a fresh deployment (keep the caches)
+
+A first bring-up is the cleanest state the stack ever has: an empty VST sensor
+registry and an empty event backlog. Heavy restart/re-registration churn slowly
+pollutes the **state layers** — `removed`-tombstone entries accumulate in the VST
+registry, and the sensor lifecycle events pile up in the Redis stream that
+`sdr-controller` replays in full whenever it restarts. When a box misbehaves in
+ways the targeted recoveries in `troubleshooting.md` don't resolve, reset those
+state layers and redeploy instead of debugging further — it reproduces the
+proven-clean first bring-up **without** paying the expensive first-run costs.
+
+What to clear vs. what to keep:
+
+| | Contains | Action |
+|---|---|---|
+| VST postgres volume | sensor registry (uuids, tombstones, ghosts) | **remove** |
+| Redis volume | sensor lifecycle event backlog + SDR workload cache | **remove** |
+| TensorRT engine / model store | built perception engine | **KEEP** (rebuild costs 10-20 min) |
+| `isaac-cache/` host dirs | compiled RT shaders | **KEEP** (recompile costs ~10 min) |
+| Images, `sil-data/` | pulled images, scene assets | KEEP (unaffected) |
+
+Procedure (≈10-15 minutes end-to-end):
+
+```bash
+# 1. Stop the scenario, then the Halos stack
+docker exec isaac-sim bash -c 'pgrep -f run_actor_sdg.py | xargs -r kill -9'
+cd <repo>/deployments && docker compose --env-file profiles/<profile>.env down
+bash ../closed-loop-testing/scripts/cleanup_all_datalog.sh <profile>
+
+# 2. Tear down VSS *with* its state volumes — but selectively.
+#    Follow the vss-deploy-profile skill's teardown reference for the compose
+#    project specifics; the state volumes to remove are the VST postgres data
+#    volume and the redis data volume (docker volume ls | grep -iE 'pg|postgres|redis').
+#    Do NOT blanket `down -v`: that also removes the TensorRT engine volume.
+
+# 3. Redeploy in the standard order: VSS Warehouse first (engine and caches are
+#    reused, so this pass is fast), then the Halos stack, then launch the scenario.
+#    VST starts empty -> the driver registers the cameras at render-warm exactly
+#    as on a first bring-up.
+```
+
+Scope guidance: this is the third tier of recovery. Routine restarts use
+`restart_isaac.sh` (~2 min, `test_scenario.md`); polluted provisioning uses the
+Redis-flush runbook (~3 min, `troubleshooting.md` → "Provisioning Chain
+Polluted"); reset + redeploy is for when the state itself is suspect.

--- a/skills/hoisa-deploy-profile/references/halos_deploy.md
+++ b/skills/hoisa-deploy-profile/references/halos_deploy.md
@@ -139,7 +139,7 @@ What to clear vs. what to keep:
 | | Contains | Action |
 |---|---|---|
 | VST postgres volume | sensor registry (uuids, tombstones, ghosts) | **remove** |
-| Redis volume | sensor lifecycle event backlog + SDR workload cache | **remove** |
+| Redis state | sensor lifecycle event backlog + SDR workload cache | **clear** (`FLUSHALL`, step 3) |
 | TensorRT engine / model store | built perception engine | **KEEP** (rebuild costs 10-20 min) |
 | `isaac-cache/` host dirs | compiled RT shaders | **KEEP** (recompile costs ~10 min) |
 | Images, `sil-data/` | pulled images, scene assets | KEEP (unaffected) |
@@ -154,14 +154,23 @@ bash ../closed-loop-testing/scripts/cleanup_all_datalog.sh <profile>
 
 # 2. Tear down VSS *with* its state volumes — but selectively.
 #    Follow the vss-deploy-profile skill's teardown reference for the compose
-#    project specifics; the state volumes to remove are the VST postgres data
-#    volume and the redis data volume (docker volume ls | grep -iE 'pg|postgres|redis').
+#    project specifics; the state volume to remove is the VST postgres data
+#    volume (docker volume ls | grep -iE 'pg|postgres').
 #    Do NOT blanket `down -v`: that also removes the TensorRT engine volume.
 
 # 3. Redeploy in the standard order: VSS Warehouse first (engine and caches are
-#    reused, so this pass is fast), then the Halos stack, then launch the scenario.
-#    VST starts empty -> the driver registers the cameras at render-warm exactly
-#    as on a first bring-up.
+#    reused, so this pass is fast), then clear redis (below), then the Halos
+#    stack, then launch the scenario. VST starts empty -> the driver registers
+#    the cameras at render-warm exactly as on a first bring-up.
+```
+
+Clear redis after the VSS redeploy, before relaunching the scenario (works whether
+redis persists to a named volume or a host bind mount):
+
+```bash
+docker exec redis redis-cli FLUSHALL
+docker restart sdr-controller
+docker restart vss-rtvi-cv
 ```
 
 Scope guidance: this is the third tier of recovery. Routine restarts use

--- a/skills/hoisa-deploy-profile/references/halos_hil.md
+++ b/skills/hoisa-deploy-profile/references/halos_hil.md
@@ -42,7 +42,7 @@ docker exec -d isaac-sim bash -lc 'cd /isaac-sim/sil/scripts && ./run_sdg.sh \
 
 Do NOT pass `--enable-vst`: the Thor-side configurator owns sensor registration (one owner only, see `vss_hil_overrides.md` §2). Forklift and clock graphs read `configs/robots.yaml` automatically; the forklift-controller then drives the forklift in a continuous loop.
 
-Scenario behavior is shared with `sil`: the first run goes quiet for ~5-10 min (scene load + shader compile, cached afterwards), and `--start` auto-stops after `simulation_length` frames - details in `test_scenario.md`. Take only the behavior notes from that file; its launch command carries `--enable-vst`, which must not be used in this flow.
+Scenario behavior is shared with `sil`: the first run goes quiet for ~5-10 min (scene load + shader compile, cached afterwards), and `--start` runs until externally stopped - details in `test_scenario.md`. Take only the behavior notes from that file; its launch command carries `--enable-vst`, which must not be used in this flow.
 
 Ready when the forklift-controller log advances (`pose=` lines with changing coordinates) and all three streams DELIVER FRAMES - a listening port is not enough, since a cold Isaac accepts RTSP clients before the encoder produces its first frame:
 
@@ -103,12 +103,29 @@ The Isaac scene's safety indicator follows `is_muted`, and the VST WebUI on the 
 | Safety Core | `nv-psf` up on the Thor; SDM process present (`atl_sdm` or `fsicom-agent`) |
 | Closed loop | comm-layer receives heartbeats + decisions; `/safety/is_muted` updates; sim-driven MUTE/UNMUTE transitions observed |
 
+## Restart the scenario (hil)
+
+Do NOT use `restart_isaac.sh` here (single-host: it pauses a local VST container; on
+hil the VST runs on the Thor), and never kill/relaunch `run_actor_sdg.py` on the x86
+while the Thor VST is running — its clients DESCRIBE the cold streams and wedge them
+(`troubleshooting.md`, RTSP Streams "no caps"). Restart across the two hosts:
+
+1. On the **Thor**: `docker stop vss-vios-streamprocessing`.
+2. On the **x86**: kill and relaunch the driver with the §2 command (still no `--enable-vst`).
+3. Confirm all three streams deliver frames (§2 ffprobe gate — not just a listening port).
+4. On the **Thor**: `docker start vss-vios-streamprocessing`, then wait for 3 sensors
+   `online` and perception `Active sources : 3`.
+
+If perception does not return, re-add the sensors on the Thor side (the Thor-side
+configurator owns registration, `vss_hil_overrides.md` §2), or take VSS down on the
+Thor and redo §3's Isaac-warm-before-VSS bring-up order.
+
 ## Troubleshooting (hil-specific)
 
 | Symptom | Fix |
 |---|---|
 | `no caps` / `could not create SDP` on the Isaac streams | Sensors were registered against a cold Isaac (deploy order, §3) - probe and recovery in `troubleshooting.md`, RTSP Streams "no caps" |
-| VST sensors `online` but perception 0 fps, no errors | RTSP-over-UDP delivering no media (`vss_2d_overrides.md` VST Config); after an Isaac restart, re-add the streams - if it recurs after every restart it is stale sensor history on a previously-used Thor (`troubleshooting.md`, Stale Sensor History Replay) |
+| VST sensors `online` but perception 0 fps, no errors | RTSP-over-UDP delivering no media (`vss_2d_overrides.md` VST Config); after an Isaac restart, follow "Restart the scenario (hil)" above - if it recurs after every restart it is stale sensor history on a previously-used Thor (`troubleshooting.md`, Stale Sensor History Replay) |
 | Forklift never moves | ROS discovery: all three x86 containers must see each other (`ros2 topic info -v /odom` from the forklift-controller must show a publisher; on multi-interface hosts LOCALHOST discovery scoping can isolate the containers - use SUBNET). Also confirm `configs/robots.yaml` exists |
 | Decisions flow but MUTE never fires | The forklift tripwire events need the forklift actually crossing the trailer tripwire; confirm the forklift moves on camera, then check the Safety Core was started on a clear scene (§4) - restart it at a clear moment otherwise |
 | comm-layer receives nothing | UDP path x86:`COMM_UDP_PORT` unreachable from the Thor, or `PSF_CMD_RX_IP/PORT` wrong in `hil-thor.env` |

--- a/skills/hoisa-deploy-profile/references/test_scenario.md
+++ b/skills/hoisa-deploy-profile/references/test_scenario.md
@@ -63,11 +63,44 @@ echo "DeepStream producing FPS on 3 Isaac cameras — handoff complete"
 > it via `troubleshooting.md` → "DeepStream Stuck at ≤2/3 Active Sources (Zombie Source
 > Bins)". A bare `added - removed` count would have hidden this (it stays 3).
 
-> **`--start` auto-stops** after `simulation_length` frames (set in the IRA config
-> `default_config_ros.yaml`), and on exit it removes the VST sensors it added. For a
-> long, watchable run, raise `simulation_length`. Stopping the run with SIGINT can
-> leave the Isaac VST sensors registered (orphaned) — re-running with `--enable-vst`
-> cleans them (it deletes, then re-adds).
+> **`--start` runs until externally stopped.** (The 5.1 `simulation_length` frame-count
+> auto-stop no longer applies on Isaac Sim 6.0 — the renamed `simulation_duration` only
+> extends the timeline end time.) Stopping the run with SIGINT/kill leaves the Isaac VST
+> sensors registered — the next `--enable-vst` run cleans them (it deletes, then re-adds).
+> To restart the scenario on a live stack, use the wrapper in the next section.
+
+### Restart the scenario on a live stack
+
+Killing and relaunching `run_actor_sdg.py` while VST is running wedges the fresh Isaac
+RTSP mounts: VST's proxy client and liveness prober reconnect within milliseconds of the
+port opening and DESCRIBE the stream before the encoder has produced a frame — the
+cold-window race from `troubleshooting.md` ("no caps"), which does not self-recover.
+Use the wrapper, which pauses VST streamprocessing for exactly the boot window:
+
+```bash
+bash closed-loop-testing/scripts/restart_isaac.sh    # reuses the running driver's own args
+```
+
+What to expect (measured on 2D and 3D single-GPU boxes and a 2-GPU 3D box, 6/6 runs):
+
+- Mounts warm in ~1-2 min (cached shaders), VST resumes, DeepStream back at 3/3 about
+  30 s later — total ≈ 2 min, with **zero** `has no caps` lines in the new run log.
+- The driver re-registers the cameras at render-warm as usual → **fresh sensor uuids on
+  every restart**; SDR re-pushes them to DeepStream automatically.
+- Cosmetic leftovers, safe to ignore: one empty-name `offline` "ghost" entry per restart
+  in `sensor/list` (the next restart's delete-all clears the previous one; the VST UI may
+  render it as a stale tile under the old camera name), a slowly growing list of
+  `removed` tombstones, and the DeepStream `source_id`↔camera mapping may shuffle.
+- DeepStream has a known intermittent abort (`std::logic_error` / "basic_string:
+  construction from null", exit 134) when its sources drain while it runs; Docker's
+  `on-failure` policy usually revives it, and the script additionally detects a dead
+  `vss-rtvi-cv`, restarts it and re-registers the sensors (a restarted DeepStream
+  comes back as an empty pipeline that nothing re-populates on its own).
+- If DeepStream sticks below 3/3 past the script's 5-minute wait (seen once, on a stack
+  whose DeepStream provisioning was days old): recover via `troubleshooting.md` →
+  "DeepStream Stuck at ≤2/3 Active Sources (Zombie Source Bins)"; if sources come up
+  DUPLICATED or provisioning behaves erratically after many restart cycles, see
+  "Provisioning Chain Polluted" there.
 
 ### Confirm the full chain (VST ↔ DeepStream identity)
 

--- a/skills/hoisa-deploy-profile/references/test_scenario.md
+++ b/skills/hoisa-deploy-profile/references/test_scenario.md
@@ -84,7 +84,9 @@ bash closed-loop-testing/scripts/restart_isaac.sh    # reuses the running driver
 What to expect (measured on 2D and 3D single-GPU boxes and a 2-GPU 3D box, 6/6 runs):
 
 - Mounts warm in ~1-2 min (cached shaders), VST resumes, DeepStream back at 3/3 about
-  30 s later — total ≈ 2 min, with **zero** `has no caps` lines in the new run log.
+  30 s later — total ≈ 2 min, with **zero** `has no caps` lines in the
+  `vss-vios-streamprocessing` and DeepStream logs (grep those, not the driver run log —
+  it can be empty while streaming works).
 - The driver re-registers the cameras at render-warm as usual → **fresh sensor uuids on
   every restart**; SDR re-pushes them to DeepStream automatically.
 - Cosmetic leftovers, safe to ignore: one empty-name `offline` "ghost" entry per restart
@@ -166,9 +168,9 @@ detect when it finishes. All signals below were verified on a live VSS 3.2.1 + H
 
 ### Launch a background scene-done monitor
 
-`--start` auto-stops after `simulation_length` frames and tears the streams down. Launch
-a **detached** monitor (non-blocking — does not hold the main flow) that announces when
-the scene finishes, so you don't have to watch it:
+The driver runs until externally stopped. Launch a **detached** monitor (non-blocking —
+does not hold the main flow) that announces when the run exits or its streams are torn
+down, so you don't have to watch it:
 
 ```bash
 nohup bash -c '

--- a/skills/hoisa-deploy-profile/references/troubleshooting.md
+++ b/skills/hoisa-deploy-profile/references/troubleshooting.md
@@ -175,6 +175,10 @@ the instant its ports open. Restart via the wrapper, which pauses
 bash closed-loop-testing/scripts/restart_isaac.sh   # see test_scenario.md for expected behavior
 ```
 
+Single-host stacks only (`base`/`sil`): the wrapper pauses a **local** VST container.
+On the two-host `hil` profile it cannot reach the Thor-side VST — follow "Restart the
+scenario (hil)" in `halos_hil.md` instead.
+
 **Recovery** — if you do wedge (e.g. stale sensors churning), stop the churn and
 re-provision cleanly:
 

--- a/skills/hoisa-deploy-profile/references/troubleshooting.md
+++ b/skills/hoisa-deploy-profile/references/troubleshooting.md
@@ -166,6 +166,15 @@ VST never DESCRIBEs a capless stream (look for `[vst-warmup]` in the run log). A
 `--start --enable-vst` run should not hit this. You can still hit it if **stale** VST
 sensors from a previous run are pointed at Isaac's RTSP and churn it during pre-roll.
 
+**Prevention (restarts)**: the warm-up gate cannot help across a **restart** — the
+previous run's sensors are still registered and their VST clients hammer the new Isaac
+the instant its ports open. Restart via the wrapper, which pauses
+`vss-vios-streamprocessing` for the boot window and resumes it once the mounts deliver:
+
+```bash
+bash closed-loop-testing/scripts/restart_isaac.sh   # see test_scenario.md for expected behavior
+```
+
 **Recovery** — if you do wedge (e.g. stale sensors churning), stop the churn and
 re-provision cleanly:
 
@@ -243,6 +252,42 @@ curl -s -X POST http://localhost:9000/api/v1/stream/add -H 'Content-Type: applic
 > ℹ️ **Separate issue** — the Isaac **cold**-DESCRIBE wedge (`Active sources : 0`, "no caps") is
 > the section above; its upstream fix is an Isaac RFE: gate the RTSP server's DESCRIBE response on
 > the **first encoded frame** so caps are cached before VST's concurrent DESCRIBEs arrive.
+
+---
+
+## Provisioning Chain Polluted (Duplicate DS Sources / Event Replay Storms)
+
+**Symptom**: after many sensor re-registration cycles (repeated Isaac restarts, recovery
+attempts), DeepStream's `get-stream-info` shows **duplicate camera names** (e.g.
+`Camera_02` twice) or a camera never lands no matter how often you re-register; restarting
+`sdr-controller` makes it *worse* (a burst of `camera_add` pushes replays).
+
+**Cause**: the sensor lifecycle events live in a **Redis stream** with a long retention.
+`sdr-controller` replays it on restart — including every stale add/remove from previous
+cycles — and stale entries steal DeepStream's `max-batch-size` slots.
+
+**Fix — flush the event backlog, then ONE clean registration round** (order matters):
+
+```bash
+docker exec redis redis-cli FLUSHALL          # clears the event backlog + SDR workload cache
+docker restart sdr-controller                 # comes up with an empty, clean cache
+docker restart vss-rtvi-cv                    # DeepStream restarts as an EMPTY pipeline
+sleep 15
+# one clean registration round -> the only events in the stream are the fresh ones
+docker exec isaac-sim bash -lc 'cd /isaac-sim && \
+  ./python.sh /isaac-sim/sil/scripts/vst_sensor_manager.py --delete-all && sleep 3 && \
+  ./python.sh /isaac-sim/sil/scripts/vst_sensor_manager.py --add-from-config /isaac-sim/sil/configs/cameras.yaml'
+# DeepStream reaches N/N in ~30-60 s
+```
+
+If a camera STILL never comes up after this, check its Isaac mount directly
+(`ffprobe -rtsp_transport tcp rtsp://localhost:<port>/<mount>` from inside `isaac-sim`) —
+a dead mount is the upstream "no caps" wedge (section above); restart the scenario with
+`restart_isaac.sh`.
+
+**Full reset (last resort)** — when the state itself is suspect, return the stack to the
+proven-clean first-bring-up state without paying the TensorRT rebuild: procedure in
+`halos_deploy.md` → "Reset to a fresh deployment (keep the caches)".
 
 ---
 

--- a/skills/hoisa-generate-regression-report/references/02_launch.md
+++ b/skills/hoisa-generate-regression-report/references/02_launch.md
@@ -556,12 +556,16 @@ sleep 30
 docker logs --tail 200 "$PERCEPTION" 2>&1 | grep PERF -A1 | tail -5
 # If all 3 FPS values now ≥ $FPS_MIN → re-run the Step 3f.7 gate and continue.
 
-# Tier 2 — perception restart + isaac-sim scene restart
+# Tier 2 — Isaac scenario restart (~2 min)
 # (use if Tier 1 still shows FPS=0 — the RTSP streams may have flap-disconnected)
-docker restart isaac-sim "$PERCEPTION"
-sleep 60
-# Then re-execute Step 3e (wait for shaders + 3 RTSP streams ready)
-# and re-poll the 3f.7 gate.
+# Do NOT `docker restart isaac-sim` (never reloads the scene — the driver runs via
+# `docker exec -d`) and do NOT relaunch run_actor_sdg.py bare under a live VST
+# ("no caps" wedge). The wrapper reuses the running driver's args (keeps --srr-gt)
+# and waits for warm mounts + DeepStream 3/3:
+bash "$HOISA_ROOT_PATH"/closed-loop-testing/scripts/restart_isaac.sh
+# Then re-poll the 3f.7 gate (skip Step 3e — mounts are already warm). Expected
+# uuid churn / source_id shuffle: hoisa-deploy-profile references/test_scenario.md
+# § "Restart the scenario on a live stack".
 
 # Tier 3 — full VSS reset recipe (SKILL.md § "When VSS is corrupted")
 #   or vss-deploy-profile skill teardown/redeploy (references/teardown.md)


### PR DESCRIPTION
## Problem

Killing and relaunching `run_actor_sdg.py` while VST is running wedges the fresh Isaac RTSP mounts. VST holds two RTSP clients per mount (the live555 proxy ingest client and the liveness prober) and reconnects within milliseconds of a port opening, DESCRIBEing the stream before the encoder has produced its first frame. Isaac Sim 6.0's shared in-process RTSP media fails SDP creation under concurrent DESCRIBEs on a cold stream ("has no caps") and the wedged mount does not self-recover. The driver's built-in warm-up gate only defers *new* registrations — it cannot protect a restart, where the previous run's sensors already exist and their clients hammer the fresh ports.

## Change

- **`closed-loop-testing/scripts/restart_isaac.sh`** (new): pauses `vss-vios-streamprocessing` for exactly the Isaac boot window — capture the running driver's args, stop streamprocessing, relaunch the driver, wait until every `cameras.yaml` mount delivers frames (ffprobe over TCP), then resume streamprocessing so its clients DESCRIBE warm mounts. The sensor registry (`vss-vios-sensor` + DB) stays up throughout, so the driver's normal registration proceeds and SDR re-provisions DeepStream. Also detects the known intermittent DeepStream abort (`std::logic_error` "basic_string: construction from null", exit 134, fires when DS sources drain; Docker's `on-failure` retry budget does not reset and an exhausted container stays down): restarts it and runs one clean sensor re-registration round, reading "Active sources" only from log lines newer than the container's `StartedAt`.
- **`test_scenario.md`**: corrects the stale "`--start` auto-stops after `simulation_length` frames" claim (the 6.0 driver runs until externally stopped; `simulation_duration` only extends the timeline end time) and documents the restart procedure with its measured behavior and cosmetic leftovers.
- **`troubleshooting.md`**: restart-prevention pointer, plus a "Provisioning Chain Polluted" recovery section — the sensor lifecycle events live in a Redis stream that `sdr-controller` replays in full on restart, so heavy re-registration churn plus an sdr restart floods DeepStream with stale adds; the fix is flushing the backlog and doing one clean registration round.
- **`halos_deploy.md`**: "Reset to a fresh deployment (keep the caches)" — tiered recovery guidance ending in a selective state-volume reset that reproduces a clean first bring-up without paying the TensorRT rebuild or shader recompile.