### PR TITLE
chore(isaac): resolve character assets against the production asset root

### DIFF
--- a/closed-loop-testing/isaac-sim/sil/configs/default_config_ros.yaml
+++ b/closed-loop-testing/isaac-sim/sil/configs/default_config_ros.yaml
@@ -8,17 +8,17 @@ isaacsim.replicator.agent:
     groups:
       inspect_workers:
         num: 1
-        asset_path: https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0/Isaac/People/Characters/
+        asset_path: Isaac/People/Characters/
         behavior_tree: /isaac-sim/sil/configs/inspect_loop.bt.json
       gather_workers:
         num: 1
-        asset_path: https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0/Isaac/People/Characters/
+        asset_path: Isaac/People/Characters/
         behavior_tree: /isaac-sim/sil/configs/gather_bend_loop.bt.json
       pickup_workers:
         num: 1
-        asset_path: https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0/Isaac/People/Characters/
+        asset_path: Isaac/People/Characters/
         behavior_tree: /isaac-sim/sil/configs/pickup_loop.bt.json
-    motion_library_path: https://omniverse-content-staging.s3.us-west-2.amazonaws.com/Assets/Behavior/110.0/Samples/Assets/MotionLibrary/Human/HumanMotionLibrary.usd
+    motion_library_path: Isaac/People/MotionLibrary/HumanMotionLibrary.usd
   sensor:
     groups:
       ceiling_cameras:

--- a/closed-loop-testing/isaac-sim/sil/scripts/run_actor_sdg.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/run_actor_sdg.py
@@ -703,16 +703,11 @@ def main():
 
     # Override the default Nucleus asset root with the public S3 prefix
     # so Kit's provider_nucleus plugin does not require OMNI_USER/OMNI_PASS
-    # at boot - no Nucleus call is needed by IRA, the JWT was only consumed
-    # by the kit-boot Nucleus token refresh against the extension-default
-    # Omniverse asset root.
-    #
-    # This prefix is load-bearing: both the character asset_path and the
-    # motion_library_path in default_config_ros.yaml are asset-root-relative
-    # (Isaac/People/Characters/ and
-    # Isaac/People/MotionLibrary/HumanMotionLibrary.usd), so IRA resolves them
-    # against the value set here. Only the scene stays absolute (local
-    # /isaac-sim/sil/...).
+    # at boot. The Halos asset_path / motion_library_path / scene paths in
+    # default_config_ros.yaml are all S3 URLs (or local /isaac-sim/sil/...),
+    # so no Nucleus call is actually needed by IRA - the JWT was only
+    # consumed by the kit-boot Nucleus token refresh against the
+    # extension-default Omniverse asset root.
     #
     # Override via sys.argv so SimulationApp forwards the flag to Kit before
     # provider_nucleus boots. Operator can pin a different prefix by passing

--- a/closed-loop-testing/isaac-sim/sil/scripts/run_actor_sdg.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/run_actor_sdg.py
@@ -703,11 +703,16 @@ def main():
 
     # Override the default Nucleus asset root with the public S3 prefix
     # so Kit's provider_nucleus plugin does not require OMNI_USER/OMNI_PASS
-    # at boot. The Halos asset_path / motion_library_path / scene paths in
-    # default_config_ros.yaml are all S3 URLs (or local /isaac-sim/sil/...),
-    # so no Nucleus call is actually needed by IRA - the JWT was only
-    # consumed by the kit-boot Nucleus token refresh against the
-    # extension-default Omniverse asset root.
+    # at boot - no Nucleus call is needed by IRA, the JWT was only consumed
+    # by the kit-boot Nucleus token refresh against the extension-default
+    # Omniverse asset root.
+    #
+    # This prefix is load-bearing: both the character asset_path and the
+    # motion_library_path in default_config_ros.yaml are asset-root-relative
+    # (Isaac/People/Characters/ and
+    # Isaac/People/MotionLibrary/HumanMotionLibrary.usd), so IRA resolves them
+    # against the value set here. Only the scene stays absolute (local
+    # /isaac-sim/sil/...).
     #
     # Override via sys.argv so SimulationApp forwards the flag to Kit before
     # provider_nucleus boots. Operator can pin a different prefix by passing
