### PR TITLE
fix(regression-reporter): make scene-ready gate profile-aware (2D vs 3D)

### DIFF
--- a/closed-loop-testing/regression-reporter/halos-integration/default_config_ros.yaml.template
+++ b/closed-loop-testing/regression-reporter/halos-integration/default_config_ros.yaml.template
@@ -43,7 +43,8 @@
 #   2. Camera / VST streaming — SRR perception needs the 3 calibrated cameras
 #      (Camera, Camera_01, Camera_02). run_actor_sdg.py is launched with
 #      --cameras-config cameras.yaml and --enable-vst; confirm frames reach VST /
-#      perception (run_multi's scene-ready gate waits on mdx-bev detections).
+#      perception (run_multi's scene-ready gate waits on the perception signal —
+#      mdx-bev detections for 3D, mdx-events for 2D/Phase-1).
 isaacsim.replicator.agent:
   version: 1.6.0
   seed: 42

--- a/closed-loop-testing/regression-reporter/scripts/run_multi.sh
+++ b/closed-loop-testing/regression-reporter/scripts/run_multi.sh
@@ -277,45 +277,74 @@ phase_vst_workaround() {
 }
 
 # Bare-run scene-ready gate (when the skill isn't orchestrating the agent
-# check). After a compose restart the 3D scene takes ~3 min to load; until then
-# perception emits EMPTY mdx-bev frames, so a "has any message" check gives a
-# false-positive. We therefore require real detections (decoded objects > 0)
-# before recording. Falls back to proceeding after SCENE_READY_TIMEOUT_S so we
-# never hang forever.
+# check). After a compose restart the scene takes ~3 min to load; until then the
+# perception pipeline emits nothing useful, so a "has any message" check gives a
+# false-positive. We therefore require a REAL perception signal before recording.
+# Falls back to proceeding after SCENE_READY_TIMEOUT_S so we never hang forever.
+#
+# Profile-aware (2D vs 3D). The signal we poll depends on the deploy profile,
+# mirroring srr-service's BEV_TOPIC default (os.environ.get("BEV_TOPIC","mdx-bev")):
+#   * 3D (Sparse4D)  — BEV_TOPIC set (default `mdx-bev`): the perception signal is
+#     real decoded 3D detections on $BEV_TOPIC. Gate on decoded objects > 0.
+#   * 2D / Phase-1   — BEV_TOPIC="" (no mdx-bev topic exists): gating on mdx-bev
+#     would never pass and would burn the whole timeout + emit a misleading WARN.
+#     The 2D perception signal is BA events, so gate on `mdx-events` instead.
+# The topic is resolved from the running srr container so the gate never hardcodes
+# a 3D-only topic.
 #
 # The counter is CUMULATIVE, not "consecutive". Perception legitimately
