### PR TITLE
chore(deploy): point profiles at the 1.3 production NGC artifacts

### DIFF
--- a/closed-loop-testing/scripts/setup.sh
+++ b/closed-loop-testing/scripts/setup.sh
@@ -85,7 +85,7 @@ if [ -n "$NEED_ISAAC" ]; then
     done
     sudo chown -R 1234:1234 "$ISAAC_CACHE_DIR"
     echo "  NOTE: sil also needs NGC sil-data (Isaac scenes/collected-assets) — pull separately:"
-    echo "    ngc registry resource download-version nvidia/halos-outside-in/sample-sil-data:v1.2.1"
+    echo "    ngc registry resource download-version nvidia/halos-outside-in/sample-sil-data:v1.3.0"
 
     # collected-assets must be readable/traversable by the isaac-sim container
     # user (UID/GID 1234; see Dockerfile `USER 1234:1234`). isaac-sim.yml mounts

--- a/deployments/profiles/base-thor.env
+++ b/deployments/profiles/base-thor.env
@@ -9,10 +9,10 @@
 HOST_IP='' # change me — this Thor's IP
 
 # === Safety Core image (nv-psf container, multi-arch arm64+amd64, one tag) ===
-PSF_IMAGE=nvcr.io/nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-release-f9210aa-2026-07-29_12-14  # multi-arch; Docker auto-selects arm64 on Thor (same tag as x86 base.env)
+PSF_IMAGE=nvcr.io/nvidia/halos-outside-in/outside-in-safety:nv-psf-halos-1.3-6932895  # multi-arch; Docker auto-selects arm64 on Thor (same tag as x86 base.env)
 
 # === Thor Safety Core package (NGC resource, downloaded once at setup; ngc_artifacts.md §4) ===
-PSF_TEGRA_RESOURCE=nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-aarch64-release-f9210aa-2026-07-29_12-12-psf-tegra  # host binaries .deb (atl_sdm, launch_hoisa, safety_monitor)
+PSF_TEGRA_RESOURCE=nvidia/halos-outside-in/outside-in-safety:nv-psf-halos-1.3-aarch64-release-6932895-psf-tegra  # host binaries .deb (atl_sdm, launch_hoisa, safety_monitor)
 
 # === SDM placement / launch mode ===
 SDM_TARGET=ccplex        # where the SDM runs: ccplex = the Thor application cores

--- a/deployments/profiles/base.env
+++ b/deployments/profiles/base.env
@@ -18,7 +18,7 @@ MDX_DATA_DIR=/path/to/data # change me
 HOST_IP='' # change me
 
 COMM_UDP_PORT=12345   # PSF cmd target = VST halo_safety_udp_port (NOT comm-layer in base)
-PSF_IMAGE=nvcr.io/nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-release-f9210aa-2026-07-29_12-14
+PSF_IMAGE=nvcr.io/nvidia/halos-outside-in/outside-in-safety:nv-psf-halos-1.3-6932895
 PSF_LAUNCH_MODE=skip  # skip = PSF without SAIM | learn = record SAIM sensor baselines | active = SAIM live (validates streams vs learned baselines)
 PSF_CMD_RX_IP=127.0.0.1
 PSF_LOG_DIR=${MDX_DATA_DIR}/psf-log

--- a/deployments/profiles/hil-thor.env
+++ b/deployments/profiles/hil-thor.env
@@ -11,9 +11,9 @@ HOST_IP='' # change me — this Thor's IP
 PEER_HOST_IP='' # change me — the x86 stimulus host (comm-layer)
 
 # nv-psf container (multi-arch; Docker selects arm64 on Thor — same tag as the x86 profiles)
-PSF_IMAGE=nvcr.io/nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-release-f9210aa-2026-07-29_12-14
+PSF_IMAGE=nvcr.io/nvidia/halos-outside-in/outside-in-safety:nv-psf-halos-1.3-6932895
 # Thor host package (install per ngc_artifacts.md §4; keep the SAME build tag as PSF_IMAGE)
