### PR TITLE
fix some srr bug

### DIFF
--- a/closed-loop-testing/regression-reporter/.env.example
+++ b/closed-loop-testing/regression-reporter/.env.example
@@ -39,6 +39,17 @@ CALIBRATION_JSON=${VSS_ROOT_PATH}/deploy/docker/industry-profiles/warehouse-oper
 # PSS_LOG_SRC=/path/to/sil-data/psf-log/pss.log
 # SIL_DATA_DIR=/path/to/sil-data
 
+# OPTIONAL: snapshot strictness. When a per-scenario pss.log snapshot fails,
+# run_multi.sh aborts the whole sweep by default — the forensic log is destroyed
+# by the next scenario's compose restart, so a failed snapshot loses it for good.
+# Set 0 to downgrade to a non-fatal warning and keep sweeping (tolerate one lost log).
+# SRR_PSS_STRICT=1
+
+# OPTIONAL: profile env that snapshot_pss.sh sources to resolve the pss.log data
+# root when run STANDALONE (from run_multi.sh the profile is already sourced).
+# Defaults to <repo>/deployments/profiles/sil.env; override for a non-sil profile.
+# SIL_ENV=/path/to/deployments/profiles/hil.env
+
 # VSS sensor names — must match the deployed scene topology.
 # These are NOT in calibration.json, hence configured here.
 SENSORS=Camera,Camera_01,Camera_02

--- a/closed-loop-testing/regression-reporter/.env.example
+++ b/closed-loop-testing/regression-reporter/.env.example
@@ -48,7 +48,7 @@ CALIBRATION_JSON=${VSS_ROOT_PATH}/deploy/docker/industry-profiles/warehouse-oper
 # OPTIONAL: profile env that snapshot_pss.sh sources to resolve the pss.log data
 # root when run STANDALONE (from run_multi.sh the profile is already sourced).
 # Defaults to <repo>/deployments/profiles/sil.env; override for a non-sil profile.
-# SIL_ENV=/path/to/deployments/profiles/hil.env
+# SIL_ENV=${HOISA_ROOT_PATH}/deployments/profiles/hil.env
 
 # VSS sensor names — must match the deployed scene topology.
 # These are NOT in calibration.json, hence configured here.

