### PR TITLE
chore(deploy): bump PSF build dd3dae5 → f9210aa across profiles

### DIFF
--- a/deployments/profiles/base-thor.env
+++ b/deployments/profiles/base-thor.env
@@ -9,10 +9,10 @@
 HOST_IP='' # change me — this Thor's IP
 
 # === Safety Core image (nv-psf container, multi-arch arm64+amd64, one tag) ===
-PSF_IMAGE=nvcr.io/nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-release-dd3dae5-2026-07-27_18-54  # multi-arch; Docker auto-selects arm64 on Thor (same tag as x86 base.env)
+PSF_IMAGE=nvcr.io/nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-release-f9210aa-2026-07-29_12-14  # multi-arch; Docker auto-selects arm64 on Thor (same tag as x86 base.env)
 
 # === Thor Safety Core package (NGC resource, downloaded once at setup; ngc_artifacts.md §4) ===
-PSF_TEGRA_RESOURCE=nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-aarch64-release-dd3dae5-2026-07-27_18-52-psf-tegra  # host binaries .deb (atl_sdm, launch_hoisa, safety_monitor)
+PSF_TEGRA_RESOURCE=nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-aarch64-release-f9210aa-2026-07-29_12-12-psf-tegra  # host binaries .deb (atl_sdm, launch_hoisa, safety_monitor)
 
 # === SDM placement / launch mode ===
 SDM_TARGET=ccplex        # where the SDM runs: ccplex = the Thor application cores

--- a/deployments/profiles/base.env
+++ b/deployments/profiles/base.env
@@ -18,7 +18,7 @@ MDX_DATA_DIR=/path/to/data # change me
 HOST_IP='' # change me
 
 COMM_UDP_PORT=12345   # PSF cmd target = VST halo_safety_udp_port (NOT comm-layer in base)
-PSF_IMAGE=nvcr.io/nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-release-dd3dae5-2026-07-27_18-54
+PSF_IMAGE=nvcr.io/nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-release-f9210aa-2026-07-29_12-14
 PSF_LAUNCH_MODE=skip  # skip = PSF without SAIM | learn = record SAIM sensor baselines | active = SAIM live (validates streams vs learned baselines)
 PSF_CMD_RX_IP=127.0.0.1
 PSF_LOG_DIR=${MDX_DATA_DIR}/psf-log

--- a/deployments/profiles/hil-thor.env
+++ b/deployments/profiles/hil-thor.env
@@ -11,9 +11,9 @@ HOST_IP='' # change me — this Thor's IP
 PEER_HOST_IP='' # change me — the x86 stimulus host (comm-layer)
 
 # nv-psf container (multi-arch; Docker selects arm64 on Thor — same tag as the x86 profiles)
-PSF_IMAGE=nvcr.io/nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-release-dd3dae5-2026-07-27_18-54
+PSF_IMAGE=nvcr.io/nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-release-f9210aa-2026-07-29_12-14
 # Thor host package (install per ngc_artifacts.md §4; keep the SAME build tag as PSF_IMAGE)
-PSF_TEGRA_RESOURCE=nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-aarch64-release-dd3dae5-2026-07-27_18-52-psf-tegra  # host binaries .deb (atl_sdm, launch_hoisa, safety_monitor)
+PSF_TEGRA_RESOURCE=nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-aarch64-release-f9210aa-2026-07-29_12-12-psf-tegra  # host binaries .deb (atl_sdm, launch_hoisa, safety_monitor)
 
 SDM_TARGET=ccplex        # where the SDM runs: ccplex = the Thor application cores
 PSF_LAUNCH_MODE=skip     # skip = PSF without SAIM | learn = record SAIM sensor baselines | active = SAIM live (validates streams vs learned baselines)

--- a/deployments/profiles/sil.env
+++ b/deployments/profiles/sil.env
@@ -21,7 +21,7 @@ COMM_LOG_DIR=${MDX_DATA_DIR}/comm-layer
 ROS_DOMAIN_ID=0
 
 # === PSF ===
-PSF_IMAGE=nvcr.io/nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-release-dd3dae5-2026-07-27_18-54
+PSF_IMAGE=nvcr.io/nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-release-f9210aa-2026-07-29_12-14
 PSF_LAUNCH_MODE=skip  # skip = PSF without SAIM | learn = record SAIM sensor baselines | active = SAIM live (validates streams vs learned baselines)
 PSF_CMD_RX_IP=127.0.0.1
 PSF_LOG_DIR=${MDX_DATA_DIR}/psf-log


### PR DESCRIPTION
Point the sil / base / base-thor / hil-thor profiles at the latest 1.3 PSF build `nv-psf-halos-1.3-release-f9210aa-2026-07-29`

- `PSF_IMAGE` → `...-release-f9210aa-2026-07-29_12-14` (multi-arch; amd64 x86 + arm64 Thor)
- `PSF_TEGRA_RESOURCE` → `...aarch64-release-f9210aa-2026-07-29_12-12-psf-tegra` (Thor host deb)