### PR TITLE
fix(deploy): FSI fsicom-agent --heartbeat + bump PSF to the FSI-fix build

### DIFF
--- a/deployments/profiles/base-thor.env
+++ b/deployments/profiles/base-thor.env
@@ -9,11 +9,11 @@
 HOST_IP='' # change me — this Thor's IP
 
 # === Safety Core image (nv-psf container, multi-arch arm64+amd64, one tag) ===
-PSF_IMAGE=nvcr.io/nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-release-9105e6e-2026-07-22_10-40  # multi-arch; Docker auto-selects arm64 on Thor (same tag as x86 base.env)
+PSF_IMAGE=nvcr.io/nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-release-dd3dae5-2026-07-27_18-54  # multi-arch; Docker auto-selects arm64 on Thor (same tag as x86 base.env)
 
 # === Thor Safety Core packages (NGC resources, downloaded once at setup; ngc_artifacts.md §4) ===
-PSF_TEGRA_RESOURCE=nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-aarch64-release-9105e6e-2026-07-22_10-37-psf-tegra         # host binaries .deb (atl_sdm, launch_hoisa, safety_monitor) for CCPLEX + FSI host side
-PSF_TEGRA_FSI_RESOURCE=nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-aarch64-release-9105e6e-2026-07-22_10-37-psf-tegra-fsi  # FSI firmware + fsicom-agent .deb (SDM_TARGET=fsi only)
+PSF_TEGRA_RESOURCE=nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-aarch64-release-dd3dae5-2026-07-27_18-52-psf-tegra         # host binaries .deb (atl_sdm, launch_hoisa, safety_monitor) for CCPLEX + FSI host side
+PSF_TEGRA_FSI_RESOURCE=nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-aarch64-release-dd3dae5-2026-07-27_18-52-psf-tegra-fsi  # FSI firmware + fsicom-agent .deb (SDM_TARGET=fsi only)
 
 # === SDM placement / launch mode ===
 SDM_TARGET=ccplex        # ccplex (host SDM, start here) | fsi (SDM on the Functional Safety Island — halos_thor.md §5B)

--- a/deployments/profiles/base.env
+++ b/deployments/profiles/base.env
@@ -18,7 +18,7 @@ MDX_DATA_DIR=/path/to/data # change me
 HOST_IP='' # change me
 
 COMM_UDP_PORT=12345   # PSF cmd target = VST halo_safety_udp_port (NOT comm-layer in base)
-PSF_IMAGE=nvcr.io/nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-release-9105e6e-2026-07-22_10-40
+PSF_IMAGE=nvcr.io/nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-release-dd3dae5-2026-07-27_18-54
 PSF_LAUNCH_MODE=skip  # skip = PSF without SAIM | learn = record SAIM sensor baselines | active = SAIM live (validates streams vs learned baselines)
 PSF_CMD_RX_IP=127.0.0.1
 PSF_LOG_DIR=${MDX_DATA_DIR}/psf-log

--- a/deployments/profiles/hil-thor.env
+++ b/deployments/profiles/hil-thor.env
@@ -11,10 +11,10 @@ HOST_IP='' # change me — this Thor's IP
 PEER_HOST_IP='' # change me — the x86 stimulus host (comm-layer)
 
 # nv-psf container (multi-arch; Docker selects arm64 on Thor — same tag as the x86 profiles)
-PSF_IMAGE=nvcr.io/nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-release-9105e6e-2026-07-22_10-40
+PSF_IMAGE=nvcr.io/nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-release-dd3dae5-2026-07-27_18-54
 # Thor host packages (install per ngc_artifacts.md §4; keep the SAME build tag as PSF_IMAGE)
-PSF_TEGRA_RESOURCE=nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-aarch64-release-9105e6e-2026-07-22_10-37-psf-tegra         # host binaries .deb (atl_sdm, launch_hoisa, safety_monitor) for CCPLEX + FSI host side
-PSF_TEGRA_FSI_RESOURCE=nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-aarch64-release-9105e6e-2026-07-22_10-37-psf-tegra-fsi  # FSI firmware + fsicom-agent .deb (SDM_TARGET=fsi only)
+PSF_TEGRA_RESOURCE=nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-aarch64-release-dd3dae5-2026-07-27_18-52-psf-tegra         # host binaries .deb (atl_sdm, launch_hoisa, safety_monitor) for CCPLEX + FSI host side
+PSF_TEGRA_FSI_RESOURCE=nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-aarch64-release-dd3dae5-2026-07-27_18-52-psf-tegra-fsi  # FSI firmware + fsicom-agent .deb (SDM_TARGET=fsi only)
 
 SDM_TARGET=ccplex        # ccplex (host SDM, start here) | fsi (SDM on the Functional Safety Island — halos_thor.md §5B)
 PSF_LAUNCH_MODE=skip     # skip = PSF without SAIM | learn = record SAIM sensor baselines | active = SAIM live (validates streams vs learned baselines)

--- a/deployments/profiles/sil.env
+++ b/deployments/profiles/sil.env
@@ -21,7 +21,7 @@ COMM_LOG_DIR=${MDX_DATA_DIR}/comm-layer
 ROS_DOMAIN_ID=0
 
 # === PSF ===
-PSF_IMAGE=nvcr.io/nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-release-9105e6e-2026-07-22_10-40
+PSF_IMAGE=nvcr.io/nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-release-dd3dae5-2026-07-27_18-54
 PSF_LAUNCH_MODE=skip  # skip = PSF without SAIM | learn = record SAIM sensor baselines | active = SAIM live (validates streams vs learned baselines)
 PSF_CMD_RX_IP=127.0.0.1
 PSF_LOG_DIR=${MDX_DATA_DIR}/psf-log

--- a/skills/hoisa-deploy-profile/references/halos_thor.md
+++ b/skills/hoisa-deploy-profile/references/halos_thor.md
@@ -193,7 +193,7 @@ ps -eo comm | grep -qx atl_sdm && echo "unexpected: CCPLEX SDM should be ABSENT 
 > reach the overlay (HOISA User Guide §2.2.2):
 >
 > ```bash
-> sudo fsicom-agent --relay-fsi-resp --ip <cmd-rx-ip> --port <cmd-rx-port>
+> sudo fsicom-agent --relay-fsi-resp --ip <cmd-rx-ip> --port <cmd-rx-port> --heartbeat
 > ```
 >
 > Pass only these flags. If decisions are produced upstream (`5C`) but the overlay never


### PR DESCRIPTION
## What
- `halos_thor.md` §5B: the FSI bridge now runs with `--heartbeat` (the FSI-SDM fix for NVBug 6488909 requires it; the pre-fix build used the no-heartbeat flow).
- `base.env` / `sil.env` / `base-thor.env` / `hil-thor.env`: bump PSF image + Thor host debs (`PSF_TEGRA_RESOURCE`, `PSF_TEGRA_FSI_RESOURCE`) off the pre-fix `9105e6e-2026-07-22` build.

## Why coupled
`--heartbeat` only works on the FSI-fixed `fsicom-agent` (in `psf-tegra-fsi.deb`), so the doc change and the image/deb bump must land together.