### PR TITLE
fix(hil): pin R101 3D model for hil-thor + correct IGX-Thor DeepStream profile docs

### DIFF
--- a/deployments/profiles/hil-thor.env
+++ b/deployments/profiles/hil-thor.env
@@ -22,3 +22,11 @@ PSF_CMD_RX_IP=${PEER_HOST_IP}
 PSF_CMD_RX_PORT=12346    # the x86 comm-layer COMM_UDP_PORT (hil.env) — NOT the VST overlay port
 KAFKA_BROKER=localhost:9092                                    # VSS Kafka on this Thor
 PSF_SENSOR_CONFIG=/opt/nvidia/psf/bin/sensor_config_thor.conf  # copy from closed-loop-testing/safety-core/configs/, fill the VST re-serve URLs (or use refresh_thor_sensor_config.sh)
+
+# === Perception model — 3D (Sparse4D) profile ONLY ===
+# R101 Sparse4D: a VSS-side perception artifact pulled as a prerequisite onto THIS Thor (where
+# hil runs perception), same as on a single-host sil box. Download BOTH — deployable = inference
+# ONNX, trainable = the kmeans anchor .npy — see references/model_r101.md. The 2D profile does
+# NOT use these. Public NGC TAO catalog; both MUST be the same version.
+R101_DEPLOYABLE_RESOURCE=nvidia/tao/sparse4d_rn101:deployable_v2.2  # inference ONNX
+R101_TRAINABLE_RESOURCE=nvidia/tao/sparse4d_rn101:trainable_v2.2    # checkpoint + kmeans anchor .npy

--- a/skills/hoisa-deploy-profile/references/halos_thor.md
+++ b/skills/hoisa-deploy-profile/references/halos_thor.md
@@ -45,9 +45,11 @@ On a `base` deploy the skill detects the platform: x86 runs the standard contain
 ## 1. Prerequisites (Thor)
 
 - IGX Thor flashed with a current IGX SW **GA release** (RT kernel `6.8.0-1019-nvidia-tegra-rt`).
-  The GA release resolves the earlier IGX-Thor perception (VIC) issue, so **no extra DeepStream
-  config edits are needed on VSS 3.2.1** (pre-GA non-RT stacks needed `compute-hw=1` plus a
-  camera-count reduction; the GA release removes that need).
+  **No manual DeepStream edits are needed on VSS 3.2.x**: selecting `HARDWARE_PROFILE=IGX-THOR`
+  (the `vss-deploy-profile` skill sets it) makes the blueprint-configurator apply the
+  Thor-specific tuning automatically — including using the VIC for tracker scaling
+  (`compute-hw=2`, the path the GA RT release fixed). (Pre-GA non-RT stacks needed a hand-set
+  `compute-hw` plus a camera-count reduction.)
 - NVIDIA driver, Container Toolkit, and Docker per `prerequisites.md`.
 - The **nv-psf container image** — multi-arch (arm64 + amd64) under one tag; Docker on Thor
   (arm64) auto-selects the arm64 variant, so it is the **same tag** as the x86 `base` profile.
@@ -63,10 +65,10 @@ On a `base` deploy the skill detects the platform: x86 runs the standard contain
 
 ## 2. Deploy VSS Warehouse 3.2.1 on Thor (perception)
 
-Deploy VSS Warehouse 3.2.1 (2D) on the Thor via the `vss-deploy-profile` skill. The GA RT
-release resolves the perception VIC issue, so the old `compute-hw=1` / nvmap edits are **not**
-needed on 3.2.1. Wait until perception serves all cameras (`Active sources : 3`) and the
-`mdx-events` Kafka topic has data. See `vss_2d_overrides.md` for the base-vs-SIL override notes.
+Deploy VSS Warehouse 3.2.1 (2D) on the Thor via the `vss-deploy-profile` skill (set
+`HARDWARE_PROFILE=IGX-THOR`; the profile applies the Thor DeepStream tuning for you — §1). Wait
+until perception serves all cameras (`Active sources : 3`) and the `mdx-events` Kafka topic has
+data. See `vss_2d_overrides.md` for the base-vs-SIL override notes.
 
 > **⚠ Two IGX-Thor VSS workarounds.** These apply to the VSS Warehouse deployment itself, but
 > are noted here because they otherwise block the Safety Core from receiving any perception data:

