### PR TITLE
fix(regression-reporter): derive tripwire inside-side from calibration direction

### DIFF
--- a/closed-loop-testing/regression-reporter/srr-service/srr/aggregator.py
+++ b/closed-loop-testing/regression-reporter/srr-service/srr/aggregator.py
@@ -22,6 +22,8 @@ from typing import Optional
 import pandas as pd
 from shapely.geometry import MultiPoint, Point, Polygon
 
+from srr.tripwire import Tripwire
+
 
 # ---------- ROI / tripwire defaults (from VSS calibration sample-data) ----------
 
@@ -36,25 +38,21 @@ DEFAULT_TW_Y_MIN = -18.9756077
 DEFAULT_TW_Y_MAX = -11.2385153
 
 
-def load_roi(calib_path: Optional[Path]) -> tuple[Polygon, float, float, float]:
-    """Returns (roi_polygon, tw_x, tw_y_min, tw_y_max)."""
+def load_roi(calib_path: Optional[Path]) -> tuple[Polygon, Tripwire]:
+    """Returns (roi_polygon, tripwire).
+
+    The tripwire's inside side comes from the calibration's ``direction``
+    field (arrow head = inside/trailer side) — see srr.tripwire.
+    """
     if calib_path and calib_path.exists():
         d = json.loads(calib_path.read_text())
         # all sensors share the same ROI/TW in this scene; take first
         s0 = d["sensors"][0]
         coords = [(c["x"], c["y"]) for c in s0["rois"][0]["roiCoordinates"]]
-        wire = s0["tripwires"][0]["wire"]
-        return (
-            Polygon(coords),
-            wire["p1"]["x"],
-            min(wire["p1"]["y"], wire["p2"]["y"]),
-            max(wire["p1"]["y"], wire["p2"]["y"]),
-        )
+        return (Polygon(coords), Tripwire.from_calib_dict(s0["tripwires"][0]))
     return (
         Polygon(DEFAULT_ROI_VERTICES),
-        DEFAULT_TW_X,
-        DEFAULT_TW_Y_MIN,
-        DEFAULT_TW_Y_MAX,
+        Tripwire.legacy(DEFAULT_TW_X, DEFAULT_TW_Y_MIN, DEFAULT_TW_Y_MAX),
     )
 
 