--- a/closed-loop-testing/regression-reporter/scripts/run_multi.sh
+++ b/closed-loop-testing/regression-reporter/scripts/run_multi.sh
@@ -482,7 +482,19 @@ phase_analyze() {
   local scn_host_dir="${RUNS_HOST_BASE}/multi-test-${TIMESTAMP}/${label}"
   if [[ -x "$snap_script" && -d "$scn_host_dir" ]]; then
     log "snapshotting pss.log (per-scn)..."
-    bash "$snap_script" "$scn_host_dir" --per-scn || log "snapshot_pss WARN (non-fatal)"
+    # The per-scenario PSF forensic log is destroyed by the next scenario's
+    # compose restart, so a failed snapshot loses it permanently. Fail the sweep
+    # by default instead of silently warning; set SRR_PSS_STRICT=0
+    # to downgrade to a non-fatal warning (tolerate one lost log, keep sweeping).
+    if ! bash "$snap_script" "$scn_host_dir" --per-scn; then
+      _pss_src="${PSF_LOG_DIR:-${MDX_DATA_DIR:-/data/sil-data}/psf-log}/pss.log"
+      if [[ "${SRR_PSS_STRICT:-1}" == "0" ]]; then
+        log "WARN snapshot_pss FAILED for ${label} (src=${_pss_src}) — PSF forensic log for this scenario is MISSING (SRR_PSS_STRICT=0, continuing)"
+      else
+        log "ERROR snapshot_pss FAILED for ${label} (src=${_pss_src}) — PSF forensic log for this scenario would be LOST; aborting the sweep (set SRR_PSS_STRICT=0 to downgrade to a warning)"
+        exit 1
+      fi
+    fi
     # Refresh the run-level concat right away, not only at end-of-multi-test:
     # if the run is aborted or resumed later, a stale run-level pss.log makes
     # clip_logs slice every clip recorded after its last timestamp to 0 lines.

--- a/closed-loop-testing/regression-reporter/scripts/safety_critical_unmute.py
+++ b/closed-loop-testing/regression-reporter/scripts/safety_critical_unmute.py
@@ -5,7 +5,8 @@
 
 For each summary.md in <multi-test-dir>/<label>/reports/, filter to clips
 where chars > 70% in ROI AND fk > 50% in trailer (= dangerous condition),
-then compute avg `100 - actMute%` across those clips.
+then compute avg `100 - over-mute%` across those clips (over-mute% =
+suppressed the safety response while a person was present).
 
 Usage:
   python3 safety_critical_unmute.py --multi-test-dir <dir>
@@ -18,23 +19,52 @@ from pathlib import Path
 
 
 def parse_summary(path: Path) -> list[dict]:
-    """Read summary.md table → list of clip dicts."""
+    """Parse the per-clip Markdown table by HEADER (robust to column reordering
+    and Markdown-linked clip cells). Returns a list of clip dicts."""
+    lines = path.read_text().splitlines()
+    header_idx = None
+    cols: list[str] = []
+    for i, line in enumerate(lines):
+        if line.lstrip().startswith("|") and "%char_in_roi" in line and "%fk_trailer" in line:
+            cols = [c.strip() for c in line.strip().strip("|").split("|")]
+            header_idx = i
+            break
+    if header_idx is None:
+        return []
+
+    def col(name: str) -> int:
+        return cols.index(name) if name in cols else -1
+
+    i_clip = col("Clip")
+    i_roi = col("%char_in_roi")
+    i_fk = col("%fk_trailer")
+    i_over = col("over-mute%")
+    i_match = col("match%")
+    if min(i_clip, i_roi, i_fk, i_over) < 0:
+        return []
+
+    def num(cell: str) -> float:
+        # strip markdown/bold/% and any link wrapper, keep the number
+        s = re.sub(r"[*`%]", "", cell).strip()
+        return float(s)
+
     rows = []
-    for line in path.read_text().splitlines():
-        if not line.startswith("| scn_"):
+    for line in lines[header_idx + 2:]:          # skip header + its |---| separator
+        if not line.lstrip().startswith("|"):
+            break                                # table ended
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        if len(cells) <= max(i_clip, i_roi, i_fk, i_over):
             continue
-        cells = [c.strip() for c in line.strip("|").split("|")]
-        # Columns: clip rows dur char_in_roi fk_trailer expMute actMute match%
-        # unmute_lag mute_lag gt_ROI n_ROI_dedup n_ROI_raw gt_TW_in n_TW_R
-        # gt_TW_out n_TW_L
+        m = re.search(r"scn_\d+", cells[i_clip])  # handles "[scn_0000](scn_0000.md)"
+        if not m:
+            continue
         try:
             rows.append({
-                "clip": cells[0],
-                "char_in_roi": float(cells[3]),
-                "fk_trailer": float(cells[4]),
-                "expMute": float(cells[5]),
-                "actMute": float(cells[6]),
-                "match": float(cells[7]),
+                "clip": m.group(0),
+                "char_in_roi": num(cells[i_roi]),
+                "fk_trailer": num(cells[i_fk]),
+                "over_mute": num(cells[i_over]),
+                "match": num(cells[i_match]) if i_match >= 0 else float("nan"),
             })
         except (IndexError, ValueError):
             continue
@@ -56,11 +86,17 @@ def main() -> int:
     print(f"  {'Scenario':<22} {'Crit/All':>8} {'Unmute%':>8} {'Pass(>=95)':>10}")
     print(f"  {'-'*22} {'-'*8} {'-'*8} {'-'*10}")
 
+    summaries_found = 0
+    rows_parsed = 0
+    scenarios_with_critical = 0
+
     for label_dir in sorted(base.iterdir()):
         summary = label_dir / "reports" / "summary.md"
         if not summary.exists():
             continue
+        summaries_found += 1
         rows = parse_summary(summary)
+        rows_parsed += len(rows)
         if not rows:
             continue
         critical = [r for r in rows
@@ -71,13 +107,28 @@ def main() -> int:
             print(f"  {label_dir.name:<22} {f'0/{total}':>8} {'-':>8} "
                   f"{'(no overlap)':>10}")
             continue
-        unmute = [100 - r["actMute"] for r in critical]
+        scenarios_with_critical += 1
+        unmute = [100 - r["over_mute"] for r in critical]
         avg = sum(unmute) / len(unmute)
         passes = sum(1 for u in unmute if u >= 95)
         print(f"  {label_dir.name:<22} {f'{ncrit}/{total}':>8} "
               f"{avg:>7.1f}% {f'{passes}/{ncrit}':>10}")
 
     print()
+
+    # INVALID guards: a run that produced summaries but yields an
+    # empty result table must NOT look like a pass.
+    if summaries_found == 0:
+        print("  INVALID: no <scenario>/reports/summary.md found under the run dir")
+        return 2
+    if rows_parsed == 0:
+        print("  INVALID: summaries present but 0 clip rows parsed "
+              "(summary.md format changed? see safety_critical_unmute.parse_summary)")
+        return 2
+    if scenarios_with_critical == 0:
+        print("  INVALID: parsed clips but NO scenario had a safety-critical "
+              "(char_in_roi>70 & fk_trailer>50) clip — nothing to score")
+        return 2
     return 0
 
 

--- a/closed-loop-testing/regression-reporter/scripts/snapshot_pss.sh
+++ b/closed-loop-testing/regression-reporter/scripts/snapshot_pss.sh
@@ -61,9 +61,11 @@ if [[ -z "${PSF_LOG_DIR:-}" && -z "${MDX_DATA_DIR:-}" ]]; then
     # shellcheck disable=SC1090
     source "$SIL_ENV"
     set +a
-    case "${MDX_DATA_DIR:-}" in
-      /path/to/*) MDX_DATA_DIR="" ;;   # unedited template — ignore
-    esac
+    # An unedited template profile yields placeholder paths — and PSF_LOG_DIR is
+    # derived from MDX_DATA_DIR, so it inherits the placeholder too. Ignore both
+    # so resolution falls through to the documented default instead of /path/to/.
+    case "${MDX_DATA_DIR:-}" in /path/to/*) MDX_DATA_DIR="" ;; esac
+    case "${PSF_LOG_DIR:-}"  in /path/to/*) PSF_LOG_DIR=""  ;; esac
   fi
 fi
 

--- a/closed-loop-testing/regression-reporter/scripts/snapshot_pss.sh
+++ b/closed-loop-testing/regression-reporter/scripts/snapshot_pss.sh
@@ -48,7 +48,37 @@ while [[ $# -gt 0 ]]; do
     *)  SRC="$1"; shift ;;
   esac
 done
-SRC="${SRC:-${PSS_LOG_SRC:-/data/sil-data/psf-log/pss.log}}"
+# When invoked standalone (not via run_multi.sh, which already `set -a; source`s
+# the SIL profile), MDX_DATA_DIR / PSF_LOG_DIR are not in the environment. Load
+# them from the SIL deployment profile so the documented per-scenario command
+# resolves the SAME data root used to launch SIL. Override the profile path with
+# SIL_ENV; a real (non-template) MDX_DATA_DIR is required for this to take effect.
+if [[ -z "${PSF_LOG_DIR:-}" && -z "${MDX_DATA_DIR:-}" ]]; then
+  _SP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  SIL_ENV="${SIL_ENV:-$_SP_DIR/../../../deployments/profiles/sil.env}"
+  if [[ -f "$SIL_ENV" ]]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "$SIL_ENV"
+    set +a
+    case "${MDX_DATA_DIR:-}" in
+      /path/to/*) MDX_DATA_DIR="" ;;   # unedited template — ignore
+    esac
+  fi
+fi
+
+# Resolve the source pss.log so a non-default data root still finds the Safety
+# Core log. Priority: explicit <source-pss-log> arg > PSS_LOG_SRC override >
+# PSF_LOG_DIR (from the profile env) > MDX_DATA_DIR > neutral fallback.
+if [[ -z "$SRC" ]]; then
+  if   [[ -n "${PSS_LOG_SRC:-}" ]]; then SRC="$PSS_LOG_SRC"
+  elif [[ -n "${PSF_LOG_DIR:-}"  ]]; then SRC="$PSF_LOG_DIR/pss.log"
+  elif [[ -n "${MDX_DATA_DIR:-}" ]]; then SRC="$MDX_DATA_DIR/psf-log/pss.log"
+  else SRC="/data/sil-data/psf-log/pss.log"
+  fi
+fi
+
+echo "snapshot_pss: resolved source = $SRC" >&2
 
 if [[ ! -d "$RUN_DIR" ]]; then
   echo "snapshot_pss: no such dir: $RUN_DIR" >&2; exit 1

--- a/closed-loop-testing/regression-reporter/scripts/snapshot_pss.sh
+++ b/closed-loop-testing/regression-reporter/scripts/snapshot_pss.sh
@@ -55,7 +55,10 @@ done
 # SIL_ENV; a real (non-template) MDX_DATA_DIR is required for this to take effect.
 if [[ -z "${PSF_LOG_DIR:-}" && -z "${MDX_DATA_DIR:-}" ]]; then
   _SP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  SIL_ENV="${SIL_ENV:-$_SP_DIR/../../../deployments/profiles/sil.env}"
+  # Prefer HOISA_ROOT_PATH (same root run_multi.sh derives the profile from) when
+  # it is exported; fall back to a script-relative repo root so a bare standalone
+  # invocation (no repo .env sourced) still resolves. Default profile: sil.env.
+  SIL_ENV="${SIL_ENV:-${HOISA_ROOT_PATH:-$_SP_DIR/../../..}/deployments/profiles/sil.env}"
   if [[ -f "$SIL_ENV" ]]; then
     set -a
     # shellcheck disable=SC1090

--- a/closed-loop-testing/regression-reporter/scripts/snapshot_pss.sh
+++ b/closed-loop-testing/regression-reporter/scripts/snapshot_pss.sh
@@ -116,10 +116,16 @@ if [[ "$MODE" == "per-scn" ]]; then
   # scenarios' lines were truncated by the prior compose restart). A plain
   # copy preserves the entire scenario including PSF init lines that no
   # mtime-window heuristic would catch.
-  if [[ ! -f "$SRC" ]]; then
-    echo "snapshot_pss: source pss.log not found: $SRC" >&2; exit 1
+  # Missing OR empty (0-byte) source both mean no Safety Core evidence for this
+  # scenario — fail rather than copy an empty log that would silently "pass".
+  if [[ ! -s "$SRC" ]]; then
+    echo "snapshot_pss: source pss.log missing or empty: $SRC" >&2; exit 1
   fi
-  write_out "$SRC" "$OUT"
+  # A failed write (host EPERM AND container fallback both denied) must propagate,
+  # otherwise run_multi's strict sweep-abort never sees the lost snapshot.
+  if ! write_out "$SRC" "$OUT"; then
+    exit 1
+  fi
   LINES=$(wc -l < "$SRC")
   SIZE=$(du -h "$SRC" | awk '{print $1}')
   echo "snapshot_pss: copied $SRC → $OUT ($LINES lines, $SIZE) [per-scn]"

--- a/closed-loop-testing/regression-reporter/srr-service/srr/recorder.py
+++ b/closed-loop-testing/regression-reporter/srr-service/srr/recorder.py
@@ -22,12 +22,14 @@ class Recorder:
         self.path: Optional[Path] = None
         self._writer: Optional[pq.ParquetWriter] = None
         self._buf: list[Frame] = []
+        self._total_rows = 0
 
     def open(self) -> None:
         ts = time.strftime("%Y%m%d-%H%M%S")
         self.path = self.out / f"run-{ts}.parquet"
         self._writer = None
         self._buf.clear()
+        self._total_rows = 0
 
     def append(self, f: Frame) -> None:
         self._buf.append(f)
@@ -62,15 +64,17 @@ class Recorder:
             for f in self._buf
         ]
         self._buf.clear()
+        self._total_rows += len(rows)
         table = pa.Table.from_pylist(rows)
         if self._writer is None:
             self._writer = pq.ParquetWriter(self.path, table.schema, compression="snappy")
         self._writer.write_table(table)
 
     def flush(self) -> int:
-        n = len(self._buf)
+        """Flush the buffer, close the writer, and return the CUMULATIVE number of
+        rows written to this parquet (not just the final in-memory buffer)."""
         self._flush_to_writer()
         if self._writer is not None:
             self._writer.close()
             self._writer = None
-        return n
+        return self._total_rows

--- a/closed-loop-testing/regression-reporter/srr-service/srr/recorder.py
+++ b/closed-loop-testing/regression-reporter/srr-service/srr/recorder.py
@@ -14,6 +14,35 @@ import pyarrow.parquet as pq
 
 from .schema import Frame
 
+# Explicit parquet schema — never let pyarrow infer it from a batch. The
+# Phase-2 / BA columns stay None until the 3D pipeline (or a BA detection)
+# produces output, so an inferred first batch types them `null`; the first
+# batch that carries a value then raises "Table schema does not match schema
+# used to create file" inside the sample timer, which kills rclpy.spin() and
+# takes the whole recording down mid-run.
+SCHEMA = pa.schema(
+    [
+        ("arrival_wall_time", pa.float64()),
+        ("sim_time", pa.float64()),
+        ("char_0_x", pa.float64()),
+        ("char_0_y", pa.float64()),
+        ("char_1_x", pa.float64()),
+        ("char_1_y", pa.float64()),
+        ("char_2_x", pa.float64()),
+        ("char_2_y", pa.float64()),
+        ("forklift_x", pa.float64()),
+        ("forklift_y", pa.float64()),
+        ("psf_command", pa.string()),
+        ("is_muted", pa.bool_()),
+        ("ba_events_json", pa.string()),
+        ("detections_json", pa.string()),
+        ("tracker_state_json", pa.string()),
+        ("bev_frame_id", pa.string()),
+        ("bev_create_time", pa.float64()),
+        ("ba_positions_json", pa.string()),
+    ]
+)
+
 
 class Recorder:
     def __init__(self, out_dir: str = "runs") -> None:
@@ -65,9 +94,9 @@ class Recorder:
         ]
         self._buf.clear()
         self._total_rows += len(rows)
-        table = pa.Table.from_pylist(rows)
+        table = pa.Table.from_pylist(rows, schema=SCHEMA)
         if self._writer is None:
-            self._writer = pq.ParquetWriter(self.path, table.schema, compression="snappy")
+            self._writer = pq.ParquetWriter(self.path, SCHEMA, compression="snappy")
         self._writer.write_table(table)
 
     def flush(self) -> int:

--- a/closed-loop-testing/regression-reporter/srr-service/srr/service.py
+++ b/closed-loop-testing/regression-reporter/srr-service/srr/service.py
@@ -195,15 +195,15 @@ class SRRNode(Node):
             resp.message = f"recording → {self.recorder.path}"
         else:
             n = self.recorder.flush()
-            self.get_logger().info(f"Recording stopped, {n} rows written")
-            resp.message = f"stopped, {n} rows written"
+            self.get_logger().info(f"Recording stopped, {n} total rows written")
+            resp.message = f"stopped, {n} total rows written"
         resp.success = True
         return resp
 
     def _svc_flush(self, req: Trigger.Request, resp: Trigger.Response) -> Trigger.Response:
         n = self.recorder.flush()
         resp.success = True
-        resp.message = f"flushed {n} rows"
+        resp.message = f"flushed; {n} rows written total"
         return resp
 
     # --- Sampling ---

--- a/closed-loop-testing/scripts/setup.sh
+++ b/closed-loop-testing/scripts/setup.sh
@@ -86,6 +86,47 @@ if [ -n "$NEED_ISAAC" ]; then
     sudo chown -R 1234:1234 "$ISAAC_CACHE_DIR"
     echo "  NOTE: sil also needs NGC sil-data (Isaac scenes/collected-assets) — pull separately:"
     echo "    ngc registry resource download-version nvidia/halos-outside-in/sample-sil-data:v1.2.1"
+
+    # collected-assets must be readable/traversable by the isaac-sim container
+    # user (UID/GID 1234; see Dockerfile `USER 1234:1234`). isaac-sim.yml mounts
+    # it :ro, so a foreign-UID 0700 extract makes the scene load hang with no RTSP
+    # writers. Fail here instead of after an 8-minute Isaac timeout.
+    CA_DIR="${MDX_DATA_DIR}/collected-assets"
+    if [ ! -d "$CA_DIR" ]; then
+        echo "ERROR: $CA_DIR missing — pull sil-data (ngc_artifacts.md §1)"; exit 1
+    fi
+    # Would the isaac-sim container user (UID/GID 1234) be able to read+traverse
+    # collected-assets once it is bind-mounted :ro at /isaac-sim/collected-assets?
+    # Judge by the path's OWN owner/mode — NOT host parent traversal: the bind
+    # mount re-roots the dir, so a private host home dir (e.g. 0750) above it is
+    # irrelevant; only the dir's + its contents' perms matter. (Running the check
+    # as `sudo -u '#1234'` on the host path would false-fail whenever the assets
+    # live under a 0700/0750 home dir.)
+    _ca_readable() {  # $1=path -> 0 if UID/GID 1234 gets r (files) / r-x (dirs)
+        local p="$1" o g m bits
+        o=$(stat -c '%u' "$p") || return 1
+        g=$(stat -c '%g' "$p"); m=$((8#$(stat -c '%a' "$p")))
+        if   [ "$o" = "1234" ]; then bits=$(( (m >> 6) & 7 ))
+        elif [ "$g" = "1234" ]; then bits=$(( (m >> 3) & 7 ))
+        else                         bits=$((  m       & 7 )); fi
+        if [ -d "$p" ]; then [ $(( bits & 5 )) -eq 5 ]; else [ $(( bits & 4 )) -eq 4 ]; fi
+    }
+    ca_bad=""
+    _ca_readable "$CA_DIR" || ca_bad="$CA_DIR"
+    if [ -z "$ca_bad" ]; then
+        # sample immediate children too (catches a partial / mixed-perm extract)
+        for _c in "$CA_DIR"/*; do
+            [ -e "$_c" ] || continue
+            _ca_readable "$_c" || { ca_bad="$_c"; break; }
+        done
+    fi
+    if [ -n "$ca_bad" ]; then
+        echo "ERROR: $ca_bad is not readable/traversable by the isaac-sim container user (UID/GID 1234)."
+        echo "  current: $(stat -c '%U:%G %a' "$ca_bad")"
+        echo "  fix:     sudo chown -R 1234:1234 '$CA_DIR'   # or: sudo chmod -R a+rX '$CA_DIR'"
+        exit 1
+    fi
+    echo "  collected-assets readable by isaac-sim user (1234:1234) ✓"
 fi
 
 echo ""

--- a/skills/hoisa-generate-regression-report/SKILL.md
+++ b/skills/hoisa-generate-regression-report/SKILL.md
@@ -218,7 +218,7 @@ This applies to every long wait in the workflow:
 | Long wait | What to verify each tick | Tick interval | Max patience |
 |---|---|---:|---:|
 | Halos compose up after `down` | `docker ps` shows new container IDs for the services | 30 s | 5 min |
-| Scene load + shader compile | Tail `/tmp/isaac-scenario-<TS>-<LBL>.log`; expect `/World/RTSPMultiGraph` built + 3 `rtsp://` stream lines | 30 s | 8 min (first), 3 min (subsequent) |
+| Scene load + shader compile | Tail `/tmp/isaac-scenario-<TS>-<LBL>.log`; expect `/World/RTSPMultiGraph` built + 3 `rtsp://` stream lines, then `vss-rtvi-cv` reporting `Active sources : 3` | 30 s | 8 min (first), 3 min (subsequent) |
 | Safety Core warm-up (30 s) | Confirm `/safety/is_muted` still publishing | 15 s | 90 s |
 | **Recording window** (5–20 min) | Verify (a) parquet file size growing, (b) parquet `ba_events_json` rows > 0 (after 90 s), (c) `$PERCEPTION` FPS ≥ `$FPS_MIN` on all 3 cams (≥25 for 2D, ≥5 for 3D) | **60 s** | RECORD_S |
 | Analysis (tw_split + aggregator + vst pull) | `ls scenes/scn_*.parquet` count, `summary.md` size > 0, mp4 count | 15 s | 5 min |
@@ -275,6 +275,7 @@ Each phase ends when its ready signal becomes true. Poll, don't fix-time.
 | Compose restart | `docker ps --format '{{.Names}}'` shows all 4: safety-core, comm-layer, isaac-sim, srr |
 | Safety Core chain alive | `ros2 topic echo /safety/is_muted --once` exits 0 |
 | Scene loaded | `/tmp/isaac-scenario.log` contains `Action Graph built at /World/RTSPMultiGraph` + 3 `rtsp://` stream lines |
+| Perception ingesting | `docker logs vss-rtvi-cv --tail 50 \| grep -o 'Active sources : [0-9]*' \| tail -1` = 3 (Isaac markers go green even when DeepStream pulled nothing) |
 | Recording active | `ros2 service call /srr/record SetBool` returned `success: True` |
 | Recording done | The above plus parquet file size > 100 KB and incrementing stops |
 | Analysis done | `summary.md` exists with header `# SRR Aggregator — N clip(s)` matching expected clip count |

--- a/skills/hoisa-generate-regression-report/SKILL.md
+++ b/skills/hoisa-generate-regression-report/SKILL.md
@@ -218,7 +218,7 @@ This applies to every long wait in the workflow:
 | Long wait | What to verify each tick | Tick interval | Max patience |
 |---|---|---:|---:|
 | Halos compose up after `down` | `docker ps` shows new container IDs for the services | 30 s | 5 min |
-| Scene load + shader compile | Tail `/tmp/isaac-scenario-<TS>-<LBL>.log`; expect 3 RTSPWriter lines | 30 s | 8 min (first), 3 min (subsequent) |
+| Scene load + shader compile | Tail `/tmp/isaac-scenario-<TS>-<LBL>.log`; expect `/World/RTSPMultiGraph` built + 3 `rtsp://` stream lines | 30 s | 8 min (first), 3 min (subsequent) |
 | Safety Core warm-up (30 s) | Confirm `/safety/is_muted` still publishing | 15 s | 90 s |
 | **Recording window** (5–20 min) | Verify (a) parquet file size growing, (b) parquet `ba_events_json` rows > 0 (after 90 s), (c) `$PERCEPTION` FPS ≥ `$FPS_MIN` on all 3 cams (≥25 for 2D, ≥5 for 3D) | **60 s** | RECORD_S |
 | Analysis (tw_split + aggregator + vst pull) | `ls scenes/scn_*.parquet` count, `summary.md` size > 0, mp4 count | 15 s | 5 min |
@@ -274,7 +274,7 @@ Each phase ends when its ready signal becomes true. Poll, don't fix-time.
 |-------|--------------------------------|
 | Compose restart | `docker ps --format '{{.Names}}'` shows all 4: safety-core, comm-layer, isaac-sim, srr |
 | Safety Core chain alive | `ros2 topic echo /safety/is_muted --once` exits 0 |
-| Scene loaded | `/tmp/isaac-scenario.log` contains `RTSPWriter_World_Cameras_Camera*_rgb` for all 3 cams |
+| Scene loaded | `/tmp/isaac-scenario.log` contains `Action Graph built at /World/RTSPMultiGraph` + 3 `rtsp://` stream lines |
 | Recording active | `ros2 service call /srr/record SetBool` returned `success: True` |
 | Recording done | The above plus parquet file size > 100 KB and incrementing stops |
 | Analysis done | `summary.md` exists with header `# SRR Aggregator — N clip(s)` matching expected clip count |

--- a/skills/hoisa-generate-regression-report/references/02_launch.md
+++ b/skills/hoisa-generate-regression-report/references/02_launch.md
@@ -404,10 +404,18 @@ Log:
 ```
 Tail /tmp/isaac-scenario-<TIMESTAMP>-<LABEL>.log inside the host
 (it's a docker exec stdout redirect — should appear on host).
-Look for all 3 lines:
-  RTSPWriter_World_Cameras_Camera_rgb
-  RTSPWriter_World_Cameras_Camera_01_rgb
-  RTSPWriter_World_Cameras_Camera_02_rgb
+Confirm the current Isaac-6.0 scene-ready markers in the log:
+  [rtsp-cameras] Loaded 3 cameras from ...
+  [rtsp-cameras] Action Graph built at /World/RTSPMultiGraph
+  3x "  - <name>: rtsp://<host>:<port><mount>"   (one per camera; ports 8554/8555/8556)
+  Pressing Play (timeline.play())
+  [srr-gt] Action Graph built at /World/SRRGraph (4 publishers)   # only with --srr-gt
+
+Then confirm the 3 RTSP mounts serve H.264 and the 4 GT topics have a publisher:
+  ffprobe -v error -show_streams rtsp://<host>:8554/camera   # repeat per port
+  ros2 topic info /gt/forklift/tf -v | grep 'Publisher count'   # =1; same for /gt/character_{0,1,2}/tf
+
+Do NOT rely on RTSPWriter_World_Cameras_*_rgb — Isaac 6.0 never emits those.
 
 If first run on this scene: shaders compile takes ~5-7 min — that's normal.
 If subsequent run: streams should appear within ~90 s.
@@ -415,7 +423,8 @@ If subsequent run: streams should appear within ~90 s.
 Poll every 30 s. Report progress with last 2 lines of the log.
 Max 8 min on first run, 3 min on subsequent.
 
-Report [ok] when all 3 RTSP lines present, or [fail: <reason>] otherwise.
+Report [ok] when /World/RTSPMultiGraph is built + 3 rtsp:// stream lines present
+(and, with --srr-gt, /World/SRRGraph built), or [fail: <reason>] otherwise.
 ```
 
 When [ok], log:

--- a/skills/hoisa-generate-regression-report/references/02_launch.md
+++ b/skills/hoisa-generate-regression-report/references/02_launch.md
@@ -415,6 +415,14 @@ Then confirm the 3 RTSP mounts serve H.264 and the 4 GT topics have a publisher:
   ffprobe -v error -show_streams rtsp://<host>:8554/camera   # repeat per port
   ros2 topic info /gt/forklift/tf -v | grep 'Publisher count'   # =1; same for /gt/character_{0,1,2}/tf
 
+Finally confirm perception actually pulled all three streams — the Isaac-side
+markers above go green even when DeepStream ingested nothing, so a run started
+on that state records no detections at all:
+  docker logs vss-rtvi-cv --tail 50 | grep -o 'Active sources : [0-9]*' | tail -1   # want 3
+A count below 3 means the empty-pipeline provisioning race: restart vss-rtvi-cv,
+re-register the sensors (vst_sensor_manager.py --delete-all then
+--add-from-config), and re-check before recording.
+
 Do NOT rely on RTSPWriter_World_Cameras_*_rgb — Isaac 6.0 never emits those.
 
 If first run on this scene: shaders compile takes ~5-7 min — that's normal.
@@ -424,7 +432,8 @@ Poll every 30 s. Report progress with last 2 lines of the log.
 Max 8 min on first run, 3 min on subsequent.
 
 Report [ok] when /World/RTSPMultiGraph is built + 3 rtsp:// stream lines present
-(and, with --srr-gt, /World/SRRGraph built), or [fail: <reason>] otherwise.
++ DeepStream reports 3/3 active sources (and, with --srr-gt, /World/SRRGraph
+built), or [fail: <reason>] otherwise.
 ```
 
 When [ok], log:


### PR DESCRIPTION
## Summary
Five SRR / SIL SQA bugfixes surfaced by the `dev-26-07.23` validation, plus one related recorder robustness fix.

## Fixes
- **Bug ID 6509970** — the `/srr/record` stop response reported the final in-memory buffer count instead of the total recorded rows (e.g. `201` vs the finalized parquet's `9929`). `Recorder` now keeps a cumulative `_total_rows` counter (reset in `open()`, incremented per flush) and `flush()` returns it, so the stop/flush logs report the true total. (`recorder.py`, `service.py`)
- **Bug ID 6511348** — `snapshot_pss.sh` hardcoded `/data/sil-data` and failed on a valid non-default `MDX_DATA_DIR`, losing the per-scenario PSF forensic log (which the next scenario's compose restart destroys). It now sources the SIL profile when the data-root vars are absent (standalone default resolved via `HOISA_ROOT_PATH`, then a script-relative fallback) and resolves the source `pss.log` by priority: arg > `PSS_LOG_SRC` > `PSF_LOG_DIR` > `MDX_DATA_DIR` > default. It fails when the source `pss.log` is missing **or empty (0-byte)** and propagates a failed write instead of silently exiting 0. `run_multi.sh` now fails the sweep on a lost snapshot instead of warning (opt out with `SRR_PSS_STRICT=0`). (`snapshot_pss.sh`, `run_multi.sh`)
- **Bug ID 6509934** — `safety_critical_unmute.py` silently produced an empty table because it parsed `summary.md` by fixed column index and a `| scn_` line prefix, both of which broke when the aggregator table gained columns and the clip cells became markdown links. It now parses by header, indexes columns by name, extracts the clip id from linked cells (`scn_\d+`), scores against `over-mute%`, and emits explicit `INVALID` (exit 2) results when no summaries / no rows / no safety-critical clips are found. (`safety_critical_unmute.py`)
- **Bug ID 6510024** — readiness checks waited for obsolete `RTSPWriter_*` markers that Isaac 6.0 no longer emits, so a healthy scene never went "ready". The skill docs now key on the Isaac-6.0 markers (`/World/RTSPMultiGraph`, the `rtsp://` stream lines, `/World/SRRGraph` for `--srr-gt`) plus a DeepStream `Active sources : 3` probe (the Isaac-side markers go green even when DeepStream ingested nothing). (`SKILL.md`, `references/02_launch.md`)
- **Bug ID 6510008** — deployment accepted a `collected-assets` extract that the isaac-sim container user (UID/GID 1234) cannot read, causing an ~8-minute Isaac startup timeout with no RTSP writers. `setup.sh` now checks that `collected-assets` and its immediate children are readable/traversable by 1234:1234 — judging the `:ro` mount source by its own owner/mode bits (a private `0700`/`0750` home dir above it is irrelevant after the bind re-roots) — and fails fast with a `chown`/`chmod` hint.

## Related (not tied to a listed bug)
- `recorder.py` also writes the parquet with an **explicit pyarrow schema** instead of letting it be inferred from the first batch. The Phase-2 / BA columns stay `None` until the 3D pipeline (or a BA detection) produces output, so an inferred first batch typed them `null`; the first batch carrying a value then raised `Table schema does not match schema used to create file` inside the sample timer, killing the recording mid-run. Surfaced while fixing 6509970 — can be filed under its own bug ID if we want it tracked separately.

## Notes for reviewers
- **Behavior change:** with the default `SRR_PSS_STRICT=1`, a missing/empty/unwritten per-scenario `pss.log` snapshot now **aborts the sweep** (previously a non-fatal warning). Set `SRR_PSS_STRICT=0` to downgrade to a warning and keep sweeping.
- **New env vars** `SRR_PSS_STRICT` (`run_multi.sh`) and `SIL_ENV` (`snapshot_pss.sh`) are documented in `.env.example`.
