### PR TITLE
docs: recording policy — sil records, hil disables always_recording on the Thor

### DIFF
--- a/skills/hoisa-deploy-profile/references/halos_hil.md
+++ b/skills/hoisa-deploy-profile/references/halos_hil.md
@@ -58,7 +58,7 @@ done
 
 Only once the streams above deliver frames, deploy VSS Warehouse on the Thor per `vss_hil_overrides.md`, applying all overrides BEFORE the first `up`. That file chains the rest: the 2D or 3D profile overrides (`vss_2d_overrides.md` / `vss_3d_overrides.md`), the `halos_thor.md` §2 IGX-Thor workarounds, sensor registration ownership, and the fresh-state teardown for a previously-used Thor. The order matters: the file-mode sensor registration has no stream-readiness gate, so deploying VSS against a cold Isaac triggers the "no caps" race (`vss_hil_overrides.md` §2; recovery in `troubleshooting.md`, RTSP Streams "no caps").
 
-Ready when the three sensors are `online` in VST pointing at the x86 host's IP, and perception shows `Active sources : 3` with non-zero fps (low fps that tracks the Isaac render rate is normal, not a network fault - `vss_hil_overrides.md` §4).
+Ready when the three sensors are `online` in VST pointing at the x86 host's IP, and perception shows `Active sources : 3` with non-zero fps (low fps that tracks the Isaac render rate is normal, not a network fault - `vss_hil_overrides.md` §5).
 
 ## 4. Gate: start the Safety Core only on a clear scene
 

