### PR TITLE
docs: factual & schema fixes across .md (audit PR-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The three pillars connect through a perception event stream: cameras feed AI per
 |---------|-------------|
 | `base` | Safety Core on an existing perception feed; the MUTE / UNMUTE decision is rendered as the VST `halo_safety` overlay. No simulation. Runs on x86 by default, or on IGX Thor (see [`halos_thor.md`](skills/hoisa-deploy-profile/references/halos_thor.md)). |
 | `sil` | Full single-host closed loop: NVIDIA Isaac Sim drives a forklift, and the safety decision is fed back to the simulated forklift over ROS. |
-| `hil` 🚧 | Hardware-in-the-loop: the Safety Core runs on an NVIDIA Thor device. Under development. |
+| `hil` | Hardware-in-the-loop: the Safety Core runs on an NVIDIA Thor device. |
 
 Deploy a profile with the [`hoisa-deploy-profile`](skills/hoisa-deploy-profile/) skill or by hand (see the [Quickstart Guide](#quickstart-guide)).
 

--- a/closed-loop-testing/regression-reporter/README.md
+++ b/closed-loop-testing/regression-reporter/README.md
@@ -1,6 +1,6 @@
-# Regression Reporter (SRR)
+# Regression Testing (SRR)
 
-**Scenario Recorder + Reporter** for the SIL stack. Runs scenarios in Isaac Sim, records ground truth + safety-system state at 30 Hz, splits by forklift tripwire crossings, and produces graded per-clip reports + per-clip review videos.
+**Regression Testing** for the SIL stack. Runs scenarios in Isaac Sim, records ground truth + safety-system state at 30 Hz, splits by forklift tripwire crossings, and produces graded per-clip reports + per-clip review videos.
 
 It lives at `closed-loop-testing/regression-reporter/`; the report skill is a sibling at `skills/hoisa-generate-regression-report/` and the browser viewer at `tools/srr-debug-viewer/`.
 

--- a/deployments/profiles/hil-thor.env
+++ b/deployments/profiles/hil-thor.env
@@ -20,7 +20,7 @@ PSF_LAUNCH_MODE=skip     # skip = PSF without SAIM | learn = record SAIM sensor 
 PSF_CMD_RX_IP=${PEER_HOST_IP}
 PSF_CMD_RX_PORT=12346    # the x86 comm-layer COMM_UDP_PORT (hil.env) — NOT the VST overlay port
 KAFKA_BROKER=localhost:9092                                    # VSS Kafka on this Thor
-PSF_SENSOR_CONFIG=/opt/nvidia/psf/bin/sensor_config_thor.conf  # copy from closed-loop-testing/safety-core/configs/, fill the VST re-serve URLs (or use refresh_thor_sensor_config.sh)
+PSF_SENSOR_CONFIG=/opt/nvidia/psf/bin/sensor_config_thor.conf  # copy from closed-loop-testing/safety-core/configs/, fill the VST re-serve URLs
 
 # === Perception model — 3D (Sparse4D) profile ONLY ===
 # R101 Sparse4D: a VSS-side perception artifact pulled as a prerequisite onto THIS Thor (where

--- a/safety-core/adapters/vss/mdx-client/README.md
+++ b/safety-core/adapters/vss/mdx-client/README.md
@@ -40,7 +40,7 @@ The config file can be:
 
 ## Event mapping config (proto)
 
-Rules are defined in `proto/event_mapping.proto`:
+Rules are defined in the sibling codec's `../mdx-msg-codec/proto/event_mapping.proto`:
 
 - **EventMappingConfig**: repeated **EventMappingRule**
 - **EventMappingRule**:
@@ -54,7 +54,7 @@ Rules are defined in `proto/event_mapping.proto`:
 
 **First matching rule wins.** Rule order in the config matters.
 
-### mdx-frames: how the three violations are derived (proto/gen/mdx-messages)
+### mdx-frames: how the three violations are derived (../mdx-msg-codec/proto/gen/mdx-messages)
 
 | Violation                   | Source in FrameMessage                          |
 |----------------------------|-------------------------------------------------|
@@ -105,7 +105,7 @@ See `safety-core/adapters/vss/event-mappings` for a full text-format example.
 ## Build
 
 - **With CMake**: Build the `mdx_client` target from the top-level `safety-core` build.
-- **Regenerate protos** (if you change `event_mapping.proto`):
+- **Regenerate protos** (protos live in the sibling `mdx-msg-codec/` — `cd` there first, then if you change `event_mapping.proto`):
   ```bash
   protoc -I proto --cpp_out=proto/gen/event-mapping proto/event_mapping.proto
   ```

--- a/skills/hoisa-generate-regression-report/PROMPT_TEMPLATES.md
+++ b/skills/hoisa-generate-regression-report/PROMPT_TEMPLATES.md
@@ -161,7 +161,7 @@ The skill parses these from the natural-language prompt — no rigid syntax requ
 - **Skill always restarts both Halos and SRR compose** between scenarios (do NOT ask it to skip — Safety Core counter drift carries across runs and corrupts the next).
 - **Safety Core cold-start outlier** is expected on scn_0000 (mute_lag spikes). Skill inserts a 30 s warm-up between scene-ready and `/srr/record true` to mitigate, but the first clip may still be slightly worse than the rest.
 - **Live clip monitor** prints one line per forklift TW crossing during recording — these are the demo's "heartbeat" between phase headers.
-- **Cross-run REPORT.md** is produced in Phase 5 — stored at `runs/multi-test-${TIMESTAMP}-REPORT.md`.
+- **Cross-run `summary.md`** is the canonical Phase-5 output — top-level `runs/multi-test-${TIMESTAMP}/summary.md`. (`REPORT.md` is a separate *optional* stakeholder write-up, produced only when asked.)
 
 ---
 

--- a/skills/hoisa-generate-regression-report/SKILL.md
+++ b/skills/hoisa-generate-regression-report/SKILL.md
@@ -175,7 +175,7 @@ When running the skill, print exactly this format. The phases / sections are anc
 > All test runs complete.
 
 > Analyzing results...
-  Aggregating per-scenario summary.md → cross-run REPORT.md
+  Aggregating per-scenario summary.md → cross-run summary.md
   Computing safety-critical unmute% per scenario...
 
 > Done. Top-level summary: /app/runs/multi-test-YYYYMMDD-HHMMSS/summary.md

--- a/skills/hoisa-generate-regression-report/references/02_launch.md
+++ b/skills/hoisa-generate-regression-report/references/02_launch.md
@@ -28,7 +28,7 @@ common symptoms:
 
 - `clip_logs.py` missing entirely → Phase 6a `docker exec` fails
 - `vst_video.py` writes per-clip MP4s to `videos/scenes/scn_*.mp4` (old layout) while host source writes flat `videos/scn_*.mp4` (new layout) — breaks aggregator's `../videos/<scn>.mp4` link in per-clip MD reports
-- Phase 2 perception metrics absent / wrong if `aggregator.py`, `kafka_consumer.py`, `schema.py`, or `recorder.py` predate the 3D pipeline (fd101f2)
+- Phase 2 perception metrics absent / wrong if `aggregator.py`, `kafka_consumer.py`, `schema.py`, or `recorder.py` predate the 3D pipeline
 - `render_perception_heatmap.py` / `render_coverage_polygons.py` missing or pre-`--density` → Phase 6d heatmap step fails at import or rejects the flag
 
 **Detect**:
@@ -188,7 +188,7 @@ docker compose --env-file ${HOISA_ROOT_PATH}/deployments/profiles/sil.env up -d
 Check `docker ps --format '{{.Names}}'` until all names are listed:
   safety-core, comm-layer, isaac-sim
 Poll every 30 s, max 5 min total. Print one heartbeat line per poll
-("[MM:SS] waiting on <missing-name>"). Report [ok] when all 4 are up,
+("[MM:SS] waiting on <missing-name>"). Report [ok] when all 3 are up,
 or [fail: <reason>] if 5 min elapses with services missing.
 ```
 

--- a/skills/hoisa-generate-regression-report/references/03_monitor.md
+++ b/skills/hoisa-generate-regression-report/references/03_monitor.md
@@ -39,7 +39,7 @@ The orchestrator pipes this stdout into the main demo log so the user sees the l
 Requirements:
 - `rclpy` available. ROS distribution differs by location:
   - **host:** typically `/opt/ros/jazzy/setup.bash`
-  - **srr container:** `/opt/ros/humble/setup.bash`
+  - **srr container:** `/opt/ros/jazzy/setup.bash`
 
   Use a robust source pattern that works either way:
   ```bash

--- a/tools/srr-debug-viewer/docs/architecture.md
+++ b/tools/srr-debug-viewer/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-A single-page debug viewer for SRR (Scenario Recorder + Reporter) `clip_logs`
+A single-page debug viewer for SRR (Regression Testing) `clip_logs`
 evidence bundles. Vanilla JS, no build step, no dependencies. The whole app
 ships as ~30 KB of source files, served over `python3 -m http.server`.
 

--- a/tools/srr-debug-viewer/docs/data-schema.md
+++ b/tools/srr-debug-viewer/docs/data-schema.md
@@ -15,7 +15,7 @@ multi-test-YYYYMMDD-HHMMSS/
 │   ├── reports/scn_*.md          per-clip aggregator reports
 │   ├── reports/summary.md        scenario-level rollup
 │   ├── scenes/scn_*.parquet      raw 30 Hz capture (not consumed by viewer)
-│   ├── videos/scenes/scn_*.mp4   per-clip MP4 (not consumed by viewer; per-clip
+│   ├── videos/scn_*.mp4          per-clip MP4 (not consumed by viewer; per-clip
 │   │                             clip_logs/ has a copy)
 │   ├── run-*.parquet             scenario-level run pool (not consumed)
 │   └── clip_logs/                THIS is the viewer's data source
@@ -25,6 +25,9 @@ multi-test-YYYYMMDD-HHMMSS/
 │           ├── gt_positions.csv  ← GT positions panel
 │           ├── psf_timeline.csv  ← PSF state panel
 │           ├── ba_events.csv     ← BA events panel
+│           ├── detections.csv    ← Detections panel      (3D runs only)
+│           ├── tracker_state.csv ← Tracker-state panel   (3D runs only)
+│           ├── ba_positions.csv  ← BA-positions panel    (3D + mdx-behavior only)
 │           ├── pss_log.txt       ← (raw — not used by viewer; kept for QA)
 │           ├── pss_log.jsonl     ← pss.log panel
 │           └── video.mp4         ← <video> source
@@ -36,6 +39,11 @@ multi-test-YYYYMMDD-HHMMSS/
 
 The viewer only reads files marked with `←` plus `summary.md` and the per-
 scenario `clip_logs/index.json`.
+
+The three Phase-2 CSVs (`detections`, `tracker_state`, `ba_positions`) are
+written **only for 3D runs** — when the clip captured `mdx-bev` / `mdx-behavior`.
+On 2D runs their `streams` keys are `null` and the viewer renders 4 panels; on a
+full 3D run it renders 7.
 
 ## File schemas
 
@@ -108,12 +116,16 @@ Per-clip metadata. Written by `srr.clip_logs` per clip.
     "gt_positions":      "gt_positions.csv",
     "psf_timeline":      "psf_timeline.csv",
     "ba_events":         "ba_events.csv",
+    "detections":        "detections.csv",     // 3D runs only; null on 2D
+    "tracker_state":     "tracker_state.csv",  // 3D runs only; null on 2D
+    "ba_positions":      "ba_positions.csv",   // 3D + mdx-behavior only; null otherwise
     "pss_log_text":      "pss_log.txt",
     "pss_log_structured":"pss_log.jsonl"
   },
   "counts": {
     "samples":         831,
     "ba_events":       40,
+    "detector_frames": 47,                     // 3D runs only (unique BEV frames); 0 on 2D
     "pss_lines_raw":   165,
     "pss_lines_safety":165
   },
@@ -207,6 +219,55 @@ multi-type events flatten across rows.
 | `ids` | str | VSS event IDs, comma-separated |
 | `create_time` | float / null | proto-extracted creation time (microsec→sec) when present |
 | `raw_hex` | str | first 60 bytes of unparseable proto, hex-encoded — debugging fallback |
+
+### `detections.csv`
+
+**3D runs only** (`mdx-bev`). One row per detection per detector (BEV) frame,
+each greedily matched to the nearest GT actor within a 1.5 m gate. Written by
+`clip_logs._write_detections_csv`.
+
+| Column | Type | Notes |
+|---|---|---|
+| `wall_time` | float (epoch sec) | sync key — the detector frame's arrival wall time |
+| `bev_frame_id` | int | detector (BEV) frame id; groups detections in one frame |
+| `track_id` | int / str | detector track id |
+| `class` | str | detected class (e.g. `Person`, `Forklift`) |
+| `x`, `y`, `z` | float | detection world position (`z` = 0.0 when the detector omits it) |
+| `conf` | float / null | detector confidence when present |
+| `matched_gt` | str | nearest GT actor within gate (`char_0`…`char_2`, `forklift`); `""` if none |
+| `dist_m` | float / "" | distance to the matched GT, metres |
+| `in_coverage` | bool | inside the detector coverage bbox (GT convex-hull + 2 m pad) |
+
+### `tracker_state.csv`
+
+**3D runs only.** One row per detector (BEV) frame: which detector `track_id`
+is assigned to each GT actor over time (track-continuity view). Written by
+`clip_logs._write_tracker_state_csv`.
+
+| Column | Type | Notes |
+|---|---|---|
+| `wall_time` | float | sync key |
+| `bev_frame_id` | int | detector frame id |
+| `n_dets` | int | number of detections in this frame |
+| `char_0_tid`, `char_1_tid`, `char_2_tid` | int / str / "" | track id matched to each character (`""` = unmatched this frame) |
+| `forklift_tid` | int / str / "" | track id matched to the forklift |
+
+### `ba_positions.csv`
+
+**3D + `mdx-behavior` runs only.** One row per Behavior-Analytics-reported
+position, de-duplicated across the 30 Hz oversampling, each matched to the
+nearest GT actor within a 1.5 m gate — so the viewer can show BA localisation
+accuracy alongside the raw detector. Written by `clip_logs._write_ba_positions_csv`.
+
+| Column | Type | Notes |
+|---|---|---|
+| `wall_time` | float | sync key |
+| `track_id` | int / str | BA track id |
+| `x`, `y` | float / "" | BA-reported world position |
+| `speed` | float / null | BA-reported speed when present |
+| `direction` | str | BA-reported heading; `""` if absent |
+| `matched_gt` | str | nearest GT actor within gate; `""` if none |
+| `dist_m` | float / "" | distance to the matched GT (metres) — BA localisation error |
 
 ### `pss_log.jsonl`
 

--- a/whitepaper/halos-outside-in-safety.md
+++ b/whitepaper/halos-outside-in-safety.md
@@ -43,7 +43,7 @@ blueprint. This repository provides the application-level interfaces, deployment
 profiles, and examples; it does not define the certified IGX safety integration.
 The source reflects that split: Safety Core can be built for x86_64 and
 aarch64/Tegra targets and packaged as desktop or Tegra artifacts. The deployment
-profiles cover local base/SIL workflows and include an under-development HIL
+profiles cover local base/SIL workflows and include a HIL
 hook where Safety Core runs on a Thor device.
 
 For platform architecture, platform safety assumptions, and integration


### PR DESCRIPTION
Factual/schema corrections from a full `.md` audit against the published psf-docs. No naming/scenario *decisions* here (those are follow-ups); this PR is safe, mechanical fixes only.

**Schema (highest impact)**
- `tools/srr-debug-viewer/docs/data-schema.md` — the viewer and `clip_logs.py` already emit 3 Phase-2 (3D) CSVs (`detections`, `tracker_state`, `ba_positions`) and render up to 7 panels, but the schema doc only described the 4 Phase-1 streams. Added: the 3 CSVs to the bundle tree + `manifest.streams` + `detector_frames` count, a full column schema per CSV, the 4-vs-7 panel note, and the flat `videos/` MP4 path.

**Factual**
- `03_monitor.md` — srr container ROS distro is **jazzy**, not humble (matches `srr-service/Dockerfile`).
- `SKILL.md` / `PROMPT_TEMPLATES.md` — the auto cross-run output is **`summary.md`**; `REPORT.md` is the *optional* stakeholder write-up.
- `mdx-client/README.md` — proto sources live in the sibling `mdx-msg-codec/proto/`, not a local `proto/`.
- `hil-thor.env` — dropped the reference to `refresh_thor_sensor_config.sh` (does not exist).
- `README.md` / `whitepaper` — HIL is no longer under development.
- Naming — SRR display name aligned to **Regression Testing** (psf-docs canonical).
- `02_launch.md` — dropped an internal commit hash; ready-signal correctly lists 3 containers.

Follow-ups (separate PRs): scenario count 6→5 + `fixed` relabel; the two empty PSF component READMEs; sil-data version bump (after prod publish).