### PR TITLE
docs: settle on one name for the Regression Testing Reporter

### DIFF
--- a/closed-loop-testing/3rdParty_Licenses.txt
+++ b/closed-loop-testing/3rdParty_Licenses.txt
@@ -8134,7 +8134,7 @@ END OF TERMS AND CONDITIONS
 
 ---
 
-## SRR (Regression Reporter) Dependencies
+## Regression Testing Reporter Dependencies
 
 Added by closed-loop-testing/regression-reporter (srr-service Docker image,
 base ros:jazzy-ros-base). The srr-debug-viewer (tools/) and the

--- a/closed-loop-testing/regression-reporter/README.md
+++ b/closed-loop-testing/regression-reporter/README.md
@@ -1,6 +1,8 @@
-# Regression Testing (SRR)
+# Regression Testing Reporter
 
-**Regression Testing** for the SIL stack. Runs scenarios in Isaac Sim, records ground truth + safety-system state at 30 Hz, splits by forklift tripwire crossings, and produces graded per-clip reports + per-clip review videos.
+**Regression Testing Reporter** for the SIL stack. Runs scenarios in Isaac Sim, records ground truth + safety-system state at 30 Hz, splits by forklift tripwire crossings, and produces graded per-clip reports + per-clip review videos.
+
+The short name `srr` is used throughout the code, the service, and the paths below, retained from the tool's original name, Scenario Recorder + Reporter.
 
 It lives at `closed-loop-testing/regression-reporter/`; the report skill is a sibling at `skills/hoisa-generate-regression-report/` and the browser viewer at `tools/srr-debug-viewer/`.
 

--- a/skills/hoisa-generate-regression-report/SKILL.md
+++ b/skills/hoisa-generate-regression-report/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hoisa-generate-regression-report
 description: >-
-  Run the SRR (Safety Regression Reporter) multi-scenario test pipeline on the
+  Run the Regression Testing Reporter (`srr`) multi-scenario test pipeline on the
   SIL stack. Picks one or more of 6 pre-built test cases (in-roi, psf-edge,
   psf-clear, balanced, fast, fixed), launches each in Isaac Sim with a clean
   compose restart, records 30 Hz parquet of GT + Safety Core state + BA / 3D

--- a/tools/srr-debug-viewer/docs/architecture.md
+++ b/tools/srr-debug-viewer/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-A single-page debug viewer for SRR (Regression Testing) `clip_logs`
+A single-page debug viewer for the Regression Testing Reporter's `clip_logs`
 evidence bundles. Vanilla JS, no build step, no dependencies. The whole app
 ships as ~30 KB of source files, served over `python3 -m http.server`.
 


### PR DESCRIPTION
The SRR acronym expands three different ways in this repo today:

| file | says |
|---|---|
| `skills/hoisa-generate-regression-report/SKILL.md` | SRR (**Safety Regression Reporter**) |
| `tools/srr-debug-viewer/docs/architecture.md` | SRR (**Regression Testing**) |
| `closed-loop-testing/3rdParty_Licenses.txt` | SRR (**Regression Reporter**) |
| `closed-loop-testing/regression-reporter/README.md` | title "Regression Testing (SRR)", unexpanded |

Someone who meets two of those has no way to tell they are the same component.

## The name

**Regression Testing Reporter.** Two of the existing strings were rejected on review:

- "Safety Regression Reporter" reads as *a regression in safety* rather than *regression testing of safety*, which is the wrong ambiguity to ship in a safety product.
- "Regression Testing" alone names the activity, not the thing that performs it, so the component ended up nameless.

## `srr` is unchanged

It is the directory, the service, the image, and the viewer, and the scripts and compose files run against it. Renaming the paths would move URLs and break commands for no gain. `closed-loop-testing/regression-reporter/README.md` now states where the short name comes from — the original **Scenario Recorder + Reporter** — so it is written down once rather than guessed at.

Full name in prose, `srr` in paths and commands.

## Checked

- No other expansion left in the repo. The two remaining `SRR (` hits are `SRR (one-time)` and `produced by SRR`, neither an expansion.
- `SKILL.md` frontmatter still parses; `description` is unchanged apart from the name.
- Docs side is psf-docs MR !119, which applies the same decision and adds a glossary entry for `SRR`.