### PR TITLE
docs(hoisa-deploy-profile): add calibration safety-readiness prerequisite check

### DIFF
--- a/skills/hoisa-deploy-profile/references/halos_deploy.md
+++ b/skills/hoisa-deploy-profile/references/halos_deploy.md
@@ -11,6 +11,49 @@ Services and config differ per profile:
 
 ---
 
+## 0. Prerequisite — calibration must be safety-ready (2D / 3D · `base` / `sil` / `hil`)
+
+Safety events are driven by the ROIs and tripwires in the VSS perception **`calibration.json`**.
+**The shipped sample calibrations already include the required fields** — the 2D sample
+(`warehouse-2d-app/calibration/sample-data/warehouse-loading-dock-3cams-synthetic/calibration.json`)
+ships with `restrictedObjectTypes` set, and the 3D calibration built per `calibration_3d.md` includes
+it too — so with the **default sample scene there is nothing to change** here.
+
+This check matters only when you bring your **own calibration** (a custom scene / your own
+AMC-generated `calibration.json`, e.g. a partner site). That calibration lives on the VSS side,
+**not in this repo**; if it's wrong, perception still detects people / forklifts fine but the Safety
+Core sees **no events** — no MUTE/UNMUTE, and **no error is logged** (a silent failure). The current use
+case runs the **ATL** app (`--app atl`), whose event map is `event_mapping_atl.pb.txt` (referenced by
+`safety-core/configs/nvpss.conf`); the proximity app has its own mapping file. Check these values:
+
+| Check | In `calibration.json` | Expected value | Silent failure if missing / wrong |
+|-------|-----------------------|----------------|-----------------------------------|
+| Restricted class per ROI | `rois[].restrictedObjectTypes` | non-empty, e.g. `["Person"]` | person entering the ROI is **never reported to the SDM** (most common) |
+| ROI id ↔ rule | `rois[].id` ↔ `rule_id` in `event_mapping_atl.pb.txt` | must match (e.g. `roi-id-1`) | ROI violation fires but maps to no `EVENT_4` / `EVENT_5` |
+| Tripwire id ↔ rule | `tripwires[].id` ↔ `rule_id` in `event_mapping_atl.pb.txt` | must match (e.g. `tripwire-id-1`) | forklift / person tripwire maps to no `EVENT_0`–`EVENT_3` |
+
+(`confinedObjectTypes`, e.g. `["Forklift"]`, is set the same way per ROI — see the ROI schema in `calibration_3d.md`.)
+
+Using a custom calibration? validate it before deploying (the shipped sample passes as-is):
+
+```bash
+CALIB=<wh_ops>/warehouse-2d-app/calibration/sample-data/<your-scene>/calibration.json
+python3 - "$CALIB" <<'PY'
+import json, sys
+c = json.load(open(sys.argv[1]))
+rois, tws = c.get("rois", []), c.get("tripwires", [])
+print("ROI ids:", [r.get("id") for r in rois], "| tripwire ids:", [t.get("id") for t in tws])
+missing = [r.get("id") for r in rois if not r.get("restrictedObjectTypes")]
+if missing:
+    sys.exit(f"ERROR: ROIs with no restrictedObjectTypes — person-in-ROI will NOT reach the SDM: {missing}")
+print("OK: every ROI restricts at least one object type")
+PY
+```
+
+Then confirm the printed `id`s match the `rule_id`s in `event_mapping_atl.pb.txt`.
+
+---
+
 ## 1. Configure the profile env
 
 Edit the profile env **in your clone** at `deployments/profiles/<profile>.env` and