-PSF_TEGRA_RESOURCE=nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-aarch64-release-f9210aa-2026-07-29_12-12-psf-tegra  # host binaries .deb (atl_sdm, launch_hoisa, safety_monitor)
+PSF_TEGRA_RESOURCE=nvidia/halos-outside-in/outside-in-safety:nv-psf-halos-1.3-aarch64-release-6932895-psf-tegra  # host binaries .deb (atl_sdm, launch_hoisa, safety_monitor)
 
 SDM_TARGET=ccplex        # where the SDM runs: ccplex = the Thor application cores
 PSF_LAUNCH_MODE=skip     # skip = PSF without SAIM | learn = record SAIM sensor baselines | active = SAIM live (validates streams vs learned baselines)

--- a/deployments/profiles/hil.env
+++ b/deployments/profiles/hil.env
@@ -9,7 +9,7 @@ COMPOSE_PROFILES=hil
 
 MDX_SAMPLE_APPS_DIR=/path/to/halos-outside-in-safety # change me
 MDX_DATA_DIR=/path/to/hil-data # change me — local extract dir (ngc_artifacts.md §1)
-MDX_DATA_RESOURCE=nvidia/halos-outside-in/sample-sil-data:v1.2.1 # NGC resource downloaded into MDX_DATA_DIR
+MDX_DATA_RESOURCE=nvidia/halos-outside-in/sample-sil-data:v1.3.0 # NGC resource downloaded into MDX_DATA_DIR
 HOST_IP='' # change me — this x86 stimulus host
 PEER_HOST_IP='' # change me — Thor safety host
 

--- a/deployments/profiles/sil.env
+++ b/deployments/profiles/sil.env
@@ -5,7 +5,7 @@ COMPOSE_PROFILES=sil
 
 MDX_SAMPLE_APPS_DIR=/path/to/halos-outside-in-safety # change me — repo checkout root
 MDX_DATA_DIR=/path/to/sil-data # change me — local extract dir (ngc_artifacts.md §1)
-MDX_DATA_RESOURCE=nvidia/halos-outside-in/sample-sil-data:v1.2.1 # NGC resource downloaded into MDX_DATA_DIR
+MDX_DATA_RESOURCE=nvidia/halos-outside-in/sample-sil-data:v1.3.0 # NGC resource downloaded into MDX_DATA_DIR
 HOST_IP='' # change me
 
 # === VST ===
@@ -21,7 +21,7 @@ COMM_LOG_DIR=${MDX_DATA_DIR}/comm-layer
 ROS_DOMAIN_ID=0
 
 # === PSF ===
-PSF_IMAGE=nvcr.io/nv-metropolis-dev/halos-outside-in/proactive-safety-framework:nv-psf-halos-1.3-release-f9210aa-2026-07-29_12-14
+PSF_IMAGE=nvcr.io/nvidia/halos-outside-in/outside-in-safety:nv-psf-halos-1.3-6932895
 PSF_LAUNCH_MODE=skip  # skip = PSF without SAIM | learn = record SAIM sensor baselines | active = SAIM live (validates streams vs learned baselines)
 PSF_CMD_RX_IP=127.0.0.1
 PSF_LOG_DIR=${MDX_DATA_DIR}/psf-log


### PR DESCRIPTION
1.3.0 has ProdSec sign-off and the NGC publishing MR is merged, so the artifacts are live and public under `nvidia/halos-outside-in` (build `6932895`). This moves the deploy profiles off the internal dev registry — **a public clone no longer needs `nv-metropolis-dev` access to deploy.**

| Variable | Was | Now |
|---|---|---|
| `PSF_IMAGE` (base, sil, base-thor, hil-thor) | `nv-metropolis-dev/…/proactive-safety-framework:…f9210aa…` | `nvcr.io/nvidia/halos-outside-in/outside-in-safety:nv-psf-halos-1.3-6932895` |
| `PSF_TEGRA_RESOURCE` (base-thor, hil-thor) | `nv-metropolis-dev/…-f9210aa-…-psf-tegra` | `nvidia/halos-outside-in/outside-in-safety:nv-psf-halos-1.3-aarch64-release-6932895-psf-tegra` |
| `MDX_DATA_RESOURCE` (sil, hil) + `setup.sh` | `sample-sil-data:v1.2.1` | `sample-sil-data:v1.3.0` |