--- a/skills/hoisa-deploy-profile/references/model_r101.md
+++ b/skills/hoisa-deploy-profile/references/model_r101.md
@@ -9,7 +9,7 @@ place the R101 model so the 3D perception `config.yaml` (see `vss_3d_overrides.m
 > This is a **perception (VSS)** artifact, not a Halos artifact. It ships in the **public NGC
 > TAO catalog** (`nvidia/tao/sparse4d_rn101`) and is pinned in the profile env as
 > `R101_DEPLOYABLE_RESOURCE` / `R101_TRAINABLE_RESOURCE` (`deployments/profiles/sil.env` |
-> `base.env`, 3D-profile-only). Both packages must be the **same version**.
+> `base.env` | `hil-thor.env`, 3D-profile-only). Both packages must be the **same version**.
 
 ---
 

--- a/skills/hoisa-deploy-profile/references/vss_hil_overrides.md
+++ b/skills/hoisa-deploy-profile/references/vss_hil_overrides.md
@@ -54,3 +54,5 @@ On a Thor that ran VSS before, tear the stack down and wipe the Kafka volumes be
 ## 5. Verify
 
 Use the profile doc's "Verification After Deploy" (`vss_2d_overrides.md` / `vss_3d_overrides.md`) plus the FPS-based poll in `test_scenario.md`. Expect the delivered fps to track the Isaac render rate (well below the nominal stream rate) - that is the simulation, not a network fault.
+
+On an IGX Thor the 3D (Sparse4D) app also runs at half rate: the `IGX-THOR` profile sets `config.yaml interval: 1` (one of the DeepStream keys the blueprint-configurator applies for the Thor — `halos_thor.md` §1). That is deliberate for real 30fps cameras a Thor can't sustain, but a hil source is Isaac, which renders lower and leaves the iGPU with headroom, so the halving is often pure loss. To run hil at the full render rate set `interval: 0` - same configurator-rewrite caveat as §3 (change it in `blueprint_config.yml` before `up`, or edit the generated `config.yaml` after the configurator finishes and restart the perception container). Don't lower the Thor default for `base` / real-camera deploys.


### PR DESCRIPTION
## What

Two HIL-facing gaps in the hoisa-deploy-profile skill, surfaced while validating the IGX-Thor 3D path. Neither is tied to a VSS version.

## Changes

- **`hil-thor.env`** — add `R101_DEPLOYABLE_RESOURCE` / `R101_TRAINABLE_RESOURCE` (`v2.2`, matching `base.env` / `sil.env`). The `hil` profile supports the 3D (Sparse4D) backend, but the R101 pins were only in `base.env`/`sil.env`; a 3D `hil` deploy sourcing `hil-thor.env` hit empty vars at `model_r101.md`'s download step. `model_r101.md` now lists `hil-thor.env` among the pinned-in envs.
- **`halos_thor.md`** — correct the IGX-Thor perception framing. The old text said the GA release "resolves the VIC issue, so no DeepStream edits are needed". In fact selecting `HARDWARE_PROFILE=IGX-THOR` (the `vss-deploy-profile` skill sets it) makes the blueprint-configurator apply the Thor tuning automatically — including using the VIC for tracker scaling (`compute-hw=2`). De-duplicated the repeated note in §2.
- **`vss_hil_overrides.md`** — note that the IGX-THOR profile sets the 3D app to `config.yaml interval: 1` (halves the perception rate). That is deliberate for real 30fps cameras a Thor can't sustain; for a `hil` Isaac source (renders lower, iGPU has headroom) you can set `interval: 0` for the full rate — without lowering the Thor default that `base` / real-camera deploys rely on.

## Scope

Docs + one profile env; no code. `base` / `sil` / 2D / 3D override files untouched. IGX-THOR profile behaviour is referenced (owned by `vss-deploy-profile` / `blueprint_config.yml`), not duplicated.