### PR TITLE
fix(regression-reporter): derive scene-ready topic from VSS MODE (single source of truth)

### DIFF
--- a/closed-loop-testing/regression-reporter/.env.example
+++ b/closed-loop-testing/regression-reporter/.env.example
@@ -14,9 +14,21 @@
 # REQUIRED: absolute path to the halos-outside-in-safety repo root.
 HOISA_ROOT_PATH=/path/to/halos-outside-in-safety
 
+# REQUIRED: root of the VSS (video-search-and-summarization) checkout that
+# provides the perception backend. Everything VSS-side derives from it, so the
+# path lives in ONE place. Must be defined before the vars that reference it.
+VSS_ROOT_PATH=/path/to/video-search-and-summarization
+
+# VSS warehouse env — source of MODE (2d|3d|mv3dt). The scene-ready gate reads
+# it to pick its perception topic automatically (2d -> mdx-raw, 3d/mv3dt ->
+# mdx-bev), so the same run_multi works on a 2D or 3D host with no extra config.
+ENV_VSS_PATH=${VSS_ROOT_PATH}/deploy/docker/industry-profiles/warehouse-operations/.env
+
 # REQUIRED: VSS calibration JSON (host path; mounts into SRR container).
 # Loaded by srr.aggregator and srr.tw_split for ROI polygon and tripwire X.
-CALIBRATION_JSON=/path/to/video-search-and-summarization/deploy/docker/industry-profiles/warehouse-operations/warehouse-3d-app/calibration/sample-data/warehouse-loading-dock-3cams-synthetic-3d/calibration.json
+# Default below is the 2D warehouse sample. For 3D (Sparse4D) use instead:
+#   CALIBRATION_JSON=${VSS_ROOT_PATH}/deploy/docker/industry-profiles/warehouse-operations/warehouse-3d-app/calibration/sample-data/warehouse-loading-dock-3cams-synthetic-3d/calibration.json
+CALIBRATION_JSON=${VSS_ROOT_PATH}/deploy/docker/industry-profiles/warehouse-operations/warehouse-2d-app/calibration/sample-data/warehouse-loading-dock-3cams-synthetic/calibration.json
 
 # Where SRR test outputs land. Default: <repo>/srr-service/runs (gitignored).
 # RUNS_HOST_DIR=./srr-service/runs
@@ -33,3 +45,9 @@ SENSORS=Camera,Camera_01,Camera_02
 
 # Kafka topic the SRR consumer reads from (matches VSS perception output).
 KAFKA_TOPIC=mdx-events
+
+# Kafka topic the scene-ready gate polls for live perception detections.
+# Normally LEFT UNSET — the gate auto-derives it from the VSS MODE (via
+# ENV_VSS_PATH): 2d -> mdx-raw (DeepStream), 3d/mv3dt -> mdx-bev (Sparse4D/BEV).
+# Set this only to force a topic (overrides the auto-detection).
+# SCENE_READY_TOPIC=mdx-raw