@@ -715,7 +720,7 @@ def main():
     # last value).
     isaac_asset_root = os.environ.get(
         "ISAAC_ASSET_ROOT",
-        "https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0",
+        "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0",
     )
     sys.argv.append(f"--/persistent/isaac/asset_root/default={isaac_asset_root}")
 

--- a/closed-loop-testing/regression-reporter/halos-integration/default_config_ros.yaml.template
+++ b/closed-loop-testing/regression-reporter/halos-integration/default_config_ros.yaml.template
@@ -54,7 +54,11 @@ isaacsim.replicator.agent:
     base_stage_asset_path: /isaac-sim/sil/scenes/indicator_warehouse_20x20_layout_overflow_test.usd
   character:
     root_prim_path: /World/Characters
-    motion_library_path: https://omniverse-content-staging.s3.us-west-2.amazonaws.com/Assets/Behavior/110.0/Samples/Assets/MotionLibrary/Human/HumanMotionLibrary.usd
+    # Asset-root-relative, like the group asset_paths below (run_actor_sdg.py pins
+    # the root). Must be spelled out: IRA 1.6.7 validates this field against a
+    # minLength schema and rejects "" with "'' is too short" before it would ever
+    # fall back to its own default.
+    motion_library_path: Isaac/People/MotionLibrary/HumanMotionLibrary.usd
     groups:
       # The 3 STOCK Halos groups — names MUST match runtime_patches
       # _HALOS_CHAR_SPAWN_TARGETS + srr_ground_truth.DEFAULT_CHAR_GROUPS positional
@@ -64,7 +68,7 @@ isaacsim.replicator.agent:
       #   pickup_workers  -> srr_char2 -> /gt/character_2 (canonical spawn -2.86,-15.28)
       inspect_workers:
         num: 1
-        asset_path: https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0/Isaac/People/Characters/
+        asset_path: Isaac/People/Characters/
         behavior_tree: /isaac-sim/sil/configs/srr_char0.bt.json
         # semantic_labels: stock IRA replicator label pairs as [[key, value]]
         # lists — `class: character` tags the spawned pedestrian mesh for the
@@ -74,14 +78,14 @@ isaacsim.replicator.agent:
           - character
       gather_workers:
         num: 1
-        asset_path: https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0/Isaac/People/Characters/
+        asset_path: Isaac/People/Characters/
         behavior_tree: /isaac-sim/sil/configs/srr_char1.bt.json
         semantic_labels:
         - - class
           - character
       pickup_workers:
         num: 1
-        asset_path: https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0/Isaac/People/Characters/
+        asset_path: Isaac/People/Characters/
         behavior_tree: /isaac-sim/sil/configs/srr_char2.bt.json
         semantic_labels:
         - - class

--- a/closed-loop-testing/regression-reporter/halos-integration/default_config_ros.yaml.template
+++ b/closed-loop-testing/regression-reporter/halos-integration/default_config_ros.yaml.template
@@ -54,10 +54,6 @@ isaacsim.replicator.agent:
     base_stage_asset_path: /isaac-sim/sil/scenes/indicator_warehouse_20x20_layout_overflow_test.usd
   character:
     root_prim_path: /World/Characters
-    # Asset-root-relative, like the group asset_paths below (run_actor_sdg.py pins
-    # the root). Must be spelled out: IRA 1.6.7 validates this field against a
-    # minLength schema and rejects "" with "'' is too short" before it would ever
-    # fall back to its own default.
     motion_library_path: Isaac/People/MotionLibrary/HumanMotionLibrary.usd
     groups:
       # The 3 STOCK Halos groups — names MUST match runtime_patches


### PR DESCRIPTION
The SIL character assets and motion library were pinned to omniverse-content-staging, which is not a source a release should depend on. Point the asset root at omniverse-content-production and make the character paths asset-root-relative, so ISAAC_ASSET_ROOT is the single knob that moves them.

The motion library could not be a like-for-like switch: the old path under Assets/Behavior/110.0/Samples exists only on staging and 404s on production, so it moves to the Isaac People motion library. That is a different asset, not a mirror, hence the verification below.

Note for anyone tempted to blank the field: IRA 1.6.7 validates motion_library_path against a minLength schema and rejects "" with "'' is too short" before it would ever fall back to its own default.

Verified on a cold Isaac cache with sil-data v1.3.0: asset root override logged as production, zero staging references, no errors, and all three characters spawned with distinct outfits and walked at ~0.45 m/s (/gt/character_*/tf sampled 15 s apart).