### PR TITLE
fix(closed-loop-testing): bump base-thor PSF to 1.3 release

### DIFF
--- a/deployments/profiles/base-thor.env
+++ b/deployments/profiles/base-thor.env
@@ -9,15 +9,15 @@
 HOST_IP='' # change me — this Thor's IP
 
 # === Safety Core image (nv-psf container, multi-arch arm64+amd64, one tag) ===
-PSF_IMAGE=nvcr.io/nvidia/halos-outside-in/outside-in-safety:nv-psf-halos-1.2.1-3041f93  # multi-arch; Docker auto-selects arm64 on Thor (same tag as x86 base.env)
+PSF_IMAGE=nvcr.io/nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-release-9105e6e-2026-07-22_10-40  # multi-arch; Docker auto-selects arm64 on Thor (same tag as x86 base.env)
 
 # === Thor Safety Core packages (NGC resources, downloaded once at setup; ngc_artifacts.md §4) ===
-PSF_TEGRA_RESOURCE=nvidia/halos-outside-in/outside-in-safety:nv-psf-halos-1.2.1-aarch64-release-3041f93-psf-tegra         # host binaries .deb (atl_sdm, launch_hoisa, safety_monitor) for CCPLEX + FSI host side
-PSF_TEGRA_FSI_RESOURCE=nvidia/outside-in-safety/outside-in-safety:nv-psf-halos-1.2.1-aarch64-release-3041f93-psf-tegra-fsi  # FSI firmware + fsicom-agent .deb (SDM_TARGET=fsi only)
+PSF_TEGRA_RESOURCE=nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-aarch64-release-9105e6e-2026-07-22_10-37-psf-tegra         # host binaries .deb (atl_sdm, launch_hoisa, safety_monitor) for CCPLEX + FSI host side
+PSF_TEGRA_FSI_RESOURCE=nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-aarch64-release-9105e6e-2026-07-22_10-37-psf-tegra-fsi  # FSI firmware + fsicom-agent .deb (SDM_TARGET=fsi only)
 
 # === SDM placement / launch mode ===
 SDM_TARGET=ccplex        # ccplex (host SDM, start here) | fsi (SDM on the Functional Safety Island — halos_thor.md §5B)
-PSF_LAUNCH_MODE=active   # active (full stack) | skip (omit the AI monitor)
+PSF_LAUNCH_MODE=active   # skip = PSF without SAIM | learn = record SAIM sensor baselines | active = SAIM live (validates streams vs learned baselines)
 
 # === Safety command sink — the VST halo_safety overlay ===
 PSF_CMD_RX_IP=127.0.0.1


### PR DESCRIPTION
## Problem

PR #33 bumped `base`, `sil`, and `hil-thor` to the 1.3 PSF build but missed `base-thor.env` — it was still pinned to `nv-psf-halos-1.2.1-3041f93`, leaving the four profiles inconsistent.

## Fix

Bring `base-thor.env` to the same 1.3 build as the other profiles:
- `PSF_IMAGE` → multi-arch `nv-psf-halos-1.3-release-9105e6e-2026-07-22_10-40`
- `PSF_TEGRA_RESOURCE` / `PSF_TEGRA_FSI_RESOURCE` → aarch64 `...-2026-07-22_10-37-psf-tegra` / `-psf-tegra-fsi`, same `9105e6e` batch
- document the `skip`/`learn`/`active` modes inline on `PSF_LAUNCH_MODE` (default kept at `active`)

## Validation

Pins are the latest 1.3 release artifacts on NGC (verified against the registry). Thor-side runtime validation is still pending, same as the other Thor profile.
