### PR TITLE
chore: remove FSI references from the repo (CCPLEX-only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The three pillars connect through a perception event stream: cameras feed AI per
 
 | Profile | Description |
 |---------|-------------|
-| `base` | Safety Core on an existing perception feed; the MUTE / UNMUTE decision is rendered as the VST `halo_safety` overlay. No simulation. Runs on x86 by default, or on IGX Thor (CCPLEX or FSI; see [`halos_thor.md`](skills/hoisa-deploy-profile/references/halos_thor.md)). |
+| `base` | Safety Core on an existing perception feed; the MUTE / UNMUTE decision is rendered as the VST `halo_safety` overlay. No simulation. Runs on x86 by default, or on IGX Thor (see [`halos_thor.md`](skills/hoisa-deploy-profile/references/halos_thor.md)). |
 | `sil` | Full single-host closed loop: NVIDIA Isaac Sim drives a forklift, and the safety decision is fed back to the simulated forklift over ROS. |
 | `hil` 🚧 | Hardware-in-the-loop: the Safety Core runs on an NVIDIA Thor device. Under development. |
 

--- a/closed-loop-testing/scripts/launch_thor_safety.sh
+++ b/closed-loop-testing/scripts/launch_thor_safety.sh
@@ -7,8 +7,9 @@
 # On Thor the Safety Core is hybrid (nv-psf container + host binaries) and is orchestrated by
 # /opt/nvidia/psf/bin/launch_hoisa.sh, not by docker compose. This helper reads a profile env
 # (deployments/profiles/<profile>.env) and invokes launch_hoisa.sh with the matching flags.
-# The SDM runs on the CCPLEX. The same launcher path serves the base (overlay) profile
-# and the HIL safety host. See skills/hoisa-deploy-profile/references/halos_thor.md.
+# SDM_TARGET selects where the SDM runs (`ccplex` — the Thor application cores). The same
+# launcher path serves the base (overlay) profile and the HIL safety host.
+# See skills/hoisa-deploy-profile/references/halos_thor.md.
 #
 # Usage:
 #   bash closed-loop-testing/scripts/launch_thor_safety.sh <profile>   # e.g. base-thor
@@ -42,13 +43,14 @@ LAUNCHER=/opt/nvidia/psf/bin/launch_hoisa.sh
 [ -x "$LAUNCHER" ] || { echo "ERROR: $LAUNCHER not found — install the Safety Core Tegra package first (PSF docs HOISA User Guide §1)."; exit 1; }
 [ -f "$PSF_SENSOR_CONFIG" ] || { echo "ERROR: sensor config not found: $PSF_SENSOR_CONFIG (copy the template + fill the VST URLs)."; exit 1; }
 
+SDM_TARGET="${SDM_TARGET:-ccplex}"
 PSF_LAUNCH_MODE="${PSF_LAUNCH_MODE:-active}"
 KAFKA_BROKER="${KAFKA_BROKER:-localhost:9092}"
 
 echo "=== Halos Thor Safety Core launch ==="
 echo "  Profile:    $PROFILE"
 echo "  Mode:       $PSF_LAUNCH_MODE"
-echo "  SDM:        atl_sdm on the CCPLEX"
+echo "  SDM target: $SDM_TARGET"
 echo "  Cmd sink:   ${PSF_CMD_RX_IP}:${PSF_CMD_RX_PORT}"
 echo "  Kafka:      $KAFKA_BROKER"
 echo ""
@@ -57,7 +59,7 @@ echo ""
 # and installs its own signal-trap cleanup. Stop with stop_thor_safety.sh.
 exec sudo "$LAUNCHER" \
     --mode "$PSF_LAUNCH_MODE" --app atl \
-    --sdm-target ccplex \
+    --sdm-target "$SDM_TARGET" \
     --sensor-config "$PSF_SENSOR_CONFIG" \
     --docker-image "$PSF_IMAGE" \
     --cmd-rx-ip "$PSF_CMD_RX_IP" --cmd-rx-port "$PSF_CMD_RX_PORT" \

--- a/closed-loop-testing/scripts/launch_thor_safety.sh
+++ b/closed-loop-testing/scripts/launch_thor_safety.sh
@@ -7,7 +7,7 @@
 # On Thor the Safety Core is hybrid (nv-psf container + host binaries) and is orchestrated by
 # /opt/nvidia/psf/bin/launch_hoisa.sh, not by docker compose. This helper reads a profile env
 # (deployments/profiles/<profile>.env) and invokes launch_hoisa.sh with the matching flags.
-# SDM_TARGET selects CCPLEX vs FSI. The same launcher path serves the base (overlay) profile
+# The SDM runs on the CCPLEX. The same launcher path serves the base (overlay) profile
 # and the HIL safety host. See skills/hoisa-deploy-profile/references/halos_thor.md.
 #
 # Usage:
@@ -42,34 +42,22 @@ LAUNCHER=/opt/nvidia/psf/bin/launch_hoisa.sh
 [ -x "$LAUNCHER" ] || { echo "ERROR: $LAUNCHER not found — install the Safety Core Tegra package first (PSF docs HOISA User Guide §1)."; exit 1; }
 [ -f "$PSF_SENSOR_CONFIG" ] || { echo "ERROR: sensor config not found: $PSF_SENSOR_CONFIG (copy the template + fill the VST URLs)."; exit 1; }
 
-SDM_TARGET="${SDM_TARGET:-ccplex}"
 PSF_LAUNCH_MODE="${PSF_LAUNCH_MODE:-active}"
 KAFKA_BROKER="${KAFKA_BROKER:-localhost:9092}"
-
-# --- FSI prerequisite: nvFsiCom daemon must already be running (the launcher does NOT start it) ---
-if [ "$SDM_TARGET" = "fsi" ]; then
-    if ! pgrep -x nvFsiCom >/dev/null; then
-        echo "ERROR: SDM_TARGET=fsi but the nvFsiCom daemon is not running. Start it first:"
-        echo "   sudo /opt/nvidia/ccplex_sf/fsi_ccplex_com/nvFsiCom &"
-        echo "(FSI also requires the HOISA FSI firmware reflashed — see halos_thor.md §5B.)"
-        exit 1
-    fi
-fi
 
 echo "=== Halos Thor Safety Core launch ==="
 echo "  Profile:    $PROFILE"
 echo "  Mode:       $PSF_LAUNCH_MODE"
-echo "  SDM target: $SDM_TARGET"
+echo "  SDM:        atl_sdm on the CCPLEX"
 echo "  Cmd sink:   ${PSF_CMD_RX_IP}:${PSF_CMD_RX_PORT}"
 echo "  Kafka:      $KAFKA_BROKER"
 echo ""
 
-# launch_hoisa.sh runs `docker run nv-psf` + spawns the host SDM (ccplex) or the fsicom-agent
-# bridge (fsi) + the AI monitor, and installs its own signal-trap cleanup. Stop with
-# stop_thor_safety.sh. For fsi, see the fsicom-agent relay-flags note in halos_thor.md §5B.
+# launch_hoisa.sh runs `docker run nv-psf` + spawns the host SDM (atl_sdm) and the AI monitor,
+# and installs its own signal-trap cleanup. Stop with stop_thor_safety.sh.
 exec sudo "$LAUNCHER" \
     --mode "$PSF_LAUNCH_MODE" --app atl \
-    --sdm-target "$SDM_TARGET" \
+    --sdm-target ccplex \
     --sensor-config "$PSF_SENSOR_CONFIG" \
     --docker-image "$PSF_IMAGE" \
     --cmd-rx-ip "$PSF_CMD_RX_IP" --cmd-rx-port "$PSF_CMD_RX_PORT" \

--- a/closed-loop-testing/scripts/stop_thor_safety.sh
+++ b/closed-loop-testing/scripts/stop_thor_safety.sh
@@ -7,7 +7,7 @@
 # Sends SIGTERM to launch_hoisa.sh so its trap handler cleans up the host binaries and the
 # nv-psf container; falls back to explicit kills. Uses `pkill -x <basename>` (exact match),
 # never `pkill -f <pattern>` — over SSH the latter can match this shell's own argv and kill
-# the session. Leaves the nvFsiCom daemon running (start/stop it separately for FSI).
+# the session.
 #
 # Usage:
 #   bash closed-loop-testing/scripts/stop_thor_safety.sh
@@ -22,7 +22,7 @@ if pgrep -x launch_hoisa.sh >/dev/null; then
 fi
 
 # 2. Fallback: explicit kills (exact basename) if the trap did not finish
-for p in atl_sdm proximity_sdm safety_monitor fsicom-agent atl_sdm_cmd_receiver; do
+for p in atl_sdm proximity_sdm safety_monitor atl_sdm_cmd_receiver; do
     sudo pkill -x "$p" 2>/dev/null || true
 done
 
@@ -32,11 +32,11 @@ sudo docker rm nv-psf 2>/dev/null || true
 
 # 4. Verify
 sleep 1
-REMAIN=$(ps -eo comm | grep -cE '^(launch_hoisa\.sh|atl_sdm|proximity_sdm|safety_monitor|fsicom-agent)$' || true)
+REMAIN=$(ps -eo comm | grep -cE '^(launch_hoisa\.sh|atl_sdm|proximity_sdm|safety_monitor)$' || true)
 if [ "$REMAIN" -eq 0 ] && [ -z "$(sudo docker ps -q -f name=nv-psf)" ]; then
     echo "Stopped."
 else
     echo "WARNING: some processes/containers may still be alive:"
-    ps -eo pid,comm | grep -E '(launch_hoisa|atl_sdm|safety_monitor|fsicom)' | grep -v grep || true
+    ps -eo pid,comm | grep -E '(launch_hoisa|atl_sdm|safety_monitor)' | grep -v grep || true
     sudo docker ps -f name=nv-psf || true
 fi

--- a/deployments/profiles/base-thor.env
+++ b/deployments/profiles/base-thor.env
@@ -14,7 +14,8 @@ PSF_IMAGE=nvcr.io/nv-metropolis-dev/halos-outside-in/proactive-safety-framework:
 # === Thor Safety Core package (NGC resource, downloaded once at setup; ngc_artifacts.md §4) ===
 PSF_TEGRA_RESOURCE=nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-aarch64-release-dd3dae5-2026-07-27_18-52-psf-tegra  # host binaries .deb (atl_sdm, launch_hoisa, safety_monitor)
 
-# === Launch mode ===
+# === SDM placement / launch mode ===
+SDM_TARGET=ccplex        # where the SDM runs: ccplex = the Thor application cores
 PSF_LAUNCH_MODE=active   # skip = PSF without SAIM | learn = record SAIM sensor baselines | active = SAIM live (validates streams vs learned baselines)
 
 # === Safety command sink — the VST halo_safety overlay ===

--- a/deployments/profiles/base-thor.env
+++ b/deployments/profiles/base-thor.env
@@ -11,12 +11,10 @@ HOST_IP='' # change me — this Thor's IP
 # === Safety Core image (nv-psf container, multi-arch arm64+amd64, one tag) ===
 PSF_IMAGE=nvcr.io/nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-release-dd3dae5-2026-07-27_18-54  # multi-arch; Docker auto-selects arm64 on Thor (same tag as x86 base.env)
 
-# === Thor Safety Core packages (NGC resources, downloaded once at setup; ngc_artifacts.md §4) ===
-PSF_TEGRA_RESOURCE=nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-aarch64-release-dd3dae5-2026-07-27_18-52-psf-tegra         # host binaries .deb (atl_sdm, launch_hoisa, safety_monitor) for CCPLEX + FSI host side
-PSF_TEGRA_FSI_RESOURCE=nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-aarch64-release-dd3dae5-2026-07-27_18-52-psf-tegra-fsi  # FSI firmware + fsicom-agent .deb (SDM_TARGET=fsi only)
+# === Thor Safety Core package (NGC resource, downloaded once at setup; ngc_artifacts.md §4) ===
+PSF_TEGRA_RESOURCE=nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-aarch64-release-dd3dae5-2026-07-27_18-52-psf-tegra  # host binaries .deb (atl_sdm, launch_hoisa, safety_monitor)
 
-# === SDM placement / launch mode ===
-SDM_TARGET=ccplex        # ccplex (host SDM, start here) | fsi (SDM on the Functional Safety Island — halos_thor.md §5B)
+# === Launch mode ===
 PSF_LAUNCH_MODE=active   # skip = PSF without SAIM | learn = record SAIM sensor baselines | active = SAIM live (validates streams vs learned baselines)
 
 # === Safety command sink — the VST halo_safety overlay ===

--- a/deployments/profiles/hil-thor.env
+++ b/deployments/profiles/hil-thor.env
@@ -1,9 +1,9 @@
 # HIL profile — Thor safety-host side (the x86 stimulus side uses profiles/hil.env).
 # Not a compose profile: `launch_thor_safety.sh hil-thor` reads this file and starts the
 # Safety Core = the nv-psf container (event integration + decision gateway) plus the host
-# SDM (`atl_sdm` for ccplex, or the `fsicom-agent` bridge for fsi). Same launch path as
-# base-thor; the one difference is the command sink: decisions go to the x86 comm-layer
-# (PEER_HOST_IP:12346), not the local VST overlay (:12345).
+# SDM (`atl_sdm` on the CCPLEX). Same launch path as base-thor; the one difference is the
+# command sink: decisions go to the x86 comm-layer (PEER_HOST_IP:12346), not the local VST
+# overlay (:12345).
 # VSS prerequisites on this Thor before launching: see references/halos_hil.md.
 # Usage:  bash closed-loop-testing/scripts/launch_thor_safety.sh hil-thor
 
@@ -12,11 +12,9 @@ PEER_HOST_IP='' # change me — the x86 stimulus host (comm-layer)
 
 # nv-psf container (multi-arch; Docker selects arm64 on Thor — same tag as the x86 profiles)
 PSF_IMAGE=nvcr.io/nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-release-dd3dae5-2026-07-27_18-54
-# Thor host packages (install per ngc_artifacts.md §4; keep the SAME build tag as PSF_IMAGE)
-PSF_TEGRA_RESOURCE=nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-aarch64-release-dd3dae5-2026-07-27_18-52-psf-tegra         # host binaries .deb (atl_sdm, launch_hoisa, safety_monitor) for CCPLEX + FSI host side
-PSF_TEGRA_FSI_RESOURCE=nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-aarch64-release-dd3dae5-2026-07-27_18-52-psf-tegra-fsi  # FSI firmware + fsicom-agent .deb (SDM_TARGET=fsi only)
+# Thor host package (install per ngc_artifacts.md §4; keep the SAME build tag as PSF_IMAGE)
+PSF_TEGRA_RESOURCE=nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-aarch64-release-dd3dae5-2026-07-27_18-52-psf-tegra  # host binaries .deb (atl_sdm, launch_hoisa, safety_monitor)
 
-SDM_TARGET=ccplex        # ccplex (host SDM, start here) | fsi (SDM on the Functional Safety Island — halos_thor.md §5B)
 PSF_LAUNCH_MODE=skip     # skip = PSF without SAIM | learn = record SAIM sensor baselines | active = SAIM live (validates streams vs learned baselines)
 PSF_CMD_RX_IP=${PEER_HOST_IP}
 PSF_CMD_RX_PORT=12346    # the x86 comm-layer COMM_UDP_PORT (hil.env) — NOT the VST overlay port

--- a/deployments/profiles/hil-thor.env
+++ b/deployments/profiles/hil-thor.env
@@ -15,6 +15,7 @@ PSF_IMAGE=nvcr.io/nv-metropolis-dev/halos-outside-in/proactive-safety-framework:
 # Thor host package (install per ngc_artifacts.md §4; keep the SAME build tag as PSF_IMAGE)
 PSF_TEGRA_RESOURCE=nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-aarch64-release-dd3dae5-2026-07-27_18-52-psf-tegra  # host binaries .deb (atl_sdm, launch_hoisa, safety_monitor)
 
+SDM_TARGET=ccplex        # where the SDM runs: ccplex = the Thor application cores
 PSF_LAUNCH_MODE=skip     # skip = PSF without SAIM | learn = record SAIM sensor baselines | active = SAIM live (validates streams vs learned baselines)
 PSF_CMD_RX_IP=${PEER_HOST_IP}
 PSF_CMD_RX_PORT=12346    # the x86 comm-layer COMM_UDP_PORT (hil.env) — NOT the VST overlay port

--- a/skills/hoisa-deploy-profile/SKILL.md
+++ b/skills/hoisa-deploy-profile/SKILL.md
@@ -43,7 +43,7 @@ Pick one profile (set `COMPOSE_PROFILES` in the profile run-env). Services start
 > for 2D and 3D — including the Isaac Sim launch (`--enable-vst`, see `references/test_scenario.md`);
 > only the VSS perception side, the model, and the calibration change.
 
-> **`base` on IGX Thor (aarch64)** — the skill detects the platform and, on Thor, asks whether to run the SDM on **CCPLEX** or **FSI** (covered in `references/halos_thor.md`). The CCPLEX path follows the x86 flow; the FSI path is advanced (a one-time firmware reflash).
+> **`base` on IGX Thor (aarch64)** — the skill detects the platform; on Thor the SDM runs on the **CCPLEX** application cores and the stack is launched by `launch_thor_safety.sh` instead of `docker compose` (covered in `references/halos_thor.md`).
 
 ---
 
@@ -138,13 +138,13 @@ Deploy in strict order. **Stack 1 (VSS) must be running before Stack 2 (Halos).*
 | Document | Use When |
 |----------|----------|
 | [references/prerequisites.md](references/prerequisites.md) | Hardware/software requirements, Docker, NGC CLI, driver, GPU selection |
-| [references/ngc_artifacts.md](references/ngc_artifacts.md) | Pulling sil-data + PSF image + VSS images from NGC; **Thor Safety Core `.deb`s (`psf-tegra` + `psf-tegra-fsi`)** |
+| [references/ngc_artifacts.md](references/ngc_artifacts.md) | Pulling sil-data + PSF image + VSS images from NGC; **Thor Safety Core `.deb` (`psf-tegra`)** |
 | [references/vss_2d_overrides.md](references/vss_2d_overrides.md) | VSS Warehouse 2D `.env`, DeepStream config, and VST config for Isaac Sim |
 | [references/vss_3d_overrides.md](references/vss_3d_overrides.md) | **3D (Sparse4D) profile** — VSS `.env`, DeepStream + `config.yaml`, VST overrides |
 | [references/model_r101.md](references/model_r101.md) | **3D** — the R101 Sparse4D model recipe (deployable ONNX + trainable kmeans anchor, version-matched) |
 | [references/calibration_3d.md](references/calibration_3d.md) | **3D** — the 3-camera BEV calibration (`group` / `rois` / `tripwires`) |
 | [references/halos_deploy.md](references/halos_deploy.md) | Configuring and deploying the Halos stack by profile |
-| [references/halos_thor.md](references/halos_thor.md) | Deploying `base` on IGX Thor (aarch64) — SDM on CCPLEX or FSI |
+| [references/halos_thor.md](references/halos_thor.md) | Deploying `base` on IGX Thor (aarch64) — the hybrid container + host-binary Safety Core |
 | [references/vss_hil_overrides.md](references/vss_hil_overrides.md) | **HIL** — VSS deltas for a remote Isaac source: stream URLs, sensor-registration ownership, fresh state |
 | [references/halos_hil.md](references/halos_hil.md) | **HIL profile** — the two-host closed loop runbook (x86 stimulus + IGX Thor safety host) |
 | [references/test_scenario.md](references/test_scenario.md) | Running the simulation, monitoring safety commands, viewing camera streams |
@@ -164,7 +164,7 @@ Deploy in strict order. **Stack 1 (VSS) must be running before Stack 2 (Halos).*
 | `BP_PROFILE_KAFKA` | VSS must use `BP_PROFILE=bp_wh_kafka` (not `bp_wh`) for Halos integration | `vss_2d_overrides.md` |
 | `LLM_VLM_NONE` | Set `LLM_MODE=none` and `VLM_MODE=none` — not needed for safety SIL | `vss_2d_overrides.md` |
 | `HALO_SAFETY_BASE` | **`base` profile**: to render the safety overlay, set `halo_safety_udp_port` in the VSS 2D `vst_config.json` from `-1` → `12345` (must equal `COMM_UDP_PORT`), then restart VST | `halos_deploy.md`, `vss_2d_overrides.md` |
-| `THOR_BASE` | **`base`: detect the platform** (`uname -m`). `x86_64` → standard container base. **`aarch64` (IGX Thor)** → **ask the user** which SDM target before deploying — **CCPLEX** (decision-maker as host software on the Thor application cores; simpler, no firmware change) or **FSI** (decision-maker on the Functional Safety Island, the on-die safety microcontroller; needs a one-time firmware reflash) — then launch via `launch_thor_safety.sh` (hybrid container + host binaries, **not** `docker compose`) | `halos_thor.md` |
+| `THOR_BASE` | **`base`: detect the platform** (`uname -m`). `x86_64` → standard container base. **`aarch64` (IGX Thor)** → the decision-maker runs as host software on the Thor application cores (**CCPLEX**); launch via `launch_thor_safety.sh` (hybrid container + host binaries, **not** `docker compose`) | `halos_thor.md` |
 | `HOST_IP_BOTH` | `HOST_IP` must be set in **both** the VSS and Halos run-env files | `halos_deploy.md` |
 | `SIL_DATA_PATH` | Halos `MDX_DATA_DIR` points to **sil-data** (has `collected-assets/`), not VSS app-data | `halos_deploy.md`, `ngc_artifacts.md` |
 | `ROS_DOMAIN_UNIQUE` | Assign a unique `ROS_DOMAIN_ID` (0-232) per machine; verify `Publisher count: 1` on `/safety/is_muted` | `halos_deploy.md`, `troubleshooting.md` |

--- a/skills/hoisa-deploy-profile/references/halos_hil.md
+++ b/skills/hoisa-deploy-profile/references/halos_hil.md
@@ -7,7 +7,7 @@ x86 stimulus host                          IGX Thor safety host
 ─────────────────                          ────────────────────
 isaac-sim (3 cams, RTSP :8554-8556) ──────▶ VST + DS perception (pull the Isaac streams)
 forklift-controller ─ROS─▶ isaac-sim              │ BA events → Kafka → Safety Core
-comm-layer ◀────────────── UDP :12346 ──── atl_sdm (ccplex) or FSI
+comm-layer ◀────────────── UDP :12346 ──── atl_sdm
      └─ROS─▶ /safety/is_muted ─▶ isaac-sim indicator / consumers
 ```
 
@@ -18,7 +18,7 @@ Run the deployment (and this skill) from the **x86 host**; ssh access to the Tho
 ## 0. Prerequisites
 
 - x86 host: per `prerequisites.md` (GPU for Isaac Sim), plus the NGC artifacts from `ngc_artifacts.md` §1 (sil-data).
-- Thor host: IGX Thor on a current GA release with VSS Warehouse 3.2.1 deployable, plus the Safety Core packages from `ngc_artifacts.md` §4 (`psf-tegra`, and `psf-tegra-fsi` for the FSI target).
+- Thor host: IGX Thor on a current GA release with VSS Warehouse 3.2.1 deployable, plus the Safety Core package from `ngc_artifacts.md` §4 (`psf-tegra`).
 - Network: the two hosts must reach each other (Isaac RTSP ports 8554-8556 toward the x86; UDP `COMM_UDP_PORT` toward the x86; VST :30888 and perception :9000 toward the Thor for orchestration).
 
 ## 1. x86: configure and start the stimulus stack
@@ -75,7 +75,7 @@ tmux new -s safety
 bash closed-loop-testing/scripts/launch_thor_safety.sh hil-thor
 ```
 
-Verify per `halos_thor.md` §5A (ccplex) or §5B (FSI): `nv-psf` up, and `atl_sdm` running (ccplex) or `fsicom-agent` with the relay flags (FSI); then confirm decisions are actually flowing per §5C. Both SDM targets work with this profile; start with ccplex.
+Verify per `halos_thor.md` §5: `nv-psf` up and `atl_sdm` running, then confirm decisions are actually flowing (same section).
 
 ## 6. Verify the closed loop
 
@@ -100,7 +100,7 @@ The Isaac scene's safety indicator follows `is_muted`, and the VST WebUI on the 
 | x86 stack | 3 services up; comm-layer healthy; UDP `COMM_UDP_PORT` bound |
 | Scenario | All 3 RTSP streams deliver frames (ffprobe, §2); forklift-controller `pose=` lines advancing |
 | Thor VSS | 3 sensors `online` in VST with the x86 IP; `Active sources : 3`, fps > 0 |
-| Safety Core | `nv-psf` up on the Thor; SDM process present (`atl_sdm` or `fsicom-agent`) |
+| Safety Core | `nv-psf` up on the Thor; SDM process present (`atl_sdm`) |
 | Closed loop | comm-layer receives heartbeats + decisions; `/safety/is_muted` updates; sim-driven MUTE/UNMUTE transitions observed |
 
 ## Restart the scenario (hil)

--- a/skills/hoisa-deploy-profile/references/halos_thor.md
+++ b/skills/hoisa-deploy-profile/references/halos_thor.md
@@ -1,13 +1,9 @@
-# Halos `base` on IGX Thor (aarch64) — CCPLEX & FSI
+# Halos `base` on IGX Thor (aarch64)
 
 Deploy the `base` profile (VSS Warehouse + Safety Core, no Isaac Sim / closed loop) on an
 **IGX Thor** device. The safety decision (MUTE / UNMUTE) renders as the VST `halo_safety`
 overlay, exactly like the x86 `base` profile — only the Safety Core runs on the Thor instead
 of as an x86 container.
-
-> **Scope.** The **CCPLEX** path mirrors the x86 `base` Safety Core flow — start here. The
-> **FSI** path is more involved (a one-time firmware reflash); steps to confirm on your board
-> are marked **⚠ validate on your hardware**.
 
 ---
 
@@ -15,30 +11,18 @@ of as an x86 container.
 
 On x86, `base` runs the Safety Core as a single container via `docker compose`
 (`profiles/base.env`). On Thor the Safety Core is **hybrid** — an `nv-psf` container (event
-integration + decision gateway) plus **host binaries** (the SDM, the AI monitor, and, for
-FSI, the FSI bridge) orchestrated by `launch_hoisa.sh`. It is therefore launched by a helper
-script that reads an env file, **not** by `docker compose`.
+integration + decision gateway) plus **host binaries** (the SDM and the AI monitor)
+orchestrated by `launch_hoisa.sh`. It is therefore launched by a helper script that reads an
+env file, **not** by `docker compose`.
 
