### PR TITLE
docs(skill): say which VSS settings differ from the defaults

### DIFF
--- a/skills/hoisa-deploy-profile/references/vss_2d_overrides.md
+++ b/skills/hoisa-deploy-profile/references/vss_2d_overrides.md
@@ -24,15 +24,15 @@ keeps decisions flowing.
 
 ## .env Overrides
 
-Set in `<wh_ops>/.env` (in 3.2.1 these are often already the `bp_wh_kafka` defaults —
-confirm they are set):
+Set in `<wh_ops>/.env`. Verified against the v3.2.1 tag: only `VLM_MODE` already carries
+the value below — the rest ship differently and must be changed:
 
 ```bash
-BP_PROFILE=bp_wh_kafka                                          # MUST include Kafka for PSF
-LLM_MODE=none                                                   # Not needed for SIL
-VLM_MODE=none                                                   # Not needed for SIL
-SAMPLE_VIDEO_DATASET="warehouse-loading-dock-3cams-synthetic"   # SIL synthetic dataset (3 cams)
-NUM_STREAMS=3                                                   # Matches 3 Isaac Sim cameras
+BP_PROFILE=bp_wh_kafka                                          # default: bp_wh — MUST include Kafka for PSF
+LLM_MODE=none                                                   # default: local — not needed for SIL
+VLM_MODE=none                                                   # already the default
+SAMPLE_VIDEO_DATASET="warehouse-loading-dock-3cams-synthetic"   # default: nv-warehouse-4cams — SIL synthetic dataset (3 cams)
+NUM_STREAMS=3                                                   # default: 4 — matches 3 Isaac Sim cameras
 ```
 
 **Why**:

--- a/skills/hoisa-deploy-profile/references/vss_3d_overrides.md
+++ b/skills/hoisa-deploy-profile/references/vss_3d_overrides.md
@@ -47,14 +47,15 @@ survives an Isaac relaunch — exactly the same reason as the 2D profile.
 
 ## .env Overrides
 
-Set in `<wh_ops>/.env`:
+Set in `<wh_ops>/.env`. Only `VLM_MODE` already carries the value below; the rest ship
+differently and must be changed:
 
 ```bash
-BP_PROFILE=bp_wh_kafka                                             # MUST include Kafka for PSF
-LLM_MODE=none                                                      # Not needed for SIL
-VLM_MODE=none                                                      # Not needed for SIL
-NUM_STREAMS=3                                                      # Matches 3 Isaac Sim cameras
-SAMPLE_VIDEO_DATASET="warehouse-loading-dock-3cams-synthetic-3d"   # 3D synthetic calibration dataset
+BP_PROFILE=bp_wh_kafka                                             # default: bp_wh — MUST include Kafka for PSF
+LLM_MODE=none                                                      # default: local — not needed for SIL
+VLM_MODE=none                                                      # already the default
+NUM_STREAMS=3                                                      # default: 4 — matches 3 Isaac Sim cameras
+SAMPLE_VIDEO_DATASET="warehouse-loading-dock-3cams-synthetic-3d"   # default: nv-warehouse-4cams — 3D calibration dataset
 ```
 
 **Why**:


### PR DESCRIPTION
The 2D override reference said these values are "often already the `bp_wh_kafka` defaults" and asked the reader to confirm them.

Checked against the **v3.2.1 tag** of the VSS Warehouse Blueprint (`deploy/docker/industry-profiles/warehouse-operations/.env`):

| Setting | Ships as | Must change |
|---|---|---|
| `BP_PROFILE` | `bp_wh` | yes |
| `LLM_MODE` | `local` | yes |
| `NUM_STREAMS` | `4` | yes |
| `SAMPLE_VIDEO_DATASET` | `nv-warehouse-4cams` | yes |
| `VLM_MODE` | `none` | no |

One of five, not "often". `bp_wh` is the one that hurts: it starts no Kafka, so the Safety Core receives no perception events while every container still reports healthy — a failure that looks like nothing is wrong.

Each line now carries its default inline, and `vss_3d_overrides.md` gets the same treatment so the two references agree.

The same wording had propagated into psf-docs; corrected there in psf-docs!110.