### PR TITLE
docs: point the repo at the 1.3 documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,19 +64,19 @@ Deploy a profile with the [`hoisa-deploy-profile`](skills/hoisa-deploy-profile/)
 
 ## Documentation
 
-For detailed instructions and additional information about this blueprint, please refer to the [official documentation](https://docs.nvidia.com/halos-outside-in/latest/index.html).
+For detailed instructions and additional information about this blueprint, please refer to the [official documentation](https://docs.nvidia.com/halos-outside-in/1.3/index.html).
 
 ## Prerequisites
 
-- An NGC account with Early-Access entitlement to the `nvidia/halos-outside-in` team (for the Safety Core image and SIL data) and an [NGC API key](https://org.ngc.nvidia.com/setup/api-keys).
+- An NGC account with Early-Access entitlement to the `nvidia/halos-outside-in` team (for the Safety Core image and SIL data) and an [NGC API key](https://org.ngc.nvidia.com/account/api-keys).
 - Docker + Docker Compose and the NVIDIA Container Toolkit (see [System Requirements](#system-requirements) for versions).
 
 ## Hardware Requirements
 
 Requirements depend on the profile:
 
-- **`base`** (inference: VSS Blueprint perception + Safety Core) follows the VSS Blueprint hardware requirements. See the [VSS prerequisites](https://docs.nvidia.com/vss/latest/prerequisites.html).
-- **`sil`** (full closed loop, adds NVIDIA Isaac Sim, which needs a GPU with RT cores). See the [Halos SIL prerequisites](https://docs.nvidia.com/halos-outside-in/latest/sil/prerequisites.html).
+- **`base`** (inference: VSS Warehouse Blueprint perception + Safety Core) follows the VSS Warehouse hardware requirements. See the [VSS Warehouse prerequisites](https://docs.nvidia.com/vss/3.2.1/warehouse-docs/Prerequisites.html).
+- **`sil`** (full closed loop, adds NVIDIA Isaac Sim, which needs a GPU with RT cores). See the [Halos SIL prerequisites](https://docs.nvidia.com/halos-outside-in/1.3/getting-started/prerequisites.html#closed-loop-host).
 
 ## Quickstart Guide
 
@@ -92,10 +92,10 @@ The [`hoisa-deploy-profile`](skills/hoisa-deploy-profile/) skill brings up both 
 
 **Ideal for:** deploying by hand on your own host or bare-metal instance.
 
-1. Deploy the [NVIDIA VSS Blueprint](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization) perception backend first. It publishes the detection events the Safety Core consumes.
+1. Deploy the [NVIDIA VSS Warehouse Blueprint 3.2.1](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/tree/v3.2.1) perception backend first. It publishes the detection events the Safety Core consumes.
 2. Fill `deployments/profiles/<profile>.env`, then `docker compose --env-file profiles/<profile>.env up -d`.
 
-For full steps, see [`skills/hoisa-deploy-profile/references/halos_deploy.md`](skills/hoisa-deploy-profile/references/halos_deploy.md) or the [Deployment guide](https://docs.nvidia.com/halos-outside-in/latest/deployment/index.html).
+For full steps, see [`skills/hoisa-deploy-profile/references/halos_deploy.md`](skills/hoisa-deploy-profile/references/halos_deploy.md) or the [Deployment guide](https://docs.nvidia.com/halos-outside-in/1.3/deployment/index.html).
 
 #### System Requirements
 

--- a/ai-perception/README.md
+++ b/ai-perception/README.md
@@ -6,8 +6,8 @@ The reference perception is **NVIDIA VSS Blueprint** (specifically the **Warehou
 drive the safety core.
 
 ## Reference backend: VSS Blueprint
-- Repo: https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization
-- Deployed via the `vss-deploy-profile` skill (see [`skills/`](../skills/)) or the public VSS Blueprint docs.
+- Repo: https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/tree/v3.2.1
+- Deployed via the `vss-deploy-profile` skill (see [`skills/`](../skills/)) or the public [VSS Warehouse Blueprint 3.2.1 quickstart](https://docs.nvidia.com/vss/3.2.1/warehouse-docs/Quickstart-Guide.html).
 
 ## Integration contract (the seam)
 The Safety Core depends only on the **event stream**, not on perception internals:

--- a/closed-loop-testing/scripts/launch_thor_safety.sh
+++ b/closed-loop-testing/scripts/launch_thor_safety.sh
@@ -40,7 +40,7 @@ esac
 
 # --- Safety Core host install present? ---
 LAUNCHER=/opt/nvidia/psf/bin/launch_hoisa.sh
-[ -x "$LAUNCHER" ] || { echo "ERROR: $LAUNCHER not found — install the Safety Core Tegra package first (PSF docs HOISA User Guide §1)."; exit 1; }
+[ -x "$LAUNCHER" ] || { echo "ERROR: $LAUNCHER not found — install the Safety Core Tegra package first (Deployment Guide 1.1 Debian Installation: https://docs.nvidia.com/halos-outside-in/1.3/deployment/index.html#debian-installation)."; exit 1; }
 [ -f "$PSF_SENSOR_CONFIG" ] || { echo "ERROR: sensor config not found: $PSF_SENSOR_CONFIG (copy the template + fill the VST URLs)."; exit 1; }
 
 SDM_TARGET="${SDM_TARGET:-ccplex}"

--- a/deployments/scripts/deploy_hoisa_launchable.ipynb
+++ b/deployments/scripts/deploy_hoisa_launchable.ipynb
@@ -7,7 +7,7 @@
       "source": [
         "# Deploy Halos Outside-In Safety — SIL (Software-in-the-Loop)\n",
         "\n",
-        "One-click deployment of the **Halos Outside-In Safety** reference architecture in **SIL** mode on a GPU cloud instance (designed for NVIDIA Brev). Full product docs: [NVIDIA Halos Outside-In Safety](https://docs.nvidia.com/halos-outside-in/latest/index.html).\n",
+        "One-click deployment of the **Halos Outside-In Safety** reference architecture in **SIL** mode on a GPU cloud instance (designed for NVIDIA Brev). Full product docs: [NVIDIA Halos Outside-In Safety](https://docs.nvidia.com/halos-outside-in/1.3/index.html).\n",
         "\n",
         "SIL runs the full **closed safety loop** on a single host across **two Docker Compose stacks**:\n",
         "\n",

--- a/skills/hoisa-deploy-profile/SKILL.md
+++ b/skills/hoisa-deploy-profile/SKILL.md
@@ -64,7 +64,7 @@ Communication Layer → ROS2 /safety/is_muted → Isaac Sim Action Graph (forkli
 ```
 
 **Two separate stacks**:
-- **Stack 1**: VSS Warehouse 3.2.1 (perception) — deploy via the `vss-deploy-profile` skill (or the public VSS Warehouse docs: github.com/NVIDIA-AI-Blueprints/video-search-and-summarization); must be up + healthy first.
+- **Stack 1**: VSS Warehouse 3.2.1 (perception) — deploy via the `vss-deploy-profile` skill (or the public VSS Warehouse docs: https://docs.nvidia.com/vss/3.2.1/warehouse-docs/Quickstart-Guide.html); must be up + healthy first.
 - **Stack 2**: Halos (`base`/`sil`/`hil`) — this skill.
 
 ---

--- a/skills/hoisa-deploy-profile/references/halos_deploy.md
+++ b/skills/hoisa-deploy-profile/references/halos_deploy.md
@@ -19,7 +19,7 @@ Safety events are driven by the ROIs and tripwires in the VSS perception **`cali
 ships with `restrictedObjectTypes` set, and the 3D calibration built per `calibration_3d.md` includes
 it too — so with the **default sample scene there is nothing to change** here.
 
-> This requirement is stated in the [Safety Core User Guide — Prerequisites](https://docs.nvidia.com/halos-outside-in/latest/HOISA-User-Guide.html#prerequisites)
+> This requirement is stated in the [Deployment Guide — Safety Core Prerequisites](https://docs.nvidia.com/halos-outside-in/1.3/deployment/index.html#safety-core-prerequisites)
 > (the calibration *"includes `restrictedObjectTypes:["Person"]` for the ROIs, where relevant"*); the
 > field itself is defined in the [VSS calibration schema](https://docs.nvidia.com/vss/3.2.1/calibration-schema.html).
 

--- a/skills/hoisa-deploy-profile/references/prerequisites.md
+++ b/skills/hoisa-deploy-profile/references/prerequisites.md
@@ -46,7 +46,7 @@ Suitable: RTX PRO 6000, RTX A6000 Ada, RTX A6000, L40S, L40.
 
 **Fail** (`nvidia-smi` missing or not loaded): the agent does **not** auto-install GPU drivers.
 - Installed but not loaded → load the module, no reboot: `sudo modprobe nvidia && sudo modprobe nvidia_uvm`
-- Missing → the user installs it (cloud / Brev images already ship the driver). Per-platform pinned versions are in the VSS prerequisites (e.g. Ubuntu 24.04 → `580.105.08`, 22.04 → `580.65.06`); download: https://www.nvidia.com/en-us/drivers/
+- Missing → the user installs it (cloud / Brev images already ship the driver). Per-platform pinned versions are in the [VSS Warehouse prerequisites](https://docs.nvidia.com/vss/3.2.1/warehouse-docs/Prerequisites.html) (x86 Ubuntu 24.04 → `580.105.08`, IGX-THOR → `580.00`); download: https://www.nvidia.com/en-us/drivers/
 
 ---
 
@@ -148,7 +148,7 @@ eval "$(grep NGC_CLI_API_KEY ~/.bashrc)"
 ```
 
 **Fail** (no key in any source) — guide user:
-1. https://ngc.nvidia.com → Setup → API Keys → Generate Personal Key
+1. https://ngc.nvidia.com → Account → API Keys → Generate Personal Key
 2. Set NGC Catalog permission
 3. User adds the key themselves — do NOT ask user to paste the key into chat
 

--- a/tools/waypoint-generator/README.md
+++ b/tools/waypoint-generator/README.md
@@ -116,7 +116,7 @@ The JSON export (including `poses`) is the input format of the SIL forklift cont
 
 ## Calibration
 
-The bundled `public/Top.png` and the calibration values come from the [VSS blueprint sample data](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/tree/main/deploy/docker/industry-profiles/warehouse-operations/warehouse-2d-app/calibration/sample-data/warehouse-loading-dock-3cams-synthetic) for the same warehouse scene that ships with `closed-loop-testing`:
+The bundled `public/Top.png` and the calibration values come from the [VSS blueprint sample data](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization/tree/v3.2.1/deploy/docker/industry-profiles/warehouse-operations/warehouse-2d-app/calibration/sample-data/warehouse-loading-dock-3cams-synthetic) for the same warehouse scene that ships with `closed-loop-testing`:
 - Scale factor: 49.51 pixels/meter
 - Default forklift start: (1.0, -13.39) in world coordinates
 


### PR DESCRIPTION
Two of the five Halos documentation links in this repo die the day 1.3 publishes, and the VSS links point at the wrong blueprint.

## Links that break

| file | was | now |
|---|---|---|
| `README.md:79` | `latest/sil/prerequisites.html` | `1.3/getting-started/prerequisites.html#closed-loop-host` |
| `skills/hoisa-deploy-profile/references/halos_deploy.md:22` | `latest/HOISA-User-Guide.html#prerequisites` | `1.3/deployment/index.html#safety-core-prerequisites` |
| `closed-loop-testing/scripts/launch_thor_safety.sh:43` | prose: "PSF docs HOISA User Guide §1" | link to `#debian-installation` |

The `sil/` tree was replaced by `getting-started/` + `testing/sil/`, and the single-page user guide was split. The third is a runtime abort message, so a Thor operator hits it exactly when they need the packaging instructions.

Every URL above was resolved against the 1.3 build, anchors included — the three anchors each return one `id=` match.

## Links that resolved but misled

`README.md:78` sent readers to `/vss/latest/prerequisites.html`. That is the **generic** VSS Blueprint page (VLM / summarization): Ubuntu 22.04, driver 580.65.06, AGX Thor, RTX PRO 4500 — none of which applies to the Warehouse Blueprint the `base` profile runs, and it contradicts this repo's own System Requirements block a few lines below.

The same error had spread into the deploy skill: `references/prerequisites.md:49` quotes that page's driver pair, so an agent following it provisions Ubuntu 22.04 + 580.65.06 for a perception stack that does not support it. Both now point at the Warehouse prerequisites.

VSS links are pinned to `3.2.1` — the version `vss_2d_overrides.md` says it was verified against, and the only version the 1.3 docs reference (27 of 27).

## Also

- NGC moved API keys from `/setup/api-keys` to `/account/api-keys`; the prose step in the skill still said "Setup → API Keys", a menu item that no longer exists.
- `tools/waypoint-generator/README.md:119` cited its hard-coded constants to `/tree/main/`. Pinned to `v3.2.1`, where the blob is byte-identical, so it costs nothing and becomes real provenance.

## One thing to time

Halos links are pinned to `/1.3/`, which does not resolve until the 1.3 docs publish. Merging before then leaves five links 404 on a public repo. Hold this until publish day, or merge now knowing it.

## Not in this PR

The audit also turned up three items that change behaviour or policy rather than links, left out deliberately: the Brev launchable clones VSS from `main` rather than the `v3.2.1` tag it was written against; seven `asset_path` lines in shipped configs point at the Omniverse **staging** CDN; and `SECURITY.md:20` says NVIDIA has no bug bounty while the form it links redirects to the Intigriti program. Happy to open those separately.