-| Variant | Where the SDM runs | Mechanism |
+| Platform | Where the SDM runs | Mechanism |
 |---|---|---|
-| x86 / CCPLEX | x86 container | `docker compose --env-file profiles/base.env` (the standard `base`) |
-| **Thor / CCPLEX** | Thor application cores | `launch_thor_safety.sh` → `launch_hoisa.sh --sdm-target ccplex` |
-| **Thor / CCPLEX + FSI** | Functional Safety Island | `launch_thor_safety.sh` → `launch_hoisa.sh --sdm-target fsi` (+ FSI firmware + `nvFsiCom`) |
+| x86 | x86 container | `docker compose --env-file profiles/base.env` (the standard `base`) |
+| **IGX Thor** | Thor application cores | `launch_thor_safety.sh` → `launch_hoisa.sh --sdm-target ccplex` |
 
 > The same Thor Safety Core launch path is reused by the (forthcoming) HIL profile — HIL adds
 > the x86 stimulus side (Isaac Sim + comm-layer + ROS) and points the safety command at the
 > comm-layer instead of the VST overlay.
-
----
-
-## Choose the SDM target
-
-On a `base` deploy the skill detects the platform: x86 runs the standard container base; on IGX Thor (aarch64) it **asks you** which SDM target to use before deploying — it does not assume one. The two options:
-
-- **CCPLEX** — the SDM (`atl_sdm`) runs as a host process on the Thor application cores. No
-  firmware change. **Start here.**
-- **FSI** — the SDM runs on the Functional Safety Island; the host runs `fsicom-agent` as a
-  bridge. Requires a one-time FSI firmware reflash and the `nvFsiCom` daemon. **Advanced.**
 
 ---
 