@@ -468,7 +466,7 @@ def _estimate_forklift_origin_offset(rows: list, gate_m: float,
 
 def compute_phase2_metrics(df: pd.DataFrame, gate_m: float = 1.5,
                            coverage_pad_m: float = 0.0,
-                           tw_x: float = DEFAULT_TW_X,
+                           tw: Optional[Tripwire] = None,
                            boundary_m: float = 2.0,
                            split_dist_m: float = 1.0) -> Optional[dict]:
     """Per-clip 3D perception metrics from the recorded mdx-bev detections.
@@ -632,8 +630,11 @@ def compute_phase2_metrics(df: pd.DataFrame, gate_m: float = 1.5,
     cls_incov_present = {c: 0 for c in classes}
     # Per-actor in-coverage matched distances → per-actor multi-gate recall.
     actor_incov_dist: dict = {a: [] for a in _GT_ACTOR_CLASS}
+    if tw is None:
+        tw = Tripwire.legacy(DEFAULT_TW_X, DEFAULT_TW_Y_MIN, DEFAULT_TW_Y_MAX)
     # Trailer-boundary slice for the forklift: frames where the forklift GT
-    # sits within ±boundary_m of the tripwire (x = tw_x). This isolates the
+    # sits within ±boundary_m of the tripwire (perpendicular distance to the
+    # wire line — was abs(x - tw_x) for the vertical wire). This isolates the
     # previously-observed ~33% forklift detection loss around the trailer boundary.
     fk_boundary_present = 0
     fk_boundary_missed = 0
@@ -691,7 +692,7 @@ def compute_phase2_metrics(df: pd.DataFrame, gate_m: float = 1.5,
                     fn_in += 1
                     cls_fn_in[cls] += 1
                     actor_stats[a]["missed_in_cov"] += 1
-                if a == "forklift" and abs(gx - tw_x) <= boundary_m:
+                if a == "forklift" and tw.line_distance(gx, gy) <= boundary_m:
                     fk_boundary_present += 1
                     if not matched:
                         fk_boundary_missed += 1
@@ -805,7 +806,7 @@ def compute_phase2_metrics(df: pd.DataFrame, gate_m: float = 1.5,
                   if fk_boundary_present else None,
         "track_loss_pct": round(100 * fk_boundary_missed / fk_boundary_present, 2)
                           if fk_boundary_present else None,
-        "window_m": boundary_m, "tw_x": round(tw_x, 3),
+        "window_m": boundary_m, "tw_x": round(tw.x_ref, 3),
     }
 
     # Split / fragmentation: per detector frame, ≥2 tracks of the same class
@@ -923,12 +924,11 @@ def compute_phase2_metrics(df: pd.DataFrame, gate_m: float = 1.5,
     return out
 
 
-def analyze_clip(parquet_path: Path, roi: Polygon, tw_x: float,
-                 tw_y_min: float, tw_y_max: float,
+def analyze_clip(parquet_path: Path, roi: Polygon, tw: Tripwire,
                  ba_events_override: Optional[list[dict]] = None) -> tuple[ClipVerdict, pd.DataFrame]:
     df = pd.read_parquet(parquet_path)
     # Phase 2 metrics computed on the full df (before the cold-start GT drop).
-    phase2 = compute_phase2_metrics(df, tw_x=tw_x)
+    phase2 = compute_phase2_metrics(df, tw=tw)
 
     # Drop the cold-start window: skip leading frames where any required GT TF is still NaN.
     # In Isaac Sim, /gt/<char>/tf can publish ~seconds after the sim starts, so a clip captured
@@ -955,11 +955,7 @@ def analyze_clip(parquet_path: Path, roi: Polygon, tw_x: float,
     import numpy as _np
     any_char = _np.array(char_in_roi.any(axis=1).fillna(False).tolist(), dtype=bool)
     fk_in_trailer = _np.array([
-        bool(
-            pd.notna(fx) and pd.notna(fy)
-            and fx > tw_x
-            and tw_y_min <= fy <= tw_y_max
-        )
+        bool(pd.notna(fx) and pd.notna(fy) and tw.is_inside(fx, fy))
         for fx, fy in zip(df["forklift_x"], df["forklift_y"])
     ], dtype=bool)
     df["any_char_in_roi"] = any_char
@@ -1189,7 +1185,7 @@ def render_clip_report(v: ClipVerdict) -> str:
         "## Ground truth (from /gt/*/tf)",
         "",
         f"- any character in ROI: **{v.pct_any_char_in_roi}%** of frames",
-        f"- forklift in trailer (x>{DEFAULT_TW_X:.3f}): **{v.pct_forklift_in_trailer}%**",
+        f"- forklift in trailer (inside-side of the trailer tripwire): **{v.pct_forklift_in_trailer}%**",
         f"- expected MUTE: **{v.pct_expected_mute}%**",
         "",
         "## Observed PSF state (from /safety/is_muted + /safety/command)",
@@ -1899,9 +1895,9 @@ def main() -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
 
     calib_path = Path(args.calib) if args.calib else None
-    roi, tw_x, tw_y_min, tw_y_max = load_roi(calib_path)
+    roi, tw = load_roi(calib_path)
     print(f"[agg] ROI bounds: {list(roi.exterior.coords)}")
-    print(f"[agg] TW x={tw_x:.3f}, y∈[{tw_y_min:.3f}, {tw_y_max:.3f}]")
+    print(f"[agg] TW {tw}")
 
     if args.top_level:
         parquets = sorted(runs_dir.glob("*/scenes/scn_*.parquet"))
@@ -1936,7 +1932,7 @@ def main() -> None:
                     scene_start = float(scene_df["arrival_wall_time"].iloc[0])
                     scene_end = float(scene_df["arrival_wall_time"].iloc[-1])
                     ba_override = filter_ba_pool(pool, scene_start, scene_end)
-            v, _df = analyze_clip(pq, roi, tw_x, tw_y_min, tw_y_max,
+            v, _df = analyze_clip(pq, roi, tw,
                                    ba_events_override=ba_override)
             verdicts.append(v)
             if args.top_level:

--- a/closed-loop-testing/regression-reporter/srr-service/srr/clip_logs.py
+++ b/closed-loop-testing/regression-reporter/srr-service/srr/clip_logs.py
@@ -47,9 +47,6 @@ from srr.aggregator import (
     BA_POOL_PAD_S,
     CHAR_COLS,
     DEFAULT_ROI_VERTICES,
-    DEFAULT_TW_X,
-    DEFAULT_TW_Y_MIN,
-    DEFAULT_TW_Y_MAX,
     _GT_ACTOR_CLASS,
     compute_phase2_metrics,
     in_roi as _in_roi,
@@ -107,8 +104,7 @@ def _clip_bounds(parquet_path: Path) -> Optional[ClipBounds]:
     )
 
 
-def _write_gt_csv(df: pd.DataFrame, roi: Polygon, tw_x: float,
-                  tw_y_min: float, tw_y_max: float, out_path: Path) -> None:
+def _write_gt_csv(df: pd.DataFrame, roi: Polygon, tw, out_path: Path) -> None:
     rows = []
     for _, r in df.iterrows():
         char_in = []
@@ -117,9 +113,7 @@ def _write_gt_csv(df: pd.DataFrame, roi: Polygon, tw_x: float,
             y = r.get(f"{c}_y")
             char_in.append(_in_roi(roi, x, y))
         fx, fy = r.get("forklift_x"), r.get("forklift_y")
-        in_trailer = bool(
-            pd.notna(fx) and pd.notna(fy) and fx > tw_x and tw_y_min <= fy <= tw_y_max
-        )
+        in_trailer = bool(pd.notna(fx) and pd.notna(fy) and tw.is_inside(fx, fy))
         rows.append({
             "wall_time": r["arrival_wall_time"],
             "sim_time": r["sim_time"],
@@ -461,8 +455,7 @@ def _gt_summary(gt_csv: Path) -> dict:
     }
 
 
-def _emit_clip(parquet_path: Path, out_dir: Path, roi: Polygon, tw_x: float,
-               tw_y_min: float, tw_y_max: float, pool: list[dict],
+def _emit_clip(parquet_path: Path, out_dir: Path, roi: Polygon, tw, pool: list[dict],
                pss_path: Optional[Path], copy_mp4: bool, pad: float) -> Optional[dict]:
     bounds = _clip_bounds(parquet_path)
     if bounds is None:
@@ -476,7 +469,7 @@ def _emit_clip(parquet_path: Path, out_dir: Path, roi: Polygon, tw_x: float,
     psf_csv = out_dir / "psf_timeline.csv"
     ba_csv = out_dir / "ba_events.csv"
 
-    _write_gt_csv(df, roi, tw_x, tw_y_min, tw_y_max, gt_csv)
+    _write_gt_csv(df, roi, tw, gt_csv)
     _write_psf_timeline(df, psf_csv)
     n_ba = _write_ba_events(pool, bounds, pad, ba_csv)
 
@@ -523,7 +516,7 @@ def _emit_clip(parquet_path: Path, out_dir: Path, roi: Polygon, tw_x: float,
     phase2_brief = None
     if has_phase2:
         try:
-            p2 = compute_phase2_metrics(df, tw_x=tw_x)
+            p2 = compute_phase2_metrics(df, tw=tw)
         except Exception:
             p2 = None
         if p2 and p2.get("enabled") and p2.get("gt_available"):
@@ -626,7 +619,7 @@ def main() -> None:
     if not runs_dir.is_dir():
         raise SystemExit(f"runs-dir not found: {runs_dir}")
 
-    roi, tw_x, tw_y_min, tw_y_max = load_roi(Path(args.calib) if args.calib else None)
+    roi, tw = load_roi(Path(args.calib) if args.calib else None)
 
     scen_filter = {s.strip() for s in args.scenarios.split(",") if s.strip()}
     fail_set: set[tuple[str, str]] = set()
@@ -672,7 +665,7 @@ def main() -> None:
             pool_cache[scen] = load_run_ba_pool(run_dir)
             print(f"[clip_logs] BA pool {scen}: {len(pool_cache[scen])} events")
         clip_dir = run_dir / args.out_name / pq.stem
-        rec = _emit_clip(pq, clip_dir, roi, tw_x, tw_y_min, tw_y_max,
+        rec = _emit_clip(pq, clip_dir, roi, tw,
                          pool_cache[scen], pss_path, copy_mp4=not args.no_mp4, pad=args.pad)
         if rec is not None:
             indexes_by_scen.setdefault(scen, []).append(rec)

--- a/closed-loop-testing/regression-reporter/srr-service/srr/tripwire.py
+++ b/closed-loop-testing/regression-reporter/srr-service/srr/tripwire.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tripwire geometry — side-of-wire tests driven by calibration.json.
+
+A tripwire in the VSS calibration is a segment (``wire.p1 → wire.p2``) plus a
+``direction`` segment (``direction.p1 → direction.p2``) that crosses it. The
+direction arrow defines the "entry" sense: movement with the arrow is the
+entry crossing (BA labels it ``Right``), and the side of the wire that
+``direction.p2`` (the arrow head) lies on is the "inside" side — for the
+warehouse scene, the trailer.
+
+This replaces the previous hardcoded assumption of a vertical wire with
+inside = +x (``fx > tw_x``): the wire may have any orientation, and which side
+is "inside" comes from the calibration instead of from code.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Tripwire:
+    x1: float
+    y1: float
+    x2: float
+    y2: float
+    inside_sign: float  # normalizes side() so that inside is always positive
+
+    # ---- construction ----
+
+    @staticmethod
+    def _raw_side(x1: float, y1: float, x2: float, y2: float,
+                  px: float, py: float) -> float:
+        """Cross product (wire vector) × (p1→point): sign = side of the line."""
+        return (x2 - x1) * (py - y1) - (y2 - y1) * (px - x1)
+
+    @classmethod
+    def from_calib_dict(cls, tw: dict) -> "Tripwire":
+        """Build from one entry of calibration.json ``sensors[i].tripwires``."""
+        w = tw["wire"]
+        x1, y1 = float(w["p1"]["x"]), float(w["p1"]["y"])
+        x2, y2 = float(w["p2"]["x"]), float(w["p2"]["y"])
+        s = 0.0
+        d = tw.get("direction")
+        if d:
+            # The arrow head (direction.p2) sits on the inside of the wire.
+            s = cls._raw_side(x1, y1, x2, y2, float(d["p2"]["x"]), float(d["p2"]["y"]))
+        if s == 0.0:
+            # No usable direction (missing, or degenerate: head exactly on the
+            # wire line) — fall back to the legacy convention, inside = +x.
+            s = cls._raw_side(x1, y1, x2, y2, max(x1, x2) + 1.0, (y1 + y2) / 2.0)
+        return cls(x1, y1, x2, y2, 1.0 if s > 0 else -1.0)
+
+    @classmethod
+    def legacy(cls, tw_x: float, y_min: float, y_max: float) -> "Tripwire":
+        """Vertical wire at x = tw_x with inside = +x (the old hardcoded model)."""
+        return cls.from_calib_dict(
+            {"wire": {"p1": {"x": tw_x, "y": y_min}, "p2": {"x": tw_x, "y": y_max}}}
+        )
+
+    # ---- queries ----
+
+    def side(self, px: float, py: float) -> float:
+        """Signed side of the (infinite) wire line; > 0 = inside half-plane."""
+        return self.inside_sign * self._raw_side(self.x1, self.y1, self.x2, self.y2, px, py)
+
+    def is_past(self, px: float, py: float) -> bool:
+        """Point in the inside half-plane (no wire-extent check). This is the
+        clip-boundary test tw_split uses — same semantics as the old
+        ``fx > tw_x`` (which also ignored the wire's extent)."""
+        return self.side(px, py) > 0.0
+
+    def is_inside(self, px: float, py: float) -> bool:
+        """Inside half-plane AND within the wire's extent (the old test also
+        required y between the wire endpoints)."""
+        return self.is_past(px, py) and 0.0 <= self._projection(px, py) <= 1.0
+
+    def line_distance(self, px: float, py: float) -> float:
+        """Perpendicular distance to the infinite wire line — same semantics
+        as the old ``abs(x - tw_x)`` used for the trailer-boundary slice."""
+        length = math.hypot(self.x2 - self.x1, self.y2 - self.y1)
+        if length <= 0.0:
+            return math.hypot(px - self.x1, py - self.y1)
+        return abs(self._raw_side(self.x1, self.y1, self.x2, self.y2, px, py)) / length
+
+    def _projection(self, px: float, py: float) -> float:
+        """Normalized projection of the point onto the wire (0 = p1, 1 = p2)."""
+        vx, vy = self.x2 - self.x1, self.y2 - self.y1
+        length_sq = vx * vx + vy * vy
+        if length_sq <= 0.0:
+            return 0.0
+        return ((px - self.x1) * vx + (py - self.y1) * vy) / length_sq
+
+    # ---- legacy accessors (report text / JSON keys kept for compat) ----
+
+    @property
+    def x_ref(self) -> float:
+        """p1.x — what the old code called TW_X (reports/JSON keep this key)."""
+        return self.x1
+
+    def __str__(self) -> str:
+        return (f"wire ({self.x1:.3f},{self.y1:.3f})→({self.x2:.3f},{self.y2:.3f})"
+                f" inside={'+' if self.inside_sign > 0 else '-'}side")

--- a/closed-loop-testing/regression-reporter/srr-service/srr/tw_split.py
+++ b/closed-loop-testing/regression-reporter/srr-service/srr/tw_split.py
@@ -3,7 +3,7 @@
 """
 Cut a continuous-run parquet into per-scene parquets at forklift TW crossings.
 
-Each time forklift_x crosses the trailer tripwire (x = TW_X) is a scene boundary.
+Each time the forklift crosses the trailer tripwire is a scene boundary.
 Consecutive boundaries delimit one scene.
 
 Run inside SRR container:
@@ -16,7 +16,7 @@ Outputs:
   scenes/scenes_manifest.csv     — adds ISO times + VST query templates
 
 Configuration (precedence: --calib JSON > env var > default):
-- TW_X            : x-coordinate of the tripwire (loaded from calibration.json
+- TW              : the tripwire segment + inside side (loaded from calibration.json
                     `sensors[0].tripwires[0].wire.p1.x` if --calib provided)
 - VST_BASE_URL    : env var, e.g. http://<HOST_IP>:30888/vst/api (defined in
                     Halos compose .env; SRR inherits it via env_file)
@@ -34,6 +34,8 @@ from pathlib import Path
 from typing import Optional
 
 import pandas as pd
+
+from srr.tripwire import Tripwire
 
 
 # Defaults — overridden by env vars at module load, optionally by --calib at runtime.
@@ -53,28 +55,34 @@ def get_sensors() -> tuple[str, ...]:
     return tuple(s.strip() for s in raw.split(",") if s.strip())
 
 
-def load_tw_x(calib_path: Optional[Path]) -> float:
-    """Load the tripwire x-coordinate from calibration.json, fall back to default."""
+def load_tripwire(calib_path: Optional[Path]) -> Tripwire:
+    """Load the tripwire (wire + inside side from ``direction``) from
+    calibration.json, fall back to the legacy vertical-wire default."""
     if calib_path and calib_path.exists():
         try:
             d = json.loads(calib_path.read_text())
-            return float(d["sensors"][0]["tripwires"][0]["wire"]["p1"]["x"])
+            return Tripwire.from_calib_dict(d["sensors"][0]["tripwires"][0])
         except (KeyError, IndexError, json.JSONDecodeError, ValueError) as e:
             print(f"[tw_split] WARN: --calib failed to parse ({e}); using default TW_X={DEFAULT_TW_X}")
-    return DEFAULT_TW_X
+    return Tripwire.legacy(DEFAULT_TW_X, 0.0, 1.0)
 
 
 # Module-level (import-time) values — kept for backward compat with callers that
 # import these names directly. Mutated by main() if --calib provided.
-TW_X = DEFAULT_TW_X
+TW = Tripwire.legacy(DEFAULT_TW_X, 0.0, 1.0)
 VST_BASE = get_vst_base()
 SENSORS = get_sensors()
 
 
 def crossings(df: pd.DataFrame) -> list[tuple[int, float]]:
-    """Return [(row_index, wall_time)] of each forklift_x TW crossing."""
-    s = df["forklift_x"].dropna()
-    side = (s > TW_X).astype(int).diff().fillna(0)
+    """Return [(row_index, wall_time)] of each forklift TW crossing.
+
+    Crossing = the forklift's signed side of the wire line flips (same
+    infinite-line semantics the old ``forklift_x > TW_X`` test had, but
+    orientation-agnostic and driven by the calibration's direction field)."""
+    fk = df[["forklift_x", "forklift_y"]].dropna()
+    inside = fk.apply(lambda r: TW.is_past(r["forklift_x"], r["forklift_y"]), axis=1)
+    side = inside.astype(int).diff().fillna(0)
     cross = side[side != 0]
     return [(idx, float(df.loc[idx, "arrival_wall_time"])) for idx in cross.index]
 
@@ -151,8 +159,10 @@ def split(parquet_in: Path, out_dir: Path, source: str = "gt") -> list[dict]:
         # Side at scene midpoint. forklift_x may be None/NaN when the forklift
         # GT is absent (e.g. out of sensor coverage) — treat as outside_trailer.
         mid = seg.iloc[len(seg) // 2]
-        fk_x = mid["forklift_x"]
-        forklift_side = "in_trailer" if (pd.notna(fk_x) and fk_x > TW_X) else "outside_trailer"
+        fk_x, fk_y = mid["forklift_x"], mid["forklift_y"]
+        forklift_side = ("in_trailer"
+                         if (pd.notna(fk_x) and pd.notna(fk_y) and TW.is_past(fk_x, fk_y))
+                         else "outside_trailer")
 
         scenes.append({
             "scenario_id":  scn_id,
@@ -209,7 +219,7 @@ def write_manifest(scenes: list[dict], out_dir: Path) -> None:
 
 
 def main() -> None:
-    global TW_X, VST_BASE, SENSORS
+    global TW, VST_BASE, SENSORS
     ap = argparse.ArgumentParser()
     ap.add_argument("parquet_in", type=Path)
     ap.add_argument("out_dir", type=Path, nargs="?", default=None)
@@ -226,10 +236,10 @@ def main() -> None:
     args = ap.parse_args()
 
     # Apply runtime overrides to module-level constants used by split()/write_manifest()
-    TW_X = load_tw_x(args.calib if args.calib and args.calib.exists() else None)
+    TW = load_tripwire(args.calib if args.calib and args.calib.exists() else None)
     VST_BASE = args.vst_base_url.rstrip("/")
     SENSORS = tuple(s.strip() for s in args.sensors.split(",") if s.strip())
-    print(f"[tw_split] TW_X={TW_X} · VST={VST_BASE} · sensors={SENSORS}")
+    print(f"[tw_split] TW={TW} · VST={VST_BASE} · sensors={SENSORS}")
 
     out_dir = args.out_dir or (args.parquet_in.parent / "scenes")
     scenes = split(args.parquet_in, out_dir, source=args.source)


### PR DESCRIPTION
Follow-up to the review feedback on the develop-update thread: the forklift in-trailer rule was hardcoded as `fx > tw_x`, assuming a vertical tripwire with the trailer on the +x side. The same assumption also lived in `tw_split.py` (the clip-boundary detector) and `clip_logs.py` (per-clip GT csv) — a tripwire drawn at any other orientation would silently produce wrong in-trailer flags, wrong expected-mute, and wrong clip boundaries.

**Fix:** new shared `srr/tripwire.py` — `Tripwire` built from the calibration's `wire` + `direction` fields. The direction arrow defines the entry sense, so the side its head lies on is the inside/trailer side:
- `is_inside()` — inside half-plane + within wire extent (replaces `fx > tw_x and y_min <= fy <= y_max`)
- `is_past()` — half-plane only, infinite-line semantics (what tw_split's crossing detector used)
- `line_distance()` — perpendicular distance to the wire line (replaces `abs(x - tw_x)` in the trailer-boundary slice)

Legacy fallback (vertical wire, inside = +x) when the calibration has no usable `direction`. The `tw_x` key in report JSON is kept for viewer compatibility.

**Verification — output-identical on existing runs** (the current scene's wire IS vertical, so all previously published numbers stand):
- aggregator A/B on a real run (old code vs new): `summary.md` identical, every metric identical; the only diff is the intended report label text
- tw_split A/B: same 11 clips, manifest fields identical, all clip parquets md5-identical
- 20k-point randomized equivalence test vs the old formulas (inside / past / distance): pass
- geometry unit checks: reversed direction flips the inside side; 45°-diagonal wire sides + perpendicular distances correct; missing-direction fallback matches legacy