### PR TITLE
fix(closed-loop-testing): bump PSF to 1.3 release + required --saim-mode skip

### DIFF
--- a/closed-loop-testing/safety-core/safety-core.yml
+++ b/closed-loop-testing/safety-core/safety-core.yml
@@ -13,6 +13,7 @@ services:
       - ${DOCKER_GID}
     command: >
       --app atl
+      --saim-mode ${PSF_LAUNCH_MODE:-skip}
       --cmd_rx_ip ${PSF_CMD_RX_IP}
       --cmd_rx_port ${COMM_UDP_PORT}
       --sensor-config /opt/nvidia/psf/bin/sensor_config.conf

--- a/deployments/profiles/base.env
+++ b/deployments/profiles/base.env
@@ -18,7 +18,8 @@ MDX_DATA_DIR=/path/to/data # change me
 HOST_IP='' # change me
 
 COMM_UDP_PORT=12345   # PSF cmd target = VST halo_safety_udp_port (NOT comm-layer in base)
-PSF_IMAGE=nvcr.io/nvidia/halos-outside-in/outside-in-safety:nv-psf-halos-1.2.1-3041f93  # public NGC path (multi-arch arm64+amd64, one tag)
+PSF_IMAGE=nvcr.io/nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-release-9105e6e-2026-07-22_10-40
+PSF_LAUNCH_MODE=skip  # skip = PSF without SAIM | learn = record SAIM sensor baselines | active = SAIM live (validates streams vs learned baselines)
 PSF_CMD_RX_IP=127.0.0.1
 PSF_LOG_DIR=${MDX_DATA_DIR}/psf-log
 DOCKER_GID=999 # change me — run: getent group docker | cut -d: -f3

--- a/deployments/profiles/hil-thor.env
+++ b/deployments/profiles/hil-thor.env
@@ -11,13 +11,13 @@ HOST_IP='' # change me — this Thor's IP
 PEER_HOST_IP='' # change me — the x86 stimulus host (comm-layer)
 
 # nv-psf container (multi-arch; Docker selects arm64 on Thor — same tag as the x86 profiles)
-PSF_IMAGE=nvcr.io/nvidia/halos-outside-in/outside-in-safety:nv-psf-halos-1.2.1-3041f93
+PSF_IMAGE=nvcr.io/nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-release-9105e6e-2026-07-22_10-40
 # Thor host packages (install per ngc_artifacts.md §4; keep the SAME build tag as PSF_IMAGE)
-PSF_TEGRA_RESOURCE=nvidia/halos-outside-in/outside-in-safety:nv-psf-halos-1.2.1-aarch64-release-3041f93-psf-tegra         # host binaries .deb (atl_sdm, launch_hoisa, safety_monitor) for CCPLEX + FSI host side
-PSF_TEGRA_FSI_RESOURCE=nvidia/outside-in-safety/outside-in-safety:nv-psf-halos-1.2.1-aarch64-release-3041f93-psf-tegra-fsi  # FSI firmware + fsicom-agent .deb (SDM_TARGET=fsi only)
+PSF_TEGRA_RESOURCE=nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-aarch64-release-9105e6e-2026-07-22_10-37-psf-tegra         # host binaries .deb (atl_sdm, launch_hoisa, safety_monitor) for CCPLEX + FSI host side
+PSF_TEGRA_FSI_RESOURCE=nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-aarch64-release-9105e6e-2026-07-22_10-37-psf-tegra-fsi  # FSI firmware + fsicom-agent .deb (SDM_TARGET=fsi only)
 
 SDM_TARGET=ccplex        # ccplex (host SDM, start here) | fsi (SDM on the Functional Safety Island — halos_thor.md §5B)
-PSF_LAUNCH_MODE=skip     # skip (no AI monitor — recommended for hil) | active (full stack incl. AI monitor)
+PSF_LAUNCH_MODE=skip     # skip = PSF without SAIM | learn = record SAIM sensor baselines | active = SAIM live (validates streams vs learned baselines)
 PSF_CMD_RX_IP=${PEER_HOST_IP}
 PSF_CMD_RX_PORT=12346    # the x86 comm-layer COMM_UDP_PORT (hil.env) — NOT the VST overlay port
 KAFKA_BROKER=localhost:9092                                    # VSS Kafka on this Thor

--- a/deployments/profiles/sil.env
+++ b/deployments/profiles/sil.env
@@ -21,7 +21,8 @@ COMM_LOG_DIR=${MDX_DATA_DIR}/comm-layer
 ROS_DOMAIN_ID=0
 
 # === PSF ===
-PSF_IMAGE=nvcr.io/nvidia/halos-outside-in/outside-in-safety:nv-psf-halos-1.2.1-3041f93  # public NGC path (multi-arch arm64+amd64, one tag)
+PSF_IMAGE=nvcr.io/nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-release-9105e6e-2026-07-22_10-40
+PSF_LAUNCH_MODE=skip  # skip = PSF without SAIM | learn = record SAIM sensor baselines | active = SAIM live (validates streams vs learned baselines)
 PSF_CMD_RX_IP=127.0.0.1
 PSF_LOG_DIR=${MDX_DATA_DIR}/psf-log
 


### PR DESCRIPTION
## Problem

The 1.3 PSF container bundles SAIM and its launcher now requires an explicit `--saim-mode` flag — without it `safety-core` crash-loops on startup (observed: 12 restarts before intervention).

## Fix

- `safety-core.yml`: pass `--saim-mode ${PSF_LAUNCH_MODE:-skip}` in the launch command. SIL runs ATL-only with SAIM off, so the default `skip` preserves the existing behavior on the new image. The knob reuses the name (and `skip`/`learn`/`active` values) the Thor profiles already use for `launch_hoisa --mode` — one concept, one variable across profiles.
- `deployments/profiles/{base,sil}.env`: bump `PSF_IMAGE` to `nv-psf-halos-1.3-release-9105e6e-2026-07-22_10-40` (multi-arch) and add `PSF_LAUNCH_MODE=skip` with the three modes documented inline.
- `deployments/profiles/hil-thor.env`: bump to the matching 1.3 build — same multi-arch image tag plus the aarch64 host packages (`...-2026-07-22_10-37-psf-tegra` / `-psf-tegra-fsi`, same `9105e6e` batch); document the `skip`/`learn`/`active` modes on the existing `PSF_LAUNCH_MODE`.

`base-thor.env` keeps its 1.2.1 pins and is bumped separately once validated.

## Validation

Verified on a SIL host: with the 1.3 image and `--saim-mode skip`, `safety-core` starts clean and behaves as before (ATL-only, SAIM off). The hil-thor package pins are the latest 1.3 release artifacts on NGC (verified against the registry); Thor-side runtime validation pending.