@@ -57,11 +41,7 @@ On a `base` deploy the skill detects the platform: x86 runs the standard contain
   binaries from the `psf-tegra` package — see the next bullet.)
 - Safety Core host binaries from the **`psf-tegra`** package installed under `/opt/nvidia/psf/`
   (`ngc_artifacts.md` §4): provides `launch_hoisa.sh`, the SDM apps (`atl_sdm`), `safety_monitor`,
-  and the sensor config. This is all CCPLEX needs.
-- **FSI only:** the **`psf-tegra-fsi`** package (`ngc_artifacts.md` §4), which provides both the
-  HOISA FSI firmware (blob `fsi-ffw-t264.bin`, reflashed onto the FSI QSPI, §5B) **and** the
-  `fsicom-agent` FSI bridge binary (installed on the Thor). Plus the `nvFsiCom` daemon at
-  `/opt/nvidia/ccplex_sf/fsi_ccplex_com/nvFsiCom` (ships with the GA OS).
+  and the sensor config.
 
 ## 2. Deploy VSS Warehouse 3.2.1 on Thor (perception)
 
@@ -92,7 +72,6 @@ data. See `vss_2d_overrides.md` for the base-vs-SIL override notes.
 Edit `deployments/profiles/base-thor.env` (fill the `# change me` fields):
 
 - `HOST_IP` — this Thor's IP.