--- a/closed-loop-testing/regression-reporter/scripts/run_multi.sh
+++ b/closed-loop-testing/regression-reporter/scripts/run_multi.sh
@@ -291,15 +291,12 @@ phase_vst_workaround() {
 # false-positive. We therefore require a REAL perception signal before recording.
 # Falls back to proceeding after SCENE_READY_TIMEOUT_S so we never hang forever.
 #
-# Profile-aware (2D vs 3D). The signal we poll depends on the deploy profile,
-# mirroring srr-service's BEV_TOPIC default (os.environ.get("BEV_TOPIC","mdx-bev")):
-#   * 3D (Sparse4D)  — BEV_TOPIC set (default `mdx-bev`): the perception signal is
-#     real decoded 3D detections on $BEV_TOPIC. Gate on decoded objects > 0.
-#   * 2D / Phase-1   — BEV_TOPIC="" (no mdx-bev topic exists): gating on mdx-bev
-#     would never pass and would burn the whole timeout + emit a misleading WARN.
-#     The 2D perception signal is BA events, so gate on `mdx-events` instead.
-# The topic is resolved from the running srr container so the gate never hardcodes
-# a 3D-only topic.
+# Profile-aware (2D vs 3D). The topic we poll is chosen by the deploy MODE
+# (resolve_scene_ready_topic, below): 2d -> mdx-raw (DeepStream), 3d/mv3dt ->
+# mdx-bev (Sparse4D/BEV). Both carry the same nv.Frame protobuf, so one decoder
+# covers both and we always require decoded detections > 0 (a real perception
+# signal, not "has any message"). MODE comes from the VSS warehouse env, so the
+# gate never hardcodes a mode-specific topic.
 #
 # The counter is CUMULATIVE, not "consecutive". Perception legitimately
 # interleaves EMPTY frames (e.g. a sparse scene where only one actor is in FOV,
@@ -312,56 +309,46 @@ phase_vst_workaround() {
 SCENE_READY_TIMEOUT_S="${SCENE_READY_TIMEOUT_S:-360}"
 SCENE_READY_HITS="${SCENE_READY_HITS:-2}"
 SCENE_READY_MISS_DECAY="${SCENE_READY_MISS_DECAY:-3}"
+# Which Kafka topic carries the perception signal depends on the deploy MODE.
+# Resolve it once, in priority order:
+#   1. explicit SCENE_READY_TOPIC override (set in .env to force a topic)
+#   2. auto-derive from the VSS warehouse env's MODE (ENV_VSS_PATH): the same
+#      nv.Frame protobuf flows on mdx-raw for 2d (DeepStream) and mdx-bev for
+#      3d/mv3dt (Sparse4D/BEV), so one decoder covers both — only the topic
+#      differs by mode. Reading MODE from the VSS deployment's own env keeps a
+#      single source of truth (no 2D/3D flag duplicated on the SRR side).
+#   3. fall back to mdx-bev (prior default) when neither is available.
+resolve_scene_ready_topic() {
+  if [ -n "${SCENE_READY_TOPIC:-}" ]; then printf '%s' "$SCENE_READY_TOPIC"; return; fi
+  local mode=""
+  [ -n "${ENV_VSS_PATH:-}" ] && [ -f "$ENV_VSS_PATH" ] && \
+    mode=$(grep -sE '^MODE=' "$ENV_VSS_PATH" | head -1 | cut -d= -f2 | tr -d ' "'"'"'' || true)
+  case "$mode" in
+    2d)        printf 'mdx-raw' ;;
+    3d|mv3dt)  printf 'mdx-bev' ;;
+    *)         printf 'mdx-bev' ;;
+  esac
+}
 phase_wait_scene_ready() {
-  # Resolve the deploy profile exactly like srr-service does: unset BEV_TOPIC
-  # defaults to mdx-bev (3D); an explicit empty string means 2D / Phase-1-only.
-  # Fall back to mdx-bev (3D, prior behaviour) if the container can't be queried.
-  local bev_topic probe_py signal
-  bev_topic="$(docker exec srr python3 -c 'import os; print(os.environ.get("BEV_TOPIC","mdx-bev"))' 2>/dev/null || echo mdx-bev)"
-  if [ -n "$bev_topic" ]; then
-    signal="3D detections (${bev_topic})"
-    # Decode $bev_topic in the srr container; exit 0 only if decoded objects > 0.
-    probe_py="
+  # Pick the perception topic by deploy MODE (resolve_scene_ready_topic);
+  # decode it and require real detections > 0. One code path covers 2d (mdx-raw)
+  # and 3d/mv3dt (mdx-bev) since both carry the same nv.Frame protobuf.
+  local topic probe_py signal
+  topic="$(resolve_scene_ready_topic)"
+  signal="perception detections (${topic})"
+  probe_py="
 from kafka import KafkaConsumer
 from srr.kafka_consumer import parse_mdx_bev_bytes
-c=KafkaConsumer('${bev_topic}', bootstrap_servers='localhost:9092', auto_offset_reset='latest', value_deserializer=None, consumer_timeout_ms=8000)
+c=KafkaConsumer('${topic}', bootstrap_servers='localhost:9092', auto_offset_reset='latest', value_deserializer=None, consumer_timeout_ms=8000)
 n=0
-# Bound the scan: consumer_timeout_ms only fires when the topic goes IDLE, so
-# a busy topic streaming all-EMPTY frames would otherwise keep this loop (and
-# the whole gate poll) blocked indefinitely. ~500 messages ≈ one 15-20 s look
-# at a 30 Hz feed — plenty to catch a real detection.
+# Bound the scan: consumer_timeout_ms only fires when the topic goes IDLE, so a
+# busy topic streaming all-EMPTY frames would otherwise block this loop (and the
+# whole gate poll) indefinitely. ~500 messages is one 15-20 s look at a 30 Hz feed.
 for i, m in enumerate(c):
     if (parse_mdx_bev_bytes(m.value).get('detections') or []): n+=1
     if n>=1 or i>=500: break
 import sys; sys.exit(0 if n>=1 else 1)
 "
-  else
-    signal="2D BA events (mdx-events)"
-    # 2D / Phase-1 has no mdx-bev topic; the perception signal is BA events on
-    # mdx-events — the same topic the recorder consumes (KAFKA_TOPIC), so the gate
-    # confirms the exact data path (perception → BA → events), not just raw
-    # perception. mdx-events are REAL, sparse events (ROI entry / TW crossing,
-    # ~every 20-40 s per forklift cycle), not per-frame snapshots — so there is no
-    # EMPTY-frame false-positive and a single caught message is a genuine ready
-    # signal. We therefore use a wider consume window (20 s vs the 8 s dense-3D
-    # feed) so one probe reliably spans the gap between sparse events and the
-    # cumulative-hit counter doesn't decay unfairly while waiting between events.
-    #
-    # NOTE (2D gate semantics): because BA only fires once a real event has
-    # occurred, a 2D "scene-ready" pass means the scenario has already produced
-    # >=1 event — i.e. recording starts a few tens of seconds into the scenario
-    # cycle. Harmless for verdicts (clips are split on forklift TW crossings and
-    # the scenario loops), but the first 2D clip begins mid-cycle by design.
-    probe_py="
-from kafka import KafkaConsumer
-c=KafkaConsumer('mdx-events', bootstrap_servers='localhost:9092', auto_offset_reset='latest', consumer_timeout_ms=20000)
-n=0
-for _ in c:
-    n+=1
-    if n>=1: break
-import sys; sys.exit(0 if n>=1 else 1)
-"
-  fi
   if _scene_ready_wait_once; then return 0; fi
   # A first-pass timeout is more often the empty-DeepStream-pipeline race than
   # a slow scene (healthy scenarios reach ready in well under a minute): the


### PR DESCRIPTION
# fix(regression-reporter): derive scene-ready topic from VSS MODE (single source of truth)

Base: `develop` (branched at the PR#34 merge). One commit, two files: `scripts/run_multi.sh` + `.env.example`.

## Problem

The scene-ready gate must poll the right Kafka topic per deploy mode:
- **2D** DeepStream publishes decoded detections on **`mdx-raw`**
- **3D / mv3dt** Sparse4D/BEV publishes on **`mdx-bev`**

Both carry the same `nv.Frame` protobuf, so one decoder covers both — only the topic differs. The current gate (PR#30) selects the 2D path via `BEV_TOPIC` and gates it on **`mdx-events` "any message"**, which is a *behaviour-analytics event*, not raw perception: it can pass on a stale/sparse BA event while DeepStream is actually dead, and it needs a wide 20 s window because BA events are sparse.

## Change

`resolve_scene_ready_topic()` picks the topic once, in priority order:
1. explicit `SCENE_READY_TOPIC` override (force a topic)
2. **VSS `MODE`** read from the warehouse env via new **`ENV_VSS_PATH`** (derived from `VSS_ROOT_PATH`): `2d → mdx-raw`, `3d|mv3dt → mdx-bev`
3. fall back to `mdx-bev`

and the gate now **always decodes + requires detections > 0** — a real perception-liveness signal, which is exactly what the empty-DeepStream-pipeline race (the reprovision retry added in PR#32) needs to detect. One code path replaces the two-branch BEV_TOPIC block.

`.env.example`: adds `VSS_ROOT_PATH` (single source of truth for the VSS checkout) + `ENV_VSS_PATH`; derives `CALIBRATION_JSON` from `VSS_ROOT_PATH` (defaults to the 2D sample, 3D shown as a commented alternative); documents `SCENE_READY_TOPIC` as normally unset.

## Why read MODE from the VSS env

`MODE` lives in the VSS deployment's own `.env` (`.../warehouse-operations/.env`). Reading it there keeps a single source of truth — no 2D/3D flag duplicated on the SRR side — so the **same `run_multi` works on a 2D or 3D host with no per-host config**.

## Migration

2D hosts now set `VSS_ROOT_PATH` (so the gate auto-resolves `mdx-raw`) instead of relying on `BEV_TOPIC=""` for gate topic selection. `BEV_TOPIC` still governs `service.py`'s Phase-2 `mdx-bev` consumer — unchanged.

## Validation

- Backward-compatible defaults: no `ENV_VSS_PATH` / unknown MODE → `mdx-bev` (prior default). Explicit `SCENE_READY_TOPIC` still wins.
- Resolver unit-tested: `MODE=2d → mdx-raw`, `MODE=3d → mdx-bev`, no-env → `mdx-bev`, override → honoured. The MODE grep is guarded with `|| true`: under `set -euo pipefail`, a present-but-MODE-less env file makes the grep pipeline exit 1, and that assignment is the final command of an `&&` chain — which **does** trip `set -e` on bash 5.1.16 (verified). The guard makes it fall through to the `mdx-bev` fallback as intended instead of aborting the run.
- `CALIBRATION_JSON=${VSS_ROOT_PATH}/...` verified to expand in both `docker compose config` (v2 5.3.1) and bash `source`.
- End-to-end on a live 2D warehouse SIL host: gate resolves `mdx-raw`, smoke `balanced:300` PASS.
- `bash -n` clean.