--- a/skills/hoisa-deploy-profile/references/vss_2d_overrides.md
+++ b/skills/hoisa-deploy-profile/references/vss_2d_overrides.md
@@ -87,7 +87,6 @@ File: `<wh_ops>/warehouse-2d-app/vst/configs/vst_config.json` (several copies of
 ```jsonc
 "rtsp_streaming_over_tcp": true,    // ingest Isaac's RTSP over TCP (not UDP)
 "use_sensor_ntp_time": false,       // use arrival time, consistent with attach-sys-ts-as-ntp
-"always_recording": false,          // recording off — SIL does not need clips
 "bbox_tolerance_ms": 100            // default 0; widen metadata-to-frame match to reduce bbox flicker
 ```
 
@@ -95,19 +94,6 @@ File: `<wh_ops>/warehouse-2d-app/vst/configs/vst_config.json` (several copies of
   ingest avoids UDP packet loss / jitter.
 - `use_sensor_ntp_time: false`: pair with `attach-sys-ts-as-ntp=1` so VST and DeepStream
   agree on wall-clock arrival time rather than the (drifting) sim-time.
-- Recording off: SIL is a live closed loop, not a capture run — leaving recording on wastes
-  disk and I/O.
-- **⚠ `always_recording` is configurator-managed — a pre-`up` edit here is silently reverted.**
-  The blueprint-configurator runs a `json_update` op that hard-writes `data.always_recording: true`
-  into this exact file on every `up` (VSS `.../blueprint-configurator/blueprint_config.yml`,
-  the `warehouse-2d-app/.../vst/configs/vst_config.json` op ~line 407 — identical in 3.2.0 and 3.2.1),
-  so a `false` set before `up` is overwritten before the VST container (`vss-vios-streamprocessing`,
-  which mounts this file) reads it. To make `false` stick, do ONE of:
-    - **(preferred)** edit `blueprint_config.yml` too: change `data.always_recording: true` → `false`
-      in that op before `up`; or
-    - after the configurator has finished, edit this file and `docker restart vss-vios-streamprocessing`.
-  The other keys above (`rtsp_streaming_over_tcp`, `use_sensor_ntp_time`, `bbox_tolerance_ms`) are
-  NOT touched by the configurator, so those pre-`up` edits survive as written.
 - `bbox_tolerance_ms: 100`: widens the metadata-to-frame matching tolerance window, reducing
   bounding-box flickering.
 

--- a/skills/hoisa-deploy-profile/references/vss_3d_overrides.md
+++ b/skills/hoisa-deploy-profile/references/vss_3d_overrides.md
@@ -159,8 +159,6 @@ File: `<wh_ops>/warehouse-3d-app/vst/configs/vst_config.json`
 ```jsonc
 "rtsp_streaming_over_tcp": true,    // ingest Isaac's RTSP over TCP (not UDP)
 "use_sensor_ntp_time": false,       // use arrival time, consistent with attach-sys-ts-as-ntp
-"always_recording": false,          // recording off — SIL does not need clips
-"event_recording": false,           // recording off
 "bbox_tolerance_ms": 100            // default 0; widen metadata-to-frame match to reduce bbox flicker
 ```
 
@@ -168,19 +166,6 @@ File: `<wh_ops>/warehouse-3d-app/vst/configs/vst_config.json`
   ingest avoids UDP packet loss / jitter on the shared host.
 - `use_sensor_ntp_time: false`: pair with `attach-sys-ts-as-ntp=1` so VST and DeepStream
   agree on wall-clock arrival time rather than the (drifting) sim-time.
-- Recording off: SIL is a live closed loop, not a capture run — leaving recording on wastes
-  disk and I/O.
-- **⚠ `always_recording` is configurator-managed — a pre-`up` edit here is silently reverted.**
-  The blueprint-configurator runs a `json_update` op that hard-writes `data.always_recording: true`
-  into this exact file on every `up` (VSS `.../blueprint-configurator/blueprint_config.yml`,
-  the `warehouse-3d-app/.../vst/configs/vst_config.json` op ~line 494 — identical in 3.2.0 and 3.2.1),
-  so a `false` set before `up` is overwritten before the VST container (`vss-vios-streamprocessing`,
-  which mounts this file) reads it. To make `false` stick, do ONE of:
-    - **(preferred)** edit `blueprint_config.yml` too: change `data.always_recording: true` → `false`
-      in that op before `up`; or
-    - after the configurator has finished, edit this file and `docker restart vss-vios-streamprocessing`.
-  The configurator does NOT touch `event_recording`, `rtsp_streaming_over_tcp`, `use_sensor_ntp_time`,
-  or `bbox_tolerance_ms`, so those pre-`up` edits survive as written.
 - `bbox_tolerance_ms: 100`: widens the metadata-to-frame matching window, reducing
   bounding-box flicker at the lower 3D frame rate.
 

--- a/skills/hoisa-deploy-profile/references/vss_hil_overrides.md
+++ b/skills/hoisa-deploy-profile/references/vss_hil_overrides.md
@@ -39,10 +39,18 @@ The VSS configurator reads this file and POSTs each entry to the VST `/sensor/ad
 
 **Isaac-side registration** (the single-host `sil` flow, run cross-host): launch with `--enable-vst` and point the x86 profile env at the Thor (`VST_BASE_URL` and `PERCEPTION_BASE_URL` in `profiles/hil.env`). This path has the built-in warm-up gate (it registers only once the render is warm, avoiding the cold-DESCRIBE race) but requires VSS to already be up when the scenario starts. Leave `SENSOR_INFO_SOURCE` at its default (not `file`).
 
-## 3. Fresh state on a previously-used Thor
+## 3. Recording on the Thor VST
+
+Set `always_recording: false` (continuous clips fill the Thor's disk) but keep
+`event_recording` **on**. The blueprint-configurator hard-writes `always_recording: true`
+on every `up` — set the same `true → false` in the configurator's `blueprint_config.yml`
+before `up`, or edit `vst_config.json` after the configurator finishes and
+`docker restart vss-vios-streamprocessing`.
+
+## 4. Fresh state on a previously-used Thor
 
 On a Thor that ran VSS before, tear the stack down and wipe the Kafka volumes before redeploying - otherwise the sensor distribution service replays the old sensor history and perception sticks at 0 fps after every restart. Symptom, cause and the exact commands: `troubleshooting.md`, "Perception 0 FPS With Sensors Online (Stale Sensor History Replay)".
 
-## 4. Verify
+## 5. Verify
 
 Use the profile doc's "Verification After Deploy" (`vss_2d_overrides.md` / `vss_3d_overrides.md`) plus the FPS-based poll in `test_scenario.md`. Expect the delivered fps to track the Isaac render rate (well below the nominal stream rate) - that is the simulation, not a network fault.


### PR DESCRIPTION
## What

Recording policy for the VST across profiles:

- **`sil` (2D + 3D)**: recording stays at the stock defaults (`always_recording` + `event_recording` on) — the clips are used for scenario review. `vss_2d_overrides.md` / `vss_3d_overrides.md` drop the `always_recording`/`event_recording: false` overrides and the configurator-revert workaround that existed only to make `false` stick.
- **`hil`**: new "Recording on the Thor VST" section in `vss_hil_overrides.md` — set `always_recording: false` (continuous clips fill the Thor's disk) but keep `event_recording` on, with the configurator note (`blueprint_config.yml` before `up`, or edit + restart `vss-vios-streamprocessing` after).

## Why

The previous guidance turned recording off for `sil` and needed a 12-line workaround to defeat the blueprint-configurator, which hard-writes `always_recording: true` on every `up`. With recording wanted on for `sil`, the stock behavior is already correct — the overrides and the workaround go away. The Thor is the only place the default needs changing.

Docs-only; no script or compose changes.