-- `SDM_TARGET` — `ccplex` (start here) or `fsi`.
 - `PSF_IMAGE` — the nv-psf container (multi-arch; same tag as x86 `base`, Docker selects arm64 on Thor).
 - `PSF_CMD_RX_PORT` — `12345`, the VST `halo_safety` overlay port (see §6).
 - `PSF_LAUNCH_MODE` — `active` (full stack) or `skip` (omit the AI monitor; use only if the
@@ -121,10 +100,6 @@ with `launch_hoisa.sh --mode learn …` (it reads the same sensor config as §3)
 
 `launch_thor_safety.sh` reads `base-thor.env` and invokes `launch_hoisa.sh`.
 
-### 5A. SDM on CCPLEX  (start here)
-
-Set `SDM_TARGET=ccplex` in `base-thor.env`, then:
-
 ```bash
 bash closed-loop-testing/scripts/launch_thor_safety.sh base-thor
 ```
@@ -133,77 +108,13 @@ Verify:
 
 ```bash
 docker ps --filter name=nv-psf        # nv-psf container Up
-ps -eo comm | grep -x atl_sdm         # CCPLEX SDM running
+ps -eo comm | grep -x atl_sdm         # SDM running
 ```
 
-### 5B. SDM on FSI  (advanced — ⚠ validate on your hardware)
-
-FSI needs host setup the launcher cannot do for you:
-
-1. **Reflash the FSI** with the HOISA safety firmware. This is done on the **flashing host**
-   (the machine with the Thor in USB recovery/RCM mode + the BSP `Linux_for_Tegra` tree),
-   **not** on the running Thor — and it replaces the SEP default FSI firmware with HOISA's.
-   - **a. Get the firmware blob.** Download + extract `psf-tegra-fsi` (`ngc_artifacts.md` §4):
-     ```bash
-     dpkg -x outside-in-safety_v*-psf-tegra-fsi/psf-tegra-fsi.deb /tmp/psf-fsi/
-     ls /tmp/psf-fsi/opt/nvidia/psf/etc/fsi-fw/atl/fsi-ffw-t264.bin   # the atl HOISA FSI firmware
-     ```
-   - **b. Stage it into the BSP**, backing up the SEP default first so you can roll back:
-     ```bash
-     cd <Linux_for_Tegra>/bootloader        # or the FSI firmware dir for your board
-     cp fsi-ffw-t264.bin fsi-ffw-t264.bin.SEP-DEFAULT.bak
-     cp /tmp/psf-fsi/opt/nvidia/psf/etc/fsi-fw/atl/fsi-ffw-t264.bin ./fsi-ffw-t264.bin
-     ```
-   - **c. Put the board in recovery and flash QSPI slot A** (`internal`; drop `UNIFIED_FLASH`):
-     ```bash
-     sudo ./tools/kernel_flash/l4t_initrd_flash.sh --qspi-only -k A_fsi-fw <board-spec> internal
-     ```
-     `<board-spec>` is your board's flash configuration (for example,
-     `p3834-0008-p4071-0008-nv-safety` for the IGX Thor Developer Kit Mini (T5000); the
-     IGX Thor Developer Kit (T7000) uses its own config — use the one from your BSP). Slot A
-     alone is sufficient for evaluation (~30 s); flash slot B as well for production failover.
-     The flash tool `l4t_initrd_flash.sh` and the `Linux_for_Tegra` tree come from the IGX Driver
-     Package (BSP) on the [NVIDIA IGX Download Center](https://developer.nvidia.com/igx-downloads).
-   - **d. Boot + confirm the FSI handshake** came up: `sudo dmesg | grep -i fsi` shows
-     `epl_client … handshake done with FSI`. **Rollback:** restore the `.SEP-DEFAULT.bak`
-     blob + reflash slot A (~5 min). QSPI-only flashing does **not** touch rootfs / VSS.
-2. **On the Thor, install `psf-tegra-fsi`** for the `fsicom-agent` bridge binary:
-   ```bash
-   ngc registry resource download-version "$PSF_TEGRA_FSI_RESOURCE"   # path from base-thor.env
-   sudo dpkg -i */psf-tegra-fsi.deb
-   ls /opt/nvidia/psf/bin/fsicom-agent
-   ```
-3. **Start `nvFsiCom`** on the CCPLEX *before* the launcher:
-   ```bash
-   sudo /opt/nvidia/ccplex_sf/fsi_ccplex_com/nvFsiCom &
-   ```
-4. Set `SDM_TARGET=fsi` in `base-thor.env`, then launch:
-   ```bash
-   bash closed-loop-testing/scripts/launch_thor_safety.sh base-thor
-   ```
-
-Verify (FSI markers):
-
-```bash
-ps -eo comm | grep -x fsicom-agent    # FSI bridge running
-ps -eo comm | grep -qx atl_sdm && echo "unexpected: CCPLEX SDM should be ABSENT in FSI mode"
-```
-
-> **⚠ FSI relay flags.** The bridge must run with the response-relay flags so FSI decisions
-> reach the overlay (HOISA User Guide §2.2.2):
->
-> ```bash
-> sudo fsicom-agent --relay-fsi-resp --ip <cmd-rx-ip> --port <cmd-rx-port> --heartbeat
-> ```
->
-> Pass only these flags. If decisions are produced upstream (`5C`) but the overlay never
-> transitions, check the `fsicom-agent` flags first.
-
-### 5C. Verify the Safety Core is producing decisions (both targets)
-
-The process checks above confirm the components are *up*; these confirm the decision chain is
-actually *flowing*. The Thor host install writes to `/var/log/psf/` (the launcher prints the
-exact paths on start). Run while VSS perception is serving and the forklift/people are moving:
+The checks above confirm the components are *up*. To confirm the decision chain is actually
+*flowing*, check the logs — the Thor host install writes to `/var/log/psf/` (the launcher
+prints the exact paths on start). Run while VSS perception is serving and the forklift/people
+are moving:
 
 ```bash
 # PSF ingested perception events and invoked the decision gateway:
@@ -245,7 +156,6 @@ bash closed-loop-testing/scripts/stop_thor_safety.sh
 | `nvstreamer-2d` stuck `Created` / `Runtime=runc`, `Active sources : 0` after a VSS `down -v` or datalog cleanup | The `runtime: nvidia` fix on `nvstreamer-2d` (§2) was reverted to stock when VSS state was wiped. Re-uncomment it in `warehouse-2d-app.yml`, then `docker compose --env-file … up -d --force-recreate --no-deps nvstreamer-2d`. Re-apply after every `down -v` / cleanup, before `up`. |
 | `nv-psf` / perception can't get the GPU after a reboot | The CDI spec lives on tmpfs — regenerate: `sudo nvidia-ctk cdi generate --output=/var/run/cdi/nvidia.yaml && sudo systemctl restart docker` |
 | AI monitor reads no frames | `sensor_config_thor.conf` URLs/UUIDs are stale — refresh from the VST sensor list |
-| FSI decisions don't reach the overlay | `nvFsiCom` not running, or `fsicom-agent` not started with exactly the §5B relay flags |
 | Overlay blank but decisions are logged | Port mismatch — `halo_safety_udp_port` ≠ `PSF_CMD_RX_PORT` (both must be `12345`) |
 
 For perception / STALE / SEI issues, see `troubleshooting.md`.

--- a/skills/hoisa-deploy-profile/references/halos_thor.md
+++ b/skills/hoisa-deploy-profile/references/halos_thor.md
@@ -72,6 +72,7 @@ data. See `vss_2d_overrides.md` for the base-vs-SIL override notes.
 Edit `deployments/profiles/base-thor.env` (fill the `# change me` fields):
 
 - `HOST_IP` — this Thor's IP.
+- `SDM_TARGET` — where the SDM runs: `ccplex`, the Thor application cores.
 - `PSF_IMAGE` — the nv-psf container (multi-arch; same tag as x86 `base`, Docker selects arm64 on Thor).
 - `PSF_CMD_RX_PORT` — `12345`, the VST `halo_safety` overlay port (see §6).
 - `PSF_LAUNCH_MODE` — `active` (full stack) or `skip` (omit the AI monitor; use only if the

--- a/skills/hoisa-deploy-profile/references/ngc_artifacts.md
+++ b/skills/hoisa-deploy-profile/references/ngc_artifacts.md
@@ -11,7 +11,7 @@ there is no Halos compose package to download. From NGC you pull only:
 
 VSS Warehouse images are pulled when you deploy VSS, not here — via the `vss-deploy-profile` skill, or per the public VSS Warehouse docs (github.com/NVIDIA-AI-Blueprints/video-search-and-summarization).
 
-> **Access**: the Halos packages are in the `nvidia/halos-outside-in` NGC team (the gated FSI package is under `nvidia/outside-in-safety`). If
+> **Access**: the Halos packages are in the `nvidia/halos-outside-in` NGC team. If
 > `ngc registry resource info` or `docker pull` returns `402` / `403`, your NGC key is not
 > authorized for that org — confirm `ngc config set` and `docker login nvcr.io` with a key
 > that has access.
@@ -72,18 +72,17 @@ docker pull "$ISAAC_SIM_IMAGE"
 
 ---
 
-## 4. Thor Safety Core packages — `psf-tegra` + `psf-tegra-fsi` (Thor `base` / `hil` only)
+## 4. Thor Safety Core package — `psf-tegra` (Thor `base` / `hil` only)
 
 On IGX Thor the Safety Core runs partly as **host binaries** (not in the PSF container),
-so it needs the aarch64 Safety Core `.deb`s from NGC. x86 profiles do **not** need these
-(the SDM runs in the container there). Both NGC resource paths are pinned in
+so it needs the aarch64 Safety Core `.deb` from NGC. x86 profiles do **not** need it
+(the SDM runs in the container there). The NGC resource path is pinned in
 `deployments/profiles/base-thor.env` — the single source of truth, the same way `PSF_IMAGE`
-is. Source that env, then reference the variables:
+is. Source that env, then reference the variable:
 
 | Env var | Needed by | Contains |
 |---|---|---|
-| `PSF_TEGRA_RESOURCE` | Thor `base` (CCPLEX **and** FSI host side) | host binaries → `/opt/nvidia/psf/`: `atl_sdm`, `launch_hoisa.sh`, `safety_monitor`, sensor config |
-| `PSF_TEGRA_FSI_RESOURCE` | **FSI only** (`SDM_TARGET=fsi`) | the HOISA FSI firmware blobs (`fsi-ffw-t264.bin` for `atl`, + proximity) flashed to the FSI QSPI, **plus** the `fsicom-agent` bridge binary installed on the Thor. See `halos_thor.md` §5B |
+| `PSF_TEGRA_RESOURCE` | Thor `base` / `hil` | host binaries → `/opt/nvidia/psf/`: `atl_sdm`, `launch_hoisa.sh`, `safety_monitor`, sensor config |
 
 ```bash
 set -a; source deployments/profiles/base-thor.env; set +a
@@ -96,23 +95,6 @@ ngc registry resource download-version "$PSF_TEGRA_RESOURCE"
 sudo dpkg -i */psf-tegra.deb
 ls /opt/nvidia/psf/bin/        # → atl_sdm, launch_hoisa.sh, safety_monitor, …
 ```
-
-### Fetch `psf-tegra-fsi` (FSI only, `SDM_TARGET=fsi`)
-
-`psf-tegra-fsi` provides the `fsicom-agent` binary (install on the Thor) and the FSI firmware
-blob (stage + QSPI-flash, see `halos_thor.md` §5B):
-
-```bash
-ngc registry resource download-version "$PSF_TEGRA_FSI_RESOURCE"
-# (a) on the Thor: install for fsicom-agent
-sudo dpkg -i */psf-tegra-fsi.deb && ls /opt/nvidia/psf/bin/fsicom-agent
-# (b) for the firmware blob (extract; flashing-host staging in halos_thor.md §5B)
-dpkg -x */psf-tegra-fsi.deb /tmp/psf-fsi/
-ls /tmp/psf-fsi/opt/nvidia/psf/etc/fsi-fw/atl/fsi-ffw-t264.bin   # the atl HOISA FSI firmware blob
-```
-
-Then follow `halos_thor.md` §5B to stage `fsi-ffw-t264.bin` into the BSP bootloader dir
-(backing up the SEP default) and flash QSPI slot A.
 
 ---
 


### PR DESCRIPTION
## Why

FSI and its related components are proprietary and must not be referenced in this public repo. This change makes the repo document and launch the Thor Safety Core on the **CCPLEX only**.

## What changed

| Area | Change |
|---|---|
| `references/halos_thor.md` | Title, scope note, SDM-target choice section, the FSI prerequisite bullet, the FSI launch section (firmware staging / QSPI flash / bridge relay flags) and the FSI troubleshooting row are removed. Top-level section numbers are unchanged, so every existing cross-reference still resolves; the remaining flow reads as the single path it now is. |
| `references/ngc_artifacts.md` | §4 documents `psf-tegra` only — the FSI package fetch/flash subsection, its env-var table row, and the gated-org note are removed. |
| `SKILL.md`, `references/halos_hil.md`, `README.md` | The Thor Safety Core is described without a target choice; the hil diagram, prerequisites, verify step and ready-signals table reference `atl_sdm` only. |
| `profiles/base-thor.env`, `profiles/hil-thor.env` | `PSF_TEGRA_FSI_RESOURCE` removed. `SDM_TARGET` stays as a profile knob, shipping `ccplex`. |
| `scripts/launch_thor_safety.sh` | Drops the FSI daemon precheck; still reads `SDM_TARGET` (default `ccplex`) and passes it to the launcher, so **the CCPLEX path is behaviourally unchanged**. |
| `scripts/stop_thor_safety.sh` | Stops only the processes the launcher starts. The primary stop path is unchanged: `SIGTERM` to the launcher, whose own trap cleans up its children. |

## Verification

- `git grep -inE "fsi|fsicom|nvFsiCom|psf-tegra-fsi|functional safety island"` over `skills/`, `closed-loop-testing/`, `deployments/`, `README.md` → **no hits** (the one remaining grep match is the substring in `bufsize=1` in a notebook).
- `bash -n` passes for both Thor scripts; the pre- and post-change launcher invocations were compared for the CCPLEX path.
- Every `halos_thor.md` section pointer cited from other files re-checked; no dangling references.
- Docs re-read end to end for seams left by the deletion.