-# interleaves EMPTY mdx-bev frames (e.g. a sparse scene where only one actor is
-# in FOV, like `fast`), so the old "2 consecutive hits, hard-reset on any miss"
-# gate false-timed-out on such scenes and burned the whole timeout before
-# proceeding — even though detections were flowing. We now accumulate hits and
-# only decay the counter after several consecutive empty polls (never below 0),
-# so intermittent empties don't wipe progress. Tunables: SCENE_READY_HITS
-# (non-empty polls needed) and SCENE_READY_MISS_DECAY (consecutive empties that
-# drop one hit).
+# interleaves EMPTY frames (e.g. a sparse scene where only one actor is in FOV,
+# like `fast`), so the old "2 consecutive hits, hard-reset on any miss" gate
+# false-timed-out on such scenes and burned the whole timeout before proceeding —
+# even though detections were flowing. We now accumulate hits and only decay the
+# counter after several consecutive empty polls (never below 0), so intermittent
+# empties don't wipe progress. Tunables: SCENE_READY_HITS (non-empty polls needed)
+# and SCENE_READY_MISS_DECAY (consecutive empties that drop one hit).
 SCENE_READY_TIMEOUT_S="${SCENE_READY_TIMEOUT_S:-360}"
 SCENE_READY_HITS="${SCENE_READY_HITS:-2}"
 SCENE_READY_MISS_DECAY="${SCENE_READY_MISS_DECAY:-3}"
 phase_wait_scene_ready() {
-  log "Waiting for scene-ready (mdx-bev detections, need ${SCENE_READY_HITS} non-empty polls, timeout ${SCENE_READY_TIMEOUT_S}s)..."
-  local waited=0 step=10 hits=0 misses=0
-  while [ "$waited" -lt "$SCENE_READY_TIMEOUT_S" ]; do
-    # Decode mdx-bev in the srr container; exit 0 only if objects > 0.
-    if docker exec srr python3 -c "
+  # Resolve the deploy profile exactly like srr-service does: unset BEV_TOPIC
+  # defaults to mdx-bev (3D); an explicit empty string means 2D / Phase-1-only.
+  # Fall back to mdx-bev (3D, prior behaviour) if the container can't be queried.
+  local bev_topic probe_py signal
+  bev_topic="$(docker exec srr python3 -c 'import os; print(os.environ.get("BEV_TOPIC","mdx-bev"))' 2>/dev/null || echo mdx-bev)"
+  if [ -n "$bev_topic" ]; then
+    signal="3D detections (${bev_topic})"
+    # Decode $bev_topic in the srr container; exit 0 only if decoded objects > 0.
+    probe_py="
 from kafka import KafkaConsumer
 from srr.kafka_consumer import parse_mdx_bev_bytes
-c=KafkaConsumer('mdx-bev', bootstrap_servers='localhost:9092', auto_offset_reset='latest', value_deserializer=None, consumer_timeout_ms=8000)
+c=KafkaConsumer('${bev_topic}', bootstrap_servers='localhost:9092', auto_offset_reset='latest', value_deserializer=None, consumer_timeout_ms=8000)
 n=0
 for m in c:
     if (parse_mdx_bev_bytes(m.value).get('detections') or []): n+=1
     if n>=1: break
 import sys; sys.exit(0 if n>=1 else 1)
-" >/dev/null 2>&1; then
+"
+  else
+    signal="2D BA events (mdx-events)"
+    # 2D has no mdx-bev topic; the perception signal is BA events on mdx-events.
+    probe_py="
+from kafka import KafkaConsumer
+c=KafkaConsumer('mdx-events', bootstrap_servers='localhost:9092', auto_offset_reset='latest', consumer_timeout_ms=8000)
+n=0
+for _ in c:
+    n+=1
+    if n>=1: break
+import sys; sys.exit(0 if n>=1 else 1)
+"
+  fi
+  log "Waiting for scene-ready (${signal}, need ${SCENE_READY_HITS} non-empty polls, timeout ${SCENE_READY_TIMEOUT_S}s)..."
+  local waited=0 step=10 hits=0 misses=0
+  while [ "$waited" -lt "$SCENE_READY_TIMEOUT_S" ]; do
+    if docker exec srr python3 -c "$probe_py" >/dev/null 2>&1; then
       hits=$((hits + 1)); misses=0
-      log "  detections seen (${hits}/${SCENE_READY_HITS}) at T+${waited}s"
-      [ "$hits" -ge "$SCENE_READY_HITS" ] && { log "scene-ready: detections flowing."; return 0; }
+      log "  signal seen (${hits}/${SCENE_READY_HITS}) at T+${waited}s"
+      [ "$hits" -ge "$SCENE_READY_HITS" ] && { log "scene-ready: perception signal flowing."; return 0; }
     else
       misses=$((misses + 1))
-      # Tolerate intermittent EMPTY mdx-bev frames: only decay one hit after
+      # Tolerate intermittent empty polls: only decay one hit after
       # SCENE_READY_MISS_DECAY consecutive empties, and never below 0 — no hard
       # reset (that was the false-timeout bug on sparse scenes).
       if [ "$misses" -ge "$SCENE_READY_MISS_DECAY" ] && [ "$hits" -gt 0 ]; then

--- a/closed-loop-testing/regression-reporter/scripts/run_multi.sh
+++ b/closed-loop-testing/regression-reporter/scripts/run_multi.sh
@@ -324,10 +324,24 @@ import sys; sys.exit(0 if n>=1 else 1)
 "
   else
     signal="2D BA events (mdx-events)"
-    # 2D has no mdx-bev topic; the perception signal is BA events on mdx-events.
+    # 2D / Phase-1 has no mdx-bev topic; the perception signal is BA events on
+    # mdx-events — the same topic the recorder consumes (KAFKA_TOPIC), so the gate
+    # confirms the exact data path (perception → BA → events), not just raw
+    # perception. mdx-events are REAL, sparse events (ROI entry / TW crossing,
+    # ~every 20-40 s per forklift cycle), not per-frame snapshots — so there is no
+    # EMPTY-frame false-positive and a single caught message is a genuine ready
+    # signal. We therefore use a wider consume window (20 s vs the 8 s dense-3D
+    # feed) so one probe reliably spans the gap between sparse events and the
+    # cumulative-hit counter doesn't decay unfairly while waiting between events.
+    #
+    # NOTE (2D gate semantics): because BA only fires once a real event has
+    # occurred, a 2D "scene-ready" pass means the scenario has already produced
+    # >=1 event — i.e. recording starts a few tens of seconds into the scenario
+    # cycle. Harmless for verdicts (clips are split on forklift TW crossings and
+    # the scenario loops), but the first 2D clip begins mid-cycle by design.
     probe_py="
 from kafka import KafkaConsumer
-c=KafkaConsumer('mdx-events', bootstrap_servers='localhost:9092', auto_offset_reset='latest', consumer_timeout_ms=8000)
+c=KafkaConsumer('mdx-events', bootstrap_servers='localhost:9092', auto_offset_reset='latest', consumer_timeout_ms=20000)
 n=0
 for _ in c:
     n+=1


### PR DESCRIPTION
phase_wait_scene_ready() hard-coded the mdx-bev topic, so on a 2D / Phase-1-only deploy (BEV_TOPIC="") the gate could never see detections: it burned the full SCENE_READY_TIMEOUT_S and printed a misleading "scene-ready timeout" WARN before proceeding.

Resolve the topic from the running srr container, mirroring srr-service's BEV_TOPIC default (os.environ.get("BEV_TOPIC","mdx-bev")):
  * 3D (Sparse4D): gate on real decoded detections on $BEV_TOPIC.
  * 2D / Phase-1 (BEV_TOPIC=""): gate on mdx-events (the 2D perception signal) instead of mdx-bev.

Falls back to mdx-bev (prior behaviour) if the container can't be queried.