### PR TITLE
fix(skill): probe RTSP with ffprobe, not gst-launch

### DIFF
--- a/skills/hoisa-deploy-profile/references/troubleshooting.md
+++ b/skills/hoisa-deploy-profile/references/troubleshooting.md
@@ -147,16 +147,21 @@ already wedges the media, so the contrast only shows cleanly before anything els
 
 ```bash
 declare -A MP=( [8554]=camera [8555]=camera_01 [8556]=camera_02 )
-# sequential — each should print video/x-h264 caps
+# sequential — a healthy port prints codec_name=h264; a wedged one times out
 for p in 8554 8555 8556; do
-  gst-launch-1.0 rtspsrc location=rtsp://127.0.0.1:$p/${MP[$p]} protocols=tcp \
-    num-buffers=1 ! fakesink 2>&1 | grep -aE "video/x-h264|no caps|could not"
+  echo "== :$p =="
+  ffprobe -rtsp_transport tcp -rw_timeout 5000000 -v error \
+    -select_streams v -show_entries stream=codec_name \
+    rtsp://127.0.0.1:$p/${MP[$p]} 2>&1 | grep -aE "codec_name|Could not|timed out|method DESCRIBE"
 done
-# concurrent — if these fail but the sequential pass worked, it's the concurrency race
+# concurrent — if the sequential pass worked but this fails, it is the concurrency race
 for p in 8554 8555 8556; do
-  gst-launch-1.0 rtspsrc location=rtsp://127.0.0.1:$p/${MP[$p]} protocols=tcp \
-    num-buffers=1 ! fakesink >/tmp/gst_$p.log 2>&1 & done; wait
-grep -lE "no caps|could not|ERROR" /tmp/gst_855*.log   # <- wedged ports
+  ffprobe -rtsp_transport tcp -rw_timeout 5000000 -v error \
+    -select_streams v -show_entries stream=codec_name \
+    rtsp://127.0.0.1:$p/${MP[$p]} >/tmp/ff_$p.log 2>&1 & done; wait
+for p in 8554 8555 8556; do
+  grep -qi h264 /tmp/ff_$p.log && echo ":$p OK" || echo ":$p WEDGED"
+done
 ```
 
 **Prevention (built-in)**: the SIL launch (`run_actor_sdg.py --enable-vst`) **defers VST


### PR DESCRIPTION
The "confirm which trigger" block in `troubleshooting.md` tells the reader to run it **from inside the `isaac-sim` container**, then calls `gst-launch-1.0`.

Verified on `isaac-sim:6.0.0`: no GStreamer tooling at all — both `command -v gst-launch-1.0` and a filesystem search come back empty. `/usr/bin/ffprobe` and `/usr/bin/ffmpeg` are present.

So both loops exit `command not found`, and the block cannot do the one thing it exists for: tell a cold pre-roll apart from the concurrent-DESCRIBE race (6478845).

The same file already probes correctly with `ffprobe` from inside the container a few sections down, and `halos_hil.md` does the same — this block was the odd one out.

Changes:
- `gst-launch-1.0 rtspsrc` → `ffprobe`, checking `codec_name`
- `-rw_timeout 5000000` so a wedged port fails in five seconds instead of hanging
- the concurrent pass now prints `:8554 OK` / `:8554 WEDGED` per port instead of leaving the reader to interpret `grep -l` output

Verified in-container by the reporter.