--- a/skills/hoisa-deploy-profile/references/halos_deploy.md
+++ b/skills/hoisa-deploy-profile/references/halos_deploy.md
@@ -19,6 +19,10 @@ Safety events are driven by the ROIs and tripwires in the VSS perception **`cali
 ships with `restrictedObjectTypes` set, and the 3D calibration built per `calibration_3d.md` includes
 it too — so with the **default sample scene there is nothing to change** here.
 
+> This requirement is stated in the [Safety Core User Guide — Prerequisites](https://docs.nvidia.com/halos-outside-in/latest/HOISA-User-Guide.html#prerequisites)
+> (the calibration *"includes `restrictedObjectTypes:["Person"]` for the ROIs, where relevant"*); the
+> field itself is defined in the [VSS calibration schema](https://docs.nvidia.com/vss/3.2.1/calibration-schema.html).
+
 This check matters only when you bring your **own calibration** (a custom scene / your own
 AMC-generated `calibration.json`, e.g. a partner site). That calibration lives on the VSS side,
 **not in this repo**; if it's wrong, perception still detects people / forklifts fine but the Safety

--- a/skills/hoisa-deploy-profile/references/troubleshooting.md
+++ b/skills/hoisa-deploy-profile/references/troubleshooting.md
@@ -392,6 +392,31 @@ window too tight for perception latency.
 
 ---
 
+## No ROI / Tripwire Events Reaching the Safety Core (detections look fine)
+
+**Symptom**: Perception detects people / forklifts correctly (boxes look good in
+VST), but the Safety Core never reacts — no MUTE/UNMUTE as a person enters a
+restricted ROI or the forklift crosses the tripwire. **No error is logged** — the
+events simply never arrive at the SDM.
+
+**Cause**: a `calibration.json` misconfiguration. The shipped sample calibrations
+(2D and 3D) already set these correctly — this shows up on a **custom scene / your own
+AMC-generated calibration** (VSS side, not shipped in this repo), most commonly one of:
+1. **A restricted ROI is missing `restrictedObjectTypes`** (e.g. `["Person"]`). The ROI
+   geometry is defined, but no object class is marked restricted, so a person inside it is
+   never reported as a violation. This is the most common cause.
+2. **The ROI / tripwire `id` does not match the `rule_id`** in the ATL event-mapping file
+   (`event_mapping_atl.pb.txt`, referenced by `safety-core/configs/nvpss.conf`) — the event
+   fires but the Safety Core can't map it to `EVENT_0`…`EVENT_5`.
+
+**Fix**: run the calibration prerequisite check in `halos_deploy.md` (§0) — it flags ROIs
+with no `restrictedObjectTypes` and prints the ids to cross-check against the event map. Add
+the missing field per the ROI schema in `calibration_3d.md`, regenerate / re-mount the
+calibration, and **recreate** (not restart) the VSS perception + safety-core containers so the
+new `calibration.json` and event mapping are picked up.
+
+---
+
 ## PSF Indicator Not Transitioning Correctly — Check Perception Stability First
 
 **Symptom**: PSF indicator doesn't switch between states (green / yellow /
@@ -499,3 +524,4 @@ using the same domain ID.
 | Bbox flickering | `bbox_tolerance_ms=100` in VST config |
 | CUDA errors on restart | Full container recreate, not restart |
 | Safety flickering (multi-machine) | Assign unique `ROS_DOMAIN_ID` (0-232) per machine |
+| No ROI/tripwire events (detections OK) | `restrictedObjectTypes` missing in `calibration.json`, or roi/tripwire `id` ≠ `rule_id` in the event map — see `halos_deploy.md` §0 |

--- a/skills/hoisa-deploy-profile/references/troubleshooting.md
+++ b/skills/hoisa-deploy-profile/references/troubleshooting.md
@@ -411,9 +411,12 @@ AMC-generated calibration** (VSS side, not shipped in this repo), most commonly 
 
 **Fix**: run the calibration prerequisite check in `halos_deploy.md` (§0) — it flags ROIs
 with no `restrictedObjectTypes` and prints the ids to cross-check against the event map. Add
-the missing field per the ROI schema in `calibration_3d.md`, regenerate / re-mount the
-calibration, and **recreate** (not restart) the VSS perception + safety-core containers so the
-new `calibration.json` and event mapping are picked up.
+the missing field per the ROI schema in `calibration_3d.md`. The AMC / Calibration Toolkit
+does not expose restricted / confined object types as a dedicated field, so set them via its
+**Full Control** JSON editor at the [export step](https://docs.nvidia.com/vss/3.2.1/autocalib-workflow-steps.html#export-calibration-data)
+(advanced) or by editing the exported `calibration.json` directly. Then regenerate / re-mount
+the calibration and **recreate** (not restart) the VSS perception + safety-core containers so
+the new `calibration.json` and event mapping are picked up.
 
 ---
 


### PR DESCRIPTION
## What

Add a **calibration prerequisite check** to the deploy skill so a common misconfiguration on custom scenes fails loudly instead of silently producing no safety events.

- `halos_deploy.md`: new **`0. Prerequisite — calibration must be safety-ready`** section — a check table (each restricted ROI needs `restrictedObjectTypes`; ROI/tripwire `id`s must match the `rule_id`s in `event_mapping_atl.pb.txt`) plus a `calibration.json` validation snippet.
- `troubleshooting.md`: new **"No ROI/Tripwire Events Reaching the Safety Core (detections look fine)"** entry + a quick-reference row.

## Why

If `calibration.json` is missing `restrictedObjectTypes` on a restricted ROI (or an ROI/tripwire `id` doesn't match a `rule_id` in the ATL event map), perception still detects people/forklifts fine but the Safety Core sees **no events** — no MUTE/UNMUTE, and **nothing is logged** (silent failure). This bit a partner bring-up (person entering the ROI never reached the SDM).

## Scope / notes

- Applies to **2D and 3D**, all profiles (`base`/`sil`/`hil`). The **shipped 2D/3D sample calibrations already set these** — the check is only needed when bringing a custom / AMC-generated calibration.
- Current use case = the **ATL** app (`--app atl`), so the check references `event_mapping_atl.pb.txt`.
- Docs-only. The deeper fixes (a runtime warning from SDM/BA when a configured ROI has no restricted types; a first-class `restrictedObjectTypes` field in the AMC/Calib Toolkit) are separate VSS/PSF-side asks.