### PR TITLE
docs: clarify SRR scenario suite (5 sweep + opt-in fixed)

### DIFF
--- a/closed-loop-testing/regression-reporter/scenarios/README.md
+++ b/closed-loop-testing/regression-reporter/scenarios/README.md
@@ -23,7 +23,7 @@ GitHub layout `closed-loop-testing/isaac-sim/sil/` — before Isaac Sim launches
 scenarios/
 ├── README.md                     # you are here
 ├── behavior-trees/               # IRA 1.6 *.bt.json — the data Isaac 6.0 consumes
-│   └── srr_<6>_char{0,1,2}.bt.json  # in-roi, psf-edge, psf-clear, balanced, fast, fixed
+│   └── srr_<name>_char{0,1,2}.bt.json  # 5 sweep: in-roi, psf-edge, psf-clear, balanced, fast · +fixed (opt-in)
 ├── scenes/                       # exported NavMesh (data)
 │   ├── README.md
 │   └── navmesh.json              # exported NavMesh — derived from the stock scene
@@ -43,7 +43,7 @@ scenarios/
 
 | If you want… | Look in |
 |---|---|
-| The 6 scenarios' behavior trees | [`behavior-trees/`](behavior-trees/) |
+| The scenario behavior trees (5 sweep + `fixed`) | [`behavior-trees/`](behavior-trees/) |
 | The exported NavMesh JSON used by `randomize_paths.py` | [`scenes/navmesh.json`](scenes/navmesh.json) |
 | To regenerate a scenario's `srr_<name>_char{0,1,2}.bt.json` | [`tools/randomize_paths.py`](tools/randomize_paths.py) |
 | To sanity-check a hand-edited `.bt.json` | [`tools/validate_waypoints.py`](tools/validate_waypoints.py) |
@@ -64,6 +64,8 @@ fast        ............................  0.6    0                200       1,3 
 ```
 
 All 5 use `--agent-radius 0.8` and target the stock scene `indicator_warehouse_20x20_layout_overflow_test.usd`.
+
+A sixth set, `srr_fixed_char{0,1,2}`, is **hand-authored** — a deterministic, always-in-ROI baseline, **not** produced by `randomize_paths.py` — and **opt-in**: it is excluded from the default `all` / `full` sweep. See the report skill's scenario table.
 
 ## Generator flags (`randomize_paths.py`)
 

--- a/closed-loop-testing/regression-reporter/scenarios/tools/README.md
+++ b/closed-loop-testing/regression-reporter/scenarios/tools/README.md
@@ -33,7 +33,7 @@ without dragging tooling along).
 
 ## Usage — regenerating a scenario
 
-The canonical scenarios were generated with these flag combinations:
+The **5 randomized** canonical scenarios were generated with these flag combinations (the opt-in `fixed` scenario is hand-authored, not generated):
 
 ```
                                      --roi-bias  --roi-clearance  --cycles  --idle-short  --spawn-return-every

--- a/skills/hoisa-generate-regression-report/references/01_test_plan.md
+++ b/skills/hoisa-generate-regression-report/references/01_test_plan.md
@@ -25,6 +25,8 @@ If user did not specify, **ask which scenarios** before proceeding (do NOT defau
 | `balanced`  |  600 | `srr_balanced_char{0,1,2}.bt.json` |
 | `fast`      | 1200 | `srr_fast_char{0,1,2}.bt.json` |
 
+> Plus an opt-in **`fixed`** — a deterministic baseline (hand-authored, always-in-ROI; **excluded from `all` / `full`**, select it explicitly). See `SKILL.md`.
+
 Each scenario is 3 IRA 1.6 behavior trees `srr_<name>_char{0,1,2}.bt.json` at
 `${HOISA_ROOT_PATH}/closed-loop-testing/isaac-sim/sil/configs/` (GitHub layout:
 `<halos-repo>/closed-loop-testing/isaac-sim/sil/configs/`), emitted directly by

--- a/skills/hoisa-generate-regression-report/references/02_launch.md
+++ b/skills/hoisa-generate-regression-report/references/02_launch.md
@@ -94,7 +94,7 @@ Skip this step on the 2nd–Nth scenarios of a multi-test — image state is sta
 
 ## Step 3.−1 — Verify SRR fixtures synced into the Isaac SIL dir (one-time / first scenario)
 
-SRR's canonical test fixtures (the 6 scenarios' IRA 1.6 behavior trees,
+SRR's canonical test fixtures (the scenario behavior trees — 5 sweep + `fixed`,
 NavMesh JSON, and the Script-Editor utilities) live under
 `regression-reporter/scenarios/{behavior-trees,scenes,isaac-scripts}/`. Isaac Sim reads
 those at the in-container path `/isaac-sim/sil/...`, which is bind-mounted
@@ -113,7 +113,7 @@ Check each path exists under ${HOISA_ROOT_PATH}/closed-loop-testing/isaac-sim/si
   configs/srr_char0.bt.json                (active tree — Character)
   configs/srr_char1.bt.json                (active tree — Character_01)
   configs/srr_char2.bt.json                (active tree — Character_02)
-  configs/srr_in-roi_char0.bt.json         (per-scenario trees; 6 scenarios x 3 chars)
+  configs/srr_in-roi_char0.bt.json         (per-scenario trees; 6 sets = 5 sweep + fixed, x3 chars)
   configs/srr_fast_char0.bt.json           (spot-check a couple more names)
   configs/navmesh.json
   scripts/isaac/check_srr_prereqs.py       (GT pre-flight diagnostic)


### PR DESCRIPTION
Follow-up to the .md audit (PR-1). Resolves the 5-vs-6 scenario inconsistency.

**Framing (matches SKILL.md, which was already correct):** the canonical suite is the **5 randomized sweep** scenarios (`in-roi`, `psf-edge`, `psf-clear`, `balanced`, `fast`) — what `all` / `full` run. The on-disk `srr_fixed_char*` set is a **hand-authored deterministic baseline**, **opt-in** and excluded from the default sweep.

Kept the `fixed` fixtures (they're a useful reproducible anchor); just relabeled the docs so nothing flatly claims 6 default scenarios:
- `scenarios/README.md` — layout comment + 'behavior trees' row now say '5 sweep + fixed'; added a note that `fixed` is hand-authored / opt-in.
- `tools/README.md` — clarified the flag table is the 5 randomized (fixed isn't generated).
- `01_test_plan.md` — added the opt-in `fixed` note under the 5-scenario table.
- `02_launch.md` — '6 scenarios' → '5 sweep + fixed' / '6 sets = 5 sweep + fixed'.

SKILL.md unchanged (its all/full=5, fixed opt-in framing is the model).