### PR TITLE
feat(sil): inject RTX sensor anomalies from a hot-reloadable preset file

### DIFF
--- a/closed-loop-testing/isaac-sim/sil/configs/postprocessing.yaml
+++ b/closed-loop-testing/isaac-sim/sil/configs/postprocessing.yaml
@@ -1,0 +1,156 @@
+# RTX post-processing presets — in-scenario sensor-anomaly injection
+# ------------------------------------------------------------------
+# Injects visual degradation (low light, colour cast, flicker, sensor grain)
+# into the rendered image. Because RTX runs post-processing before the encoder,
+# a preset shows up in the viewport, in the SDG RGB output and on every RTSP
+# stream at once — no graph rebuild, and data generation never has to start.
+#
+# Switching preset while the sim is running:
+#
+#     edit `active:` below and save          (run_actor_sdg.py polls this file)
+#     ./scripts/postprocessing/set_preset.sh tv_noise
+#
+# Scope. A preset with no `cameras:` key sets carb settings, which affect the
+# viewport and every camera — "the whole site went dark". Adding `cameras:`
+# authors USD attributes on those cameras instead, so only they degrade —
+# "camera 2 is dirty", which is the case an anomaly campaign usually wants.
+#
+# Per-camera caveat: exposure lives on the camera prim and applies at once, but
+# grain / scanlines / vignetting / colour grading live on the RENDER PRODUCT,
+# which the RTSP graph only creates on the first tick after Play. Those settings
+# stay pending until Play and the log says so.
+#
+# Every key below is validated against an allow-list (scripts/postprocessing/
+# effects.py) transcribed from the Kit renderer source, so a typo is rejected
+# with the preset name and key rather than silently creating a dead carb key.
+# A rejected edit keeps the previously applied preset running.
+
+version: 1
+
+# Which preset is live. Quote names that YAML would read as booleans (off, no).
+active: baseline
+
+presets:
+  # Renderer defaults — what the pipeline looks like with no anomaly.
+  baseline:
+    description: No degradation. The reference look for a golden run.
+    settings: {}
+
+  # Sudden low light: lamp failure, dusk, or an under-exposed sensor.
+  # Auto-exposure must go off first, or the histogram claws the image back to
+  # a normal brightness within about a second and the anomaly disappears.
+  low_light:
+    description: Sudden low light — ISO 12 against a nominal 100.
+    settings:
+      auto_exposure.enabled: false
+      exposure.iso: 12.0
+
+  # White-balance drift: a warm cast that shifts every colour-based cue
+  # without changing geometry, so tracking should survive and colour
+  # classification should not.
+  hue_shift:
+    description: Warm colour cast (white-balance drift), R up / B down ~3%.
+    settings:
+      grade.enabled: true
+      grade.gain: [1.03, 1.0, 0.97]
+
+  # Mains flicker / failing luminaire: sensor gain swings around its base.
+  #
+  # Keep frequency_hz below half the rate the renderer actually achieves, or the
+  # anomaly you ship is not the anomaly the consumer sees. The animation is
+  # sampled once per rendered frame, and this warehouse renders at 8-9 fps on
+  # the SIL box (the RTSP stream declares 30 fps but delivers ~8). Measured on a
+  # continuous capture, 1 Hz and 2 Hz requests read back at 1.0 and 1.8 Hz — the
+  # residual is the error in estimating the achieved frame rate — while 6 Hz
+  # folds down to an unambiguous 3.0 Hz. Raise this only after checking the
+  # frame rate the scene actually achieves.
+  #
+  # This animates ISO, not shutter, and that is deliberate. The obvious knob,
+  # exposure.time, does nothing at global scope in a running sim: something in
+  # the render loop rewrites /rtx/post/tonemap/exposureTime every frame, so our
+  # value never survives to the tonemapper. Measured over 8 RTSP frames, a
+  # +/-35% shutter swing left brightness flat (std 1.3) against a scene-motion
+  # noise floor of std 8.1, while this ISO version swings std 22.7 / range 61.
+  # Shutter flicker DOES work when scoped to `cameras:`, because that authors
+  # exposure:time on the camera prim instead of setting carb -- see the note on
+  # exposure.time in effects.py.
+  flicker:
+    description: 2 Hz brightness flicker, +/-35% around ISO 100.
+    settings:
+      auto_exposure.enabled: false
+      exposure.iso: 100.0
+    animation:
+      target: exposure.iso
+      waveform: sine
+      base: 100.0
+      amplitude_fraction: 0.35
+      frequency_hz: 2.0
+
+  # Degraded stream: sensor grain plus scanlines, the classic "bad analog
+  # camera" look. Grain amount tops out at 0.2. Note that scanline severity is
+  # not tunable — the shader always swings +/-25% and `spread` only sets the
+  # band spacing (1.0 is ~86 bands on a 540-line image).
+  tv_noise:
+    description: Sensor grain + scanlines (degraded/noisy stream).
+    settings:
+      tv_noise.enabled: true
+      tv_noise.film_grain.enabled: true
+      tv_noise.film_grain.amount: 0.12
+      tv_noise.scanlines.enabled: true
+      tv_noise.scanlines.spread: 1.0
+
+  # Soft lens obstruction: a heavy vignette pinches the usable image down to
+  # the centre. Not a true blockage — an opaque occluder prim in front of the
+  # lens is still the only way to model that — but it degrades the frame
+  # border-first the way grime or a misfitted housing does.
+  #
+  # size MUST be 2.0 here, and that is not a typo for the documented default of
+  # 107. The RTX vignette is unnormalised: centre gain is 0.0625 * (size + 14),
+  # so 107 multiplies the middle of the frame by ~7.6 and burns it to pure white
+  # (verified by capture — the pallets disappear entirely). 2.0 gives a centre
+  # gain of exactly 1.0, leaving `strength` as the only knob that matters.
+  #
+  # strength is calibrated by capture, because the real falloff is steeper than
+  # the shader formula predicts per pixel. Ratio of centre brightness to border
+  # brightness on the RTSP frame, which sits at 0.86-0.96 with no vignette:
+  #
+  #     0.2 -> 1.5    0.4 -> 2.2    0.8 -> 4.4    1.6 -> 17.3
+  #
+  # 1.6 is not a vignette, it is a spotlight: the border falls to 1/17 of the
+  # centre and whole-frame brightness drops 70%. 0.8 keeps the centre usable
+  # while the border loses objects, which is the failure this preset is for.
+  vignette_heavy:
+    description: Heavy vignette — soft lens obstruction / grimy housing.
+    settings:
+      tv_noise.enabled: true
+      tv_noise.film_grain.enabled: false
+      tv_noise.vignetting.enabled: true
+      tv_noise.vignetting.size: 2.0
+      tv_noise.vignetting.strength: 0.8
+
+  # Same grain as tv_noise but with the renderer's time input frozen, the intent
+  # being that two runs of one scenario render identical noise — per-frame
+  # randomness would defeat diffing in a regression campaign. Unlike the other
+  # presets here this one is not verified: proving it takes two runs compared
+  # frame by frame.
+  tv_noise_deterministic:
+    description: tv_noise with a frozen time seed, for seeded re-execution.
+    settings:
+      tv_noise.enabled: true
+      tv_noise.film_grain.enabled: true
+      tv_noise.film_grain.amount: 0.12
+      tv_noise.scanlines.enabled: true
+      tv_noise.fixed_time.seed: true
+      tv_noise.fixed_time.seed_count: 12.0
+
+  # One camera degrades while the rest stay clean — the shape of a real
+  # anomaly scenario. `cameras:` takes cameras.yaml names or full prim paths.
+  one_camera_degraded:
+    description: Camera_01 alone goes dark and grainy; other cameras unaffected.
+    cameras: [Camera_01]
+    settings:
+      auto_exposure.enabled: false
+      exposure.iso: 20.0
+      tv_noise.enabled: true
+      tv_noise.film_grain.enabled: true
+      tv_noise.film_grain.amount: 0.15

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/README.md
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/README.md
@@ -91,7 +91,16 @@ the timeline is playing.
 - **A rejected edit keeps the last good preset.** Hot reload means the config is
   edited while a scenario is mid-flight; a half-saved file must not blank the
   degradation being tested. The bad digest is remembered so the warning prints
-  once instead of at poll rate.
+  once instead of at poll rate. That covers every config error — a parse error,
+  an unknown key, a camera not on the stage — because all of them are caught
+  before anything is written.
+- **A failure *inside* the apply falls back to the baseline instead.** Applying a
+  preset starts by reverting the previous one, so once that has begun the last
+  good preset no longer exists to keep; what is on screen is half of a preset
+  that was just rejected. That case reverts to the pre-controller state, drops
+  the animation and the pending render-product writes, and forgets the last good
+  digest so putting the file back re-applies it rather than reading as
+  "unchanged".
 - **All USD authoring goes to the session layer.** A preset never dirties the
   scene `.usd` on disk and never survives a restart, so a degraded run cannot
   leak into the next one through version control.

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/README.md
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/README.md
@@ -38,7 +38,27 @@ cd closed-loop-testing/isaac-sim/sil/scripts/postprocessing
 ```
 
 Editing `active:` in the YAML by hand does the same thing — the script only
-exists so a campaign runner does not have to do string surgery.
+exists so a campaign runner does not have to do string surgery. Both are inert
+against a run launched with `--postprocessing-preset`: that run pins its preset
+for its whole lifetime and never consults `active:` again.
+
+`postprocessing.yaml` is git-tracked, and `set_preset.sh` rewrites it in place:
+the preset is state that outlives the run that set it. Anything scripted has to
+put it back, or the next run — which nobody thinks of as an anomaly run — starts
+degraded:
+
+```bash
+PP=closed-loop-testing/isaac-sim/sil/scripts/postprocessing/set_preset.sh
+trap '"$PP" baseline' EXIT
+"$PP" low_light
+```
+
+A campaign should not depend on that discipline at all. Pass
+`--postprocessing-preset baseline` to `run_actor_sdg.py` and the run pins its
+own preset, ignoring `active:` entirely — `run_multi.sh` does this. A pinned run
+chooses its anomaly at launch (pass the preset you want instead of `baseline`)
+rather than mid-run; an unknown name is rejected before Kit boots, not silently
+ignored — a mistyped anomaly would otherwise score a clean run as a fault run.
 
 Turn the whole thing off with `--no-postprocessing`, or point it at a different
 preset file with `--postprocessing-config`.

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/README.md
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/README.md
@@ -1,0 +1,156 @@
+# `sil/scripts/postprocessing/` — RTX sensor-anomaly injection
+
+Injects visual degradation into the rendered image so the safety monitor can be
+regression-tested against a bad camera: sudden low light, colour cast, exposure
+flicker, sensor grain, heavy vignetting.
+
+This is **not** an OmniGraph, and that is the point. RTX post-processing is
+consumed by the renderer itself, so writing a setting changes the next rendered
+frames — no graph to rebuild, no writer to attach, and **data generation never
+has to start**. The pass runs before the encoder, so one preset shows up in the
+viewport, in the SDG RGB output and on every RTSP stream at once. Compare with
+`../action_graphs/`, where each module builds a graph and needs Play to tick.
+
+Upstream reference: [RTX post-processing](https://docs.omniverse.nvidia.com/materials-and-rendering/latest/rtx_post-processing.html)
+and the IRA visual-noise example.
+
+## What lives here
+
+| Module | Public entry point | Purpose |
+|---|---|---|
+| `effects.py` | `EFFECTS` | Allow-list mapping a stable logical key (`tv_noise.film_grain.amount`) to its carb setting, its USD attribute, and which prim carries it. |
+| `controller.py` | `PostProcessingController` | Loads the active preset, applies it globally or per camera, polls the config for live edits, drives animated effects, and restores the renderer on shutdown. |
+| `set_preset.sh` | — | Switches the live preset by rewriting `active:` atomically. Run it from the host while the sim is running. |
+
+Presets live in [`../../configs/postprocessing.yaml`](../../configs/postprocessing.yaml).
+
+## Using it
+
+The controller is default-ON in `run_actor_sdg.py` whenever
+`configs/postprocessing.yaml` exists, starting on the `baseline` preset (no
+degradation). To inject an anomaly mid-run, from the host:
+
+```bash
+cd closed-loop-testing/isaac-sim/sil/scripts/postprocessing
+./set_preset.sh                 # list presets, show the active one
+./set_preset.sh low_light       # takes effect within ~0.5 s, no restart
+./set_preset.sh baseline        # lift the anomaly
+```
+
+Editing `active:` in the YAML by hand does the same thing — the script only
+exists so a campaign runner does not have to do string surgery.
+
+Turn the whole thing off with `--no-postprocessing`, or point it at a different
+preset file with `--postprocessing-config`.
+
+## Two scopes, and why the difference matters
+
+A preset with no `cameras:` key writes **carb settings**, which the renderer
+applies to the viewport and every camera. That models an environment-wide event
+("the lights went out"), and it is what the IRA example demonstrates.
+
+A preset **with** `cameras:` authors **USD attributes** on those cameras
+instead, which override the carb value for them alone. That models the case an
+anomaly campaign actually cares about: one camera degrades while the others stay
+clean, so you can assert the monitor still covers the zone.
+
+The USD attribute names are not a rename of the carb paths, and the split is
+easy to get wrong:
+
+| Effect family | Carb (global) | USD (per camera) | Authored on |
+|---|---|---|---|
+| Auto-exposure | `/rtx/post/histogram/enabled` | `omni:rtx:autoExposure:enabled` | Camera prim |
+| Exposure | `/rtx/post/tonemap/filmIso` (`exposureTime` is inert — see below) | `exposure:iso`, `exposure:time` | Camera prim |
+| Colour grading | `/rtx/post/colorgrad/gain` | `omni:rtx:post:grade:gain` | **Render product** |
+| TV noise | `/rtx/post/tvNoise/grainAmount` | `omni:rtx:post:tvNoise:filmGrain:amount` | **Render product** |
+
+Note `colorgrad` on the carb side versus `grade` on the USD side, and the
+flattened `enableFilmGrain` versus the nested `filmGrain:enabled`. `effects.py`
+is transcribed from the Kit renderer source (`RtxPostProcessingSettingNames.cpp`,
+`generatedSchema.usda`, `TvNoiseSettings.h`) rather than from the docs table, so
+it is the place to check a name.
+
+### Per-camera timing caveat
+
+Render products are created by `IsaacCreateRenderProduct` inside the RTSP graph,
+which only runs on the **first tick after Play**. So for a per-camera preset:
+
+- exposure settings land immediately (the camera prim already exists);
+- grain, scanlines, vignetting and colour grading stay **pending until Play**.
+
+The controller logs the pending keys once and keeps retrying, rather than
+failing. If a per-camera noise preset looks like it did nothing, check whether
+the timeline is playing.
+
+## Design notes
+
+- **Logical keys, not raw carb paths, in YAML.** One preset then works in either
+  scope, and an operator does not have to know that carb and USD disagree on
+  spelling. The allow-list also turns a typo into a rejection naming the preset
+  and key, instead of silently creating a carb key RTX never reads.
+- **A rejected edit keeps the last good preset.** Hot reload means the config is
+  edited while a scenario is mid-flight; a half-saved file must not blank the
+  degradation being tested. The bad digest is remembered so the warning prints
+  once instead of at poll rate.
+- **All USD authoring goes to the session layer.** A preset never dirties the
+  scene `.usd` on disk and never survives a restart, so a degraded run cannot
+  leak into the next one through version control.
+- **Revert removes the applied API schemas too, not just the attributes.**
+  Leaving `OmniRtxPostTvNoiseAPI_1` applied with its attribute removed makes the
+  prim resolve the *schema default* (noise disabled), which would then override a
+  later global preset for that camera — the opposite of reverting.
+- **Auto-exposure is switched off in every exposure preset.** Left on, the
+  histogram adapts and claws a darkened image back to normal brightness within
+  about a second, so the anomaly quietly disappears.
+- **One animated float, sine only.** Enough for mains flicker, which is the
+  time-varying anomaly that comes up; anything richer belongs in a scenario
+  script rather than a preset file.
+- **Animate ISO for flicker, not shutter.** `/rtx/post/tonemap/exposureTime` is
+  rewritten by the render loop on every frame — it mirrors `cameraShutter`, the
+  same quantity expressed as 1/s — so a global write never reaches the
+  tonemapper and the flicker silently does nothing. `exposure:time` on a camera
+  prim does work, so shutter flicker is available at per-camera scope.
+- **Animation frequency is bounded by the frame rate, not by the config.** The
+  sine is sampled once per rendered frame, so a request above half the achieved
+  rate aliases: on the SIL box (8–9 fps for this warehouse) 6 Hz comes back as
+  3 Hz. Check the achieved rate before raising `frequency_hz`.
+- **`tv_noise_deterministic` exists for regression runs.** `fixed_time.seed`
+  freezes the renderer's time input, the intent being that two runs of one
+  scenario produce identical noise; per-frame randomness would otherwise defeat
+  diffing. Not yet proven — it needs two runs diffed frame by frame.
+
+## Measured on the SIL warehouse
+
+Numbers below come from single frames pulled off the RTSP streams with `ffmpeg`
+while the scenario ran, so they describe what a consumer of the stream receives,
+after H.264 encode — not what the renderer intended. `hf` is the standard
+deviation of the Laplacian, which rises with grain and scanlines; `c/edge` is
+centre brightness over border brightness.
+
+| Preset | Effect on the stream |
+|---|---|
+| `low_light` | mean 133 → 36, all three cameras |
+| `tv_noise` | `hf` 16.8 → 37.8, all three cameras |
+| `vignette_heavy` | `c/edge` 0.95 → 4.2 |
+| `flicker` | brightness ripple 0.13 → 14.0 over a continuous capture |
+| `one_camera_degraded` | Camera_01 mean −74.7 and `hf` +16.8, while Camera and Camera_02 move −2.7 and −0.1 |
+
+The last row is the one worth re-running after any change to scoping: it is the
+only check that a per-camera preset does not leak onto the other streams.
+
+`hue_shift` is not in the table — a 3% channel shift needs a per-channel
+measurement to show up at all, and it has not been done.
+
+## Not covered
+
+**Blockage** (an opaque object over the lens) is not a post-processing effect.
+Heavy vignetting (`vignette_heavy`) degrades the frame border-first the way
+grime does, but a real occlusion still needs a prim placed in front of the
+camera. There is no Isaac Sim component for it today.
+
+**Sensor-level noise** — photon shot noise, dark-current noise, depth disparity
+noise — is a different mechanism, modelled inside the sensor pipeline by
+`isaacsim.sensors.experimental.rtx` (experimental) rather than in the post
+stack. It is more physically faithful and correspondingly more work to
+configure; post-processing is the right tool when the goal is a repeatable
+image-level anomaly.

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/__init__.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Runtime RTX post-processing for Halos SIL sensor-anomaly injection."""
+
+from .controller import DEFAULT_CONFIG, PostProcessingController
+from .effects import EFFECTS
+
+__all__ = ["DEFAULT_CONFIG", "EFFECTS", "PostProcessingController"]

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/controller.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/controller.py
@@ -155,29 +155,70 @@ class PostProcessingController:
         if digest in (self._digest, self._rejected_digest):
             return
 
+        # Set immediately BEFORE the call, not inside it: _apply() starts by
+        # reverting, so a raise anywhere in it means the renderer is already
+        # dirty. Everything above it is pure config work that touches nothing.
+        entered_apply = False
         try:
             import yaml
 
             config = yaml.safe_load(raw) or {}
             name, preset = _select_preset(config)
             _validate_preset(name, preset)
-            # Resolved here, before anything is reverted: a bad camera name has
-            # to be rejected like any other config error, leaving the preset
-            # that is currently degrading the scene untouched.
+            # Resolved before anything is reverted: a bad camera name has to be
+            # rejected like any other config error, leaving the preset that is
+            # currently degrading the scene untouched.
             camera_prim_paths = self._resolve_scope(preset)
+            # Inside the try as well, because the apply layer raises too (a
+            # KIND_COLOR3 value carb refuses, a closed stage, a USD authoring
+            # error).
+            entered_apply = True
+            self._apply(name, preset, camera_prim_paths)
         except Exception as exc:
             # Remember the bad digest so a broken edit is reported once instead
-            # of every poll, and keep serving the last good preset.
+            # of every poll — which also keeps a failing apply from retrying at
+            # render rate.
             self._rejected_digest = digest
+
+            if not entered_apply:
+                # Config error: nothing was touched, so the anomaly under test
+                # keeps running. _digest still describes what is live, which is
+                # what makes restoring the file early-return correctly.
+                _say(f"WARNING: rejected {self.config_path}: {exc}; active preset is {self._active_name!r}")
+                return
+
+            # A failure part-way through _apply cannot leave the last good preset
+            # standing, because applying starts by reverting: what is on screen is
+            # half of a preset that was just rejected, a look nothing in the file
+            # describes. Go back to the baseline instead. This also drops the
+            # _pending_rp_settings the failed apply queued, which would otherwise
+            # be authored onto the render products on the first tick after Play —
+            # silently installing the very preset rejected here.
+            try:
+                self._revert()
+            except Exception as revert_exc:
+                _say(f"WARNING: could not fully restore renderer state: {revert_exc}")
+            # The rejected preset's animation would keep driving a value every
+            # frame, and a stale name would make active_preset lie about it.
+            self._animation = None
+            self._active_name = None
+            # Forget the last good digest too. The usual recovery is to put the
+            # file back the way it was, and that content still matches _digest —
+            # it would early-return as "unchanged" and strand the scene on the
+            # baseline for the rest of the run. _rejected_digest still absorbs
+            # every re-read of the broken file, so this cannot become a retry
+            # storm.
+            self._digest = None
             _say(
                 f"WARNING: rejected {self.config_path}: {exc}; "
-                f"keeping preset {self._active_name!r}"
+                "reverted the renderer to its pre-preset state"
             )
             return
 
+        # Committed only once the preset is actually live, so a rejected edit
+        # cannot make the controller believe it applied something it did not.
         self._digest = digest
         self._rejected_digest = None
-        self._apply(name, preset, camera_prim_paths)
 
     # -- apply / revert ----------------------------------------------------
 

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/controller.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/controller.py
@@ -207,20 +207,25 @@ class PostProcessingController:
         _say(f"Applied preset {name!r} ({detail})")
 
     def _revert(self):
-        for path, value in self._carb_snapshot.items():
-            if value is _MISSING:
-                destroy = getattr(self._settings, "destroy_item", None)
-                if destroy is not None:
-                    destroy(path)
-            else:
-                self._settings.set(path, value)
+        # Two phases, and the USD one must not be hostage to the carb one: a
+        # single failing settings path would otherwise leave the previous
+        # preset's per-camera attributes authored on the stage, which both
+        # close() and the _apply() preset switch promise to clear.
+        try:
+            for path, value in self._carb_snapshot.items():
+                if value is _MISSING:
+                    destroy = getattr(self._settings, "destroy_item", None)
+                    if destroy is not None:
+                        destroy(path)
+                else:
+                    self._settings.set(path, value)
+        finally:
+            if self._authored_attrs or self._authored_apis:
+                self._clear_authored_usd()
 
-        if self._authored_attrs or self._authored_apis:
-            self._clear_authored_usd()
-
-        self._pending_rp_settings = []
-        self._pending_warned = False
-        self._camera_prim_paths = []
+            self._pending_rp_settings = []
+            self._pending_warned = False
+            self._camera_prim_paths = []
 
     def _snapshot_carb(self):
         for key, effect in EFFECTS.items():

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/controller.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/controller.py
@@ -268,12 +268,21 @@ class PostProcessingController:
                 else:
                     self._settings.set(path, value)
         finally:
-            if self._authored_attrs or self._authored_apis:
-                self._clear_authored_usd()
-
-            self._pending_rp_settings = []
-            self._pending_warned = False
-            self._camera_prim_paths = []
+            # Three phases, not two, and for the same reason: the state resets
+            # below must not be hostage to the USD cleanup either. A raise from
+            # _clear_authored_usd() used to skip them, leaving the reverted
+            # preset's DEFERRED render-product writes queued -- and update()
+            # authors those onto the render products on the first tick after
+            # Play, installing a preset that active_preset reports as gone. The
+            # raise still propagates once the resets have run, so close() and
+            # _reload_if_changed() still log the cleanup failure.
+            try:
+                if self._authored_attrs or self._authored_apis:
+                    self._clear_authored_usd()
+            finally:
+                self._pending_rp_settings = []
+                self._pending_warned = False
+                self._camera_prim_paths = []
 
     def _snapshot_carb(self):
         for key, effect in EFFECTS.items():

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/controller.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/controller.py
@@ -1,0 +1,529 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Config-driven RTX post-processing for in-scenario sensor-anomaly injection.
+
+Deliberately NOT an OmniGraph. RTX post-processing is consumed by the renderer
+itself, so a preset takes effect on the next rendered frame — the viewport, the
+SDG RGB output and the RTSP stream all carry it, because the pass runs before
+the encoder. Nothing has to be rebuilt and data generation never has to start.
+
+Two scopes, chosen per preset:
+
+  * global (default) — carb settings. Affects the viewport and every camera.
+    Use it for "the whole site went dark".
+  * per camera (`cameras:` in the preset) — USD attributes on that camera's
+    prim and render product, which override the carb value for that camera
+    alone. Use it for "camera 2 is degraded", the case an anomaly campaign
+    actually cares about.
+
+Per-camera scoping has one timing quirk worth knowing: the RTSP graph creates
+render products through `IsaacCreateRenderProduct`, which only runs on the
+first tick after Play. Grain, scanlines, vignetting and color grading live on
+the render product, so those stay pending until Play; exposure lives on the
+camera prim and applies immediately. `update()` keeps retrying and says so once
+per preset rather than failing.
+
+All USD authoring goes into the stage's session layer, so a preset never dirties
+the scene `.usd` on disk and never survives a restart.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import os
+import time
+
+from .effects import (
+    ANIMATABLE,
+    EFFECTS,
+    KIND_BOOL,
+    KIND_COLOR3,
+    KIND_FLOAT,
+    TARGET_CAMERA,
+    TARGET_RENDER_PRODUCT,
+)
+
+DEFAULT_CONFIG = "/isaac-sim/sil/configs/postprocessing.yaml"
+
+# Sentinel for "this carb key did not exist before we touched it".
+_MISSING = object()
+
+_LOG = "[postprocessing]"
+
+
+def _say(message):
+    """Log a line that survives being piped.
+
+    Kit's own logging is C++ writing straight to the file descriptor, but these
+    lines go through Python's stdout, which block-buffers when it is a pipe. Two
+    or three short lines never fill the buffer, so without an explicit flush the
+    whole preset history can stay invisible for an entire run while carb log
+    output streams past it.
+    """
+    print(f"{_LOG} {message}", flush=True)
+
+
+class PostProcessingController:
+    """Apply one preset from `postprocessing.yaml` and hot-reload it live.
+
+    Lifecycle, driven by run_actor_sdg.py:
+        start()   once, after the simulation is set up
+        update()  every frame from the run loop
+        close()   on shutdown, to put the renderer back as it was
+    """
+
+    def __init__(
+        self,
+        config_path=DEFAULT_CONFIG,
+        *,
+        cameras_config_path=None,
+        poll_interval_sec=0.5,
+        settings=None,
+        clock=None,
+    ):
+        self.config_path = os.path.abspath(config_path)
+        self.cameras_config_path = cameras_config_path
+        # Sub-100ms polling would stat the file several times per rendered
+        # frame for no operator-visible benefit.
+        self.poll_interval_sec = max(float(poll_interval_sec), 0.1)
+
+        self._clock = clock or time.monotonic
+        self._settings = settings
+
+        self._next_poll_at = 0.0
+        self._digest = None
+        self._rejected_digest = None
+
+        self._active_name = None
+        self._carb_snapshot = {}
+        self._authored_attrs = []   # (prim_path, attr_name)
+        self._authored_apis = []    # (prim_path, api_name)
+
+        self._camera_prim_paths = []
+        self._pending_rp_settings = []
+        self._pending_warned = False
+
+        self._animation = None
+        self._animation_t0 = 0.0
+
+    @property
+    def active_preset(self):
+        return self._active_name
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def start(self):
+        """Load and apply the active preset. Call after setup_simulation()."""
+        if self._settings is None:
+            import carb.settings
+
+            self._settings = carb.settings.get_settings()
+        self._snapshot_carb()
+        self.update(force_reload=True)
+
+    def update(self, *, force_reload=False):
+        """Re-read the config when due, retry pending writes, advance animation."""
+        now = self._clock()
+        if force_reload or now >= self._next_poll_at:
+            self._next_poll_at = now + self.poll_interval_sec
+            self._reload_if_changed()
+        if self._pending_rp_settings:
+            self._flush_pending_render_product_settings()
+        self._advance_animation(now)
+
+    def close(self):
+        """Restore the renderer to its pre-controller state."""
+        try:
+            self._revert()
+        except Exception as exc:
+            _say(f"WARNING: could not fully restore renderer state: {exc}")
+        self._animation = None
+        self._active_name = None
+
+    # -- config ------------------------------------------------------------
+
+    def _reload_if_changed(self):
+        try:
+            with open(self.config_path, "rb") as stream:
+                raw = stream.read()
+        except OSError as exc:
+            _say(f"WARNING: cannot read {self.config_path}: {exc}")
+            return
+
+        digest = hashlib.sha256(raw).digest()
+        if digest in (self._digest, self._rejected_digest):
+            return
+
+        try:
+            import yaml
+
+            config = yaml.safe_load(raw) or {}
+            name, preset = _select_preset(config)
+            _validate_preset(name, preset)
+            # Resolved here, before anything is reverted: a bad camera name has
+            # to be rejected like any other config error, leaving the preset
+            # that is currently degrading the scene untouched.
+            camera_prim_paths = self._resolve_scope(preset)
+        except Exception as exc:
+            # Remember the bad digest so a broken edit is reported once instead
+            # of every poll, and keep serving the last good preset.
+            self._rejected_digest = digest
+            _say(
+                f"WARNING: rejected {self.config_path}: {exc}; "
+                f"keeping preset {self._active_name!r}"
+            )
+            return
+
+        self._digest = digest
+        self._rejected_digest = None
+        self._apply(name, preset, camera_prim_paths)
+
+    # -- apply / revert ----------------------------------------------------
+
+    def _apply(self, name, preset, camera_prim_paths):
+        # Revert first: switching presets must not leak the previous one's ISO,
+        # gain or noise toggles into the new look.
+        self._revert()
+
+        settings = preset.get("settings") or {}
+        self._camera_prim_paths = camera_prim_paths
+
+        if self._camera_prim_paths:
+            for key, value in settings.items():
+                self._write_scoped(key, value)
+        else:
+            for key, value in settings.items():
+                self._settings.set(EFFECTS[key].carb_path, value)
+
+        self._animation = preset.get("animation")
+        self._animation_t0 = self._clock()
+        self._active_name = name
+
+        scope = ", ".join(self._camera_prim_paths) if self._camera_prim_paths else "global"
+        detail = f"{len(settings)} setting(s), scope={scope}"
+        if self._animation:
+            detail += f", animating {self._animation['target']}"
+        _say(f"Applied preset {name!r} ({detail})")
+
+    def _revert(self):
+        for path, value in self._carb_snapshot.items():
+            if value is _MISSING:
+                destroy = getattr(self._settings, "destroy_item", None)
+                if destroy is not None:
+                    destroy(path)
+            else:
+                self._settings.set(path, value)
+
+        if self._authored_attrs or self._authored_apis:
+            self._clear_authored_usd()
+
+        self._pending_rp_settings = []
+        self._pending_warned = False
+        self._camera_prim_paths = []
+
+    def _snapshot_carb(self):
+        for key, effect in EFFECTS.items():
+            current = self._settings.get(effect.carb_path)
+            self._carb_snapshot[effect.carb_path] = _MISSING if current is None else current
+
+    # -- per-camera authoring ---------------------------------------------
+
+    def _resolve_scope(self, preset):
+        """Camera prim paths for a per-camera preset; empty list means global.
+
+        Also proves the prims exist, so `_apply` cannot fail halfway through
+        and leave the scene wearing half a preset.
+        """
+        cameras = preset.get("cameras") or []
+        if not cameras:
+            return []
+        paths = self._resolve_camera_prims(cameras)
+        stage = self._stage()
+        missing = [p for p in paths if not stage.GetPrimAtPath(p).IsValid()]
+        if missing:
+            raise ValueError(f"camera prim(s) not on stage: {', '.join(missing)}")
+        return paths
+
+    def _resolve_camera_prims(self, cameras):
+        """Map preset `cameras:` entries to camera prim paths.
+
+        An entry starting with "/" is taken as a prim path; anything else is
+        looked up as a camera `name` in cameras.yaml, so a preset can say
+        `Camera_01` instead of repeating the full prim path.
+        """
+        paths = []
+        by_name = None
+        for entry in cameras:
+            if entry.startswith("/"):
+                paths.append(entry)
+                continue
+            if by_name is None:
+                by_name = self._load_camera_name_map()
+            prim_path = by_name.get(entry)
+            if prim_path is None:
+                known = ", ".join(sorted(by_name)) or "none"
+                raise ValueError(
+                    f"camera {entry!r} not found in {self.cameras_config_path} (known: {known})"
+                )
+            paths.append(prim_path)
+        return paths
+
+    def _load_camera_name_map(self):
+        if not self.cameras_config_path or not os.path.isfile(self.cameras_config_path):
+            raise ValueError(
+                "preset selects cameras by name but cameras.yaml is unavailable; "
+                "pass full prim paths instead"
+            )
+        import yaml
+
+        with open(self.cameras_config_path) as stream:
+            cfg = yaml.safe_load(stream) or {}
+        return {
+            cam["name"]: cam["camera_prim"]
+            for cam in (cfg.get("cameras") or [])
+            if "name" in cam and "camera_prim" in cam
+        }
+
+    def _write_scoped(self, key, value):
+        effect = EFFECTS[key]
+        if effect.target == TARGET_CAMERA:
+            stage = self._stage()
+            for prim_path in self._camera_prim_paths:
+                prim = stage.GetPrimAtPath(prim_path)
+                if not prim or not prim.IsValid():
+                    raise RuntimeError(f"camera prim missing on stage: {prim_path}")
+                self._author(prim, effect, value)
+            return
+
+        # Render products do not exist until the first tick after Play, so
+        # defer instead of failing and let update() pick them up.
+        products = self._render_products()
+        if not products:
+            self._pending_rp_settings.append((key, value))
+            return
+        for prim in products:
+            self._author(prim, effect, value)
+
+    def _flush_pending_render_product_settings(self):
+        products = self._render_products()
+        if not products:
+            if not self._pending_warned:
+                self._pending_warned = True
+                keys = ", ".join(key for key, _ in self._pending_rp_settings)
+                _say(
+                    f"{len(self._pending_rp_settings)} setting(s) waiting for render "
+                    f"products (created on the first tick after Play): {keys}"
+                )
+            return
+
+        pending, self._pending_rp_settings = self._pending_rp_settings, []
+        for key, value in pending:
+            for prim in products:
+                self._author(prim, EFFECTS[key], value)
+        _say(f"Applied {len(pending)} deferred setting(s) to {len(products)} render product(s)")
+
+    def _render_products(self):
+        """Render product prims bound to the preset's cameras."""
+        stage = self._stage()
+        wanted = set(self._camera_prim_paths)
+        found = []
+        for prim in stage.Traverse():
+            if prim.GetTypeName() != "RenderProduct":
+                continue
+            rel = prim.GetRelationship("camera")
+            if not rel:
+                continue
+            if any(str(target) in wanted for target in rel.GetTargets()):
+                found.append(prim)
+        return found
+
+    def _author(self, prim, effect, value):
+        """Author one USD attribute in the session layer, tracked for cleanup."""
+        from pxr import Sdf, Usd
+
+        stage = self._stage()
+        prim_path = str(prim.GetPath())
+
+        with Usd.EditContext(stage, stage.GetSessionLayer()):
+            if effect.usd_api and effect.usd_api not in prim.GetAppliedSchemas():
+                prim.AddAppliedSchema(effect.usd_api)
+                self._authored_apis.append((prim_path, effect.usd_api))
+
+            attr = prim.CreateAttribute(effect.usd_attr, _sdf_type(Sdf, effect.kind))
+            attr.Set(_usd_value(effect.kind, value))
+
+        # An animated per-camera preset re-authors the same attribute on every
+        # frame, so this has to record it once rather than append 60 times a
+        # second for as long as the scenario runs.
+        entry = (prim_path, effect.usd_attr)
+        if entry not in self._authored_attrs:
+            self._authored_attrs.append(entry)
+
+    def _clear_authored_usd(self):
+        """Remove every attribute and API schema this controller authored.
+
+        The API schemas have to go too: leaving one applied with its attribute
+        removed makes the prim resolve the SCHEMA DEFAULT (e.g. tvNoise
+        disabled), which would then override a later global carb preset for
+        that camera — the opposite of reverting.
+        """
+        from pxr import Usd
+
+        stage = self._stage(required=False)
+        if stage is None:
+            self._authored_attrs = []
+            self._authored_apis = []
+            return
+
+        with Usd.EditContext(stage, stage.GetSessionLayer()):
+            for prim_path, attr_name in self._authored_attrs:
+                prim = stage.GetPrimAtPath(prim_path)
+                if prim and prim.IsValid():
+                    prim.RemoveProperty(attr_name)
+            for prim_path, api_name in self._authored_apis:
+                prim = stage.GetPrimAtPath(prim_path)
+                remove = getattr(prim, "RemoveAppliedSchema", None) if prim else None
+                if remove is not None:
+                    remove(api_name)
+
+        self._authored_attrs = []
+        self._authored_apis = []
+
+    def _stage(self, required=True):
+        import omni.usd
+
+        stage = omni.usd.get_context().get_stage()
+        if stage is None and required:
+            raise RuntimeError("no USD stage open")
+        return stage
+
+    # -- animation ---------------------------------------------------------
+
+    def _advance_animation(self, now):
+        """Drive one float effect per frame, for flicker-style anomalies."""
+        if not self._animation:
+            return
+        base = float(self._animation["base"])
+        amplitude = float(self._animation["amplitude_fraction"])
+        frequency = float(self._animation["frequency_hz"])
+        phase = 2.0 * math.pi * frequency * (now - self._animation_t0)
+        value = base * (1.0 + amplitude * math.sin(phase))
+
+        key = self._animation["target"]
+        if self._camera_prim_paths:
+            self._write_scoped(key, value)
+        else:
+            self._settings.set(EFFECTS[key].carb_path, value)
+
+
+# -- helpers ---------------------------------------------------------------
+
+
+def _sdf_type(Sdf, kind):
+    return {
+        KIND_BOOL: Sdf.ValueTypeNames.Bool,
+        KIND_FLOAT: Sdf.ValueTypeNames.Float,
+        KIND_COLOR3: Sdf.ValueTypeNames.Color3f,
+    }[kind]
+
+
+def _usd_value(kind, value):
+    if kind == KIND_COLOR3:
+        from pxr import Gf
+
+        return Gf.Vec3f(*[float(v) for v in value])
+    if kind == KIND_FLOAT:
+        return float(value)
+    return bool(value)
+
+
+def _is_number(value):
+    # bool is a subclass of int; reject it so `true` cannot pass as a number.
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _select_preset(config):
+    if not isinstance(config, dict):
+        raise ValueError("top level must be a mapping")
+    if config.get("version") != 1:
+        raise ValueError("version must be 1")
+
+    presets = config.get("presets")
+    if not isinstance(presets, dict) or not presets:
+        raise ValueError("'presets' must be a non-empty mapping")
+
+    active = config.get("active")
+    if isinstance(active, bool):
+        # YAML 1.1 reads off/no/false as booleans, so `active: off` silently
+        # becomes False and no preset matches. Name presets in words instead.
+        raise ValueError(
+            "'active' parsed as a boolean — quote it (\"off\") or use a word like 'baseline'"
+        )
+    if not isinstance(active, str) or not active:
+        raise ValueError("'active' must be a non-empty preset name")
+    if active not in presets:
+        raise ValueError(f"active preset {active!r} not in presets ({', '.join(sorted(presets))})")
+
+    preset = presets[active]
+    if preset is None:
+        preset = {}
+    if not isinstance(preset, dict):
+        raise ValueError(f"preset {active!r} must be a mapping")
+    return active, preset
+
+
+def _validate_preset(name, preset):
+    unknown = set(preset) - {"description", "settings", "cameras", "animation"}
+    if unknown:
+        raise ValueError(f"preset {name!r} has unsupported keys: {sorted(unknown)}")
+
+    settings = preset.get("settings") or {}
+    if not isinstance(settings, dict):
+        raise ValueError(f"preset {name!r}: 'settings' must be a mapping")
+    for key, value in settings.items():
+        effect = EFFECTS.get(key)
+        if effect is None:
+            raise ValueError(f"preset {name!r}: unknown setting {key!r}")
+        if effect.kind == KIND_BOOL and not isinstance(value, bool):
+            raise ValueError(f"preset {name!r}: {key} must be true or false")
+        if effect.kind == KIND_FLOAT and not _is_number(value):
+            raise ValueError(f"preset {name!r}: {key} must be a number")
+        if effect.kind == KIND_COLOR3 and not (
+            isinstance(value, (list, tuple)) and len(value) == 3 and all(_is_number(v) for v in value)
+        ):
+            raise ValueError(f"preset {name!r}: {key} must be three numbers")
+
+    cameras = preset.get("cameras")
+    if cameras is not None:
+        if not isinstance(cameras, list) or not cameras:
+            raise ValueError(f"preset {name!r}: 'cameras' must be a non-empty list when present")
+        if not all(isinstance(entry, str) and entry for entry in cameras):
+            raise ValueError(f"preset {name!r}: 'cameras' entries must be names or prim paths")
+
+    animation = preset.get("animation")
+    if animation is None:
+        return
+    if not isinstance(animation, dict):
+        raise ValueError(f"preset {name!r}: 'animation' must be a mapping")
+
+    unknown = set(animation) - {"target", "waveform", "base", "amplitude_fraction", "frequency_hz"}
+    if unknown:
+        raise ValueError(f"preset {name!r}: animation has unsupported keys: {sorted(unknown)}")
+
+    target = animation.get("target")
+    if target not in ANIMATABLE:
+        raise ValueError(
+            f"preset {name!r}: animation.target must be one of {', '.join(sorted(ANIMATABLE))}"
+        )
+    if animation.get("waveform", "sine") != "sine":
+        raise ValueError(f"preset {name!r}: only animation.waveform 'sine' is supported")
+    for field in ("base", "amplitude_fraction", "frequency_hz"):
+        if not _is_number(animation.get(field)):
+            raise ValueError(f"preset {name!r}: animation.{field} must be a number")
+    if animation["base"] <= 0:
+        raise ValueError(f"preset {name!r}: animation.base must be > 0")
+    if not 0 <= animation["amplitude_fraction"] < 1:
+        raise ValueError(f"preset {name!r}: animation.amplitude_fraction must be in [0, 1)")
+    if animation["frequency_hz"] <= 0:
+        raise ValueError(f"preset {name!r}: animation.frequency_hz must be > 0")

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/controller.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/controller.py
@@ -413,14 +413,19 @@ class PostProcessingController:
                 self._authored_apis.append((prim_path, effect.usd_api))
 
             attr = prim.CreateAttribute(effect.usd_attr, _sdf_type(Sdf, effect.kind))
-            attr.Set(_usd_value(effect.kind, value))
 
-        # An animated per-camera preset re-authors the same attribute on every
-        # frame, so this has to record it once rather than append 60 times a
-        # second for as long as the scenario runs.
-        entry = (prim_path, effect.usd_attr)
-        if entry not in self._authored_attrs:
-            self._authored_attrs.append(entry)
+            # Record before writing, not after. CreateAttribute is what puts the
+            # attribute on the prim, so a Set() that raises would otherwise leave
+            # it on the stage and out of the ledger -- surviving every _revert()
+            # and close() for the rest of the process, while active_preset
+            # reports None. An animated preset re-authors the same attribute
+            # every frame, so record it once rather than append 60 times a
+            # second for as long as the scenario runs.
+            entry = (prim_path, effect.usd_attr)
+            if entry not in self._authored_attrs:
+                self._authored_attrs.append(entry)
+
+            attr.Set(_usd_value(effect.kind, value))
 
     def _clear_authored_usd(self):
         """Remove every attribute and API schema this controller authored.

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/controller.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/controller.py
@@ -78,12 +78,19 @@ class PostProcessingController:
         config_path=DEFAULT_CONFIG,
         *,
         cameras_config_path=None,
+        preset_override=None,
         poll_interval_sec=0.5,
         settings=None,
         clock=None,
     ):
         self.config_path = os.path.abspath(config_path)
         self.cameras_config_path = cameras_config_path
+        # Pins the preset for the whole run, ignoring `active:` in the file.
+        # postprocessing.yaml is git-tracked but set_preset.sh rewrites it in
+        # place, so without a pin the last anomaly an operator injected is what
+        # the NEXT run starts in. Polling stays on: an unrelated edit to the
+        # file still re-applies this preset, which is a no-op look-wise.
+        self.preset_override = preset_override
         # Sub-100ms polling would stat the file several times per rendered
         # frame for no operator-visible benefit.
         self.poll_interval_sec = max(float(poll_interval_sec), 0.1)
@@ -163,7 +170,7 @@ class PostProcessingController:
             import yaml
 
             config = yaml.safe_load(raw) or {}
-            name, preset = _select_preset(config)
+            name, preset = _select_preset(config, self.preset_override)
             _validate_preset(name, preset)
             # Resolved before anything is reverted: a bad camera name has to be
             # rejected like any other config error, leaving the preset that is
@@ -489,7 +496,7 @@ def _is_number(value):
     return isinstance(value, (int, float)) and not isinstance(value, bool)
 
 
-def _select_preset(config):
+def _select_preset(config, override=None):
     if not isinstance(config, dict):
         raise ValueError("top level must be a mapping")
     if config.get("version") != 1:
@@ -499,7 +506,21 @@ def _select_preset(config):
     if not isinstance(presets, dict) or not presets:
         raise ValueError("'presets' must be a non-empty mapping")
 
-    active = config.get("active")
+    if override is not None and not str(override).strip():
+        # `--postprocessing-preset "$PRESET"` with PRESET unset arrives as an
+        # empty string. Falling back to `active:` there would hand the run
+        # whatever preset set_preset.sh last wrote — the exact leak the pin
+        # exists to prevent — so treat it as the launcher bug it is.
+        raise ValueError("--postprocessing-preset was given an empty value")
+
+    active = override or config.get("active")
+    if override and override not in presets:
+        # Named against the flag, not the file: a launcher pinning a preset that
+        # the config does not define is a launcher bug, and pointing the
+        # operator at `active:` would send them editing the wrong thing.
+        raise ValueError(
+            f"--postprocessing-preset {override!r} not in presets ({', '.join(sorted(presets))})"
+        )
     if isinstance(active, bool):
         # YAML 1.1 reads off/no/false as booleans, so `active: off` silently
         # becomes False and no preset matches. Name presets in words instead.

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/effects.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/effects.py
@@ -1,0 +1,303 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Allow-list of RTX post-processing controls, keyed by a stable logical name.
+
+Each effect can be applied two ways, and the two use DIFFERENT names for the
+same control:
+
+  * globally, by setting a carb setting (`/rtx/post/...`) — affects the viewport
+    and every render product that does not override it;
+  * per camera, by authoring a USD attribute on a specific prim — overrides the
+    carb value for that camera only.
+
+The USD side is not a rename of the carb path, so the mapping has to be a table
+rather than a string transform. Two things in particular bite:
+
+  * exposure and auto-exposure are authored on the CAMERA prim
+    (`exposure:iso`, `omni:rtx:autoExposure:enabled`), while grain, scanlines,
+    vignetting and color grading are authored on the RENDER PRODUCT
+    (`omni:rtx:post:tvNoise:*`, `omni:rtx:post:grade:*`);
+  * carb spells color grading `colorgrad` but USD spells it `grade`, and carb
+    flattens the tvNoise toggles (`enableFilmGrain`) where USD nests them
+    (`tvNoise:filmGrain:enabled`).
+
+Names and defaults are transcribed from the Kit renderer source rather than the
+public docs table:
+  kit/rendering/source/plugins/rtx.postprocessing/RtxPostProcessingSettingNames.cpp
+  kit/schemas/rtx_settings/usd_plugins/generatedSchema.usda
+  kit/rendering/include/rtx/postprocessing/TvNoiseSettings.h
+"""
+
+from __future__ import annotations
+
+# Which prim carries the USD attribute for an effect.
+TARGET_CAMERA = "camera"
+TARGET_RENDER_PRODUCT = "render_product"
+
+# Value kinds. Kept as strings so this table stays importable outside Kit
+# (the pxr Sdf types are resolved lazily in the controller).
+KIND_BOOL = "bool"
+KIND_FLOAT = "float"
+KIND_COLOR3 = "color3f"
+
+
+class Effect:
+    """One renderer control, addressable as a carb setting or a USD attribute."""
+
+    __slots__ = ("carb_path", "usd_attr", "usd_api", "target", "kind", "doc")
+
+    def __init__(self, carb_path, usd_attr, usd_api, target, kind, doc=""):
+        self.carb_path = carb_path
+        self.usd_attr = usd_attr
+        self.usd_api = usd_api
+        self.target = target
+        self.kind = kind
+        self.doc = doc
+
+
+_CAM_EXPOSURE_API = "OmniRtxCameraExposureAPI_1"
+_CAM_AUTO_EXPOSURE_API = "OmniRtxCameraAutoExposureAPI_1"
+_GRADE_API = "OmniRtxPostColorGradingAPI_1"
+_TV_NOISE_API = "OmniRtxPostTvNoiseAPI_1"
+
+
+EFFECTS = {
+    # --- Exposure: the "sudden low light" / "flicker" family. -------------
+    # Auto-exposure must be off for iso/time to hold: with it on, the
+    # histogram drives exposure back to a normal-looking image and the
+    # injected anomaly disappears within a second.
+    "auto_exposure.enabled": Effect(
+        "/rtx/post/histogram/enabled",
+        "omni:rtx:autoExposure:enabled",
+        _CAM_AUTO_EXPOSURE_API,
+        TARGET_CAMERA,
+        KIND_BOOL,
+        "Auto-exposure. Turn OFF before forcing iso/time.",
+    ),
+    "exposure.iso": Effect(
+        "/rtx/post/tonemap/filmIso",
+        "exposure:iso",
+        _CAM_EXPOSURE_API,
+        TARGET_CAMERA,
+        KIND_FLOAT,
+        "Sensor speed. 100 = nominal; lower darkens the image.",
+    ),
+    "exposure.time": Effect(
+        "/rtx/post/tonemap/exposureTime",
+        "exposure:time",
+        _CAM_EXPOSURE_API,
+        TARGET_CAMERA,
+        KIND_FLOAT,
+        "Shutter time in seconds. PER-CAMERA ONLY: the USD attribute works, but "
+        "the carb key is inert in a running sim -- the render loop rewrites "
+        "/rtx/post/tonemap/exposureTime every frame (it mirrors cameraShutter, "
+        "the same quantity as 1/s), so a global write never reaches the "
+        "tonemapper. Measured: setting it globally left RTSP brightness flat, "
+        "while the same value on the camera prim halved it. For a global "
+        "brightness flicker animate exposure.iso instead.",
+    ),
+    "exposure.f_stop": Effect(
+        "/rtx/post/tonemap/fNumber",
+        "exposure:fStop",
+        _CAM_EXPOSURE_API,
+        TARGET_CAMERA,
+        KIND_FLOAT,
+        "Aperture. Larger numbers darken the image.",
+    ),
+    # --- Color grading: the "hue shift" / white-balance-drift family. -----
+    "grade.enabled": Effect(
+        "/rtx/post/colorgrad/enabled",
+        "omni:rtx:post:grade:enabled",
+        _GRADE_API,
+        TARGET_RENDER_PRODUCT,
+        KIND_BOOL,
+    ),
+    "grade.gain": Effect(
+        "/rtx/post/colorgrad/gain",
+        "omni:rtx:post:grade:gain",
+        _GRADE_API,
+        TARGET_RENDER_PRODUCT,
+        KIND_COLOR3,
+        "Per-channel multiplier. [1.03, 1.0, 0.97] reads as a warm cast.",
+    ),
+    "grade.gamma": Effect(
+        "/rtx/post/colorgrad/gamma",
+        "omni:rtx:post:grade:gamma",
+        _GRADE_API,
+        TARGET_RENDER_PRODUCT,
+        KIND_COLOR3,
+    ),
+    "grade.contrast": Effect(
+        "/rtx/post/colorgrad/contrast",
+        "omni:rtx:post:grade:contrast",
+        _GRADE_API,
+        TARGET_RENDER_PRODUCT,
+        KIND_COLOR3,
+    ),
+    # --- TV noise: grain, scanlines, vignetting, analog artifacts. --------
+    # One RTX compute pass; the toggles below become a shader bitmask, so
+    # `tv_noise.enabled` gates all of them.
+    "tv_noise.enabled": Effect(
+        "/rtx/post/tvNoise/enabled",
+        "omni:rtx:post:tvNoise:enabled",
+        _TV_NOISE_API,
+        TARGET_RENDER_PRODUCT,
+        KIND_BOOL,
+        "Master gate for the whole TV-noise pass.",
+    ),
+    "tv_noise.film_grain.enabled": Effect(
+        "/rtx/post/tvNoise/enableFilmGrain",
+        "omni:rtx:post:tvNoise:filmGrain:enabled",
+        _TV_NOISE_API,
+        TARGET_RENDER_PRODUCT,
+        KIND_BOOL,
+        "Defaults ON once the pass is enabled, unlike the other toggles.",
+    ),
+    "tv_noise.film_grain.amount": Effect(
+        "/rtx/post/tvNoise/grainAmount",
+        "omni:rtx:post:tvNoise:filmGrain:amount",
+        _TV_NOISE_API,
+        TARGET_RENDER_PRODUCT,
+        KIND_FLOAT,
+        "0.0-0.2 (default 0.05).",
+    ),
+    "tv_noise.film_grain.size": Effect(
+        "/rtx/post/tvNoise/grainSize",
+        "omni:rtx:post:tvNoise:filmGrain:size",
+        _TV_NOISE_API,
+        TARGET_RENDER_PRODUCT,
+        KIND_FLOAT,
+        "Inverse grain size, 1.5-2.5 (default 1.6).",
+    ),
+    "tv_noise.color_amount": Effect(
+        "/rtx/post/tvNoise/colorAmount",
+        "omni:rtx:post:tvNoise:colorAmount",
+        _TV_NOISE_API,
+        TARGET_RENDER_PRODUCT,
+        KIND_FLOAT,
+        "Chroma variation per grain, 0.0-1.0 (default 0.6).",
+    ),
+    "tv_noise.lum_amount": Effect(
+        "/rtx/post/tvNoise/lumAmount",
+        "omni:rtx:post:tvNoise:lumAmount",
+        _TV_NOISE_API,
+        TARGET_RENDER_PRODUCT,
+        KIND_FLOAT,
+        "Luminance variation per grain, 0.0-1.0 (default 1.0).",
+    ),
+    "tv_noise.scanlines.enabled": Effect(
+        "/rtx/post/tvNoise/enableScanlines",
+        "omni:rtx:post:tvNoise:scanlines:enabled",
+        _TV_NOISE_API,
+        TARGET_RENDER_PRODUCT,
+        KIND_BOOL,
+    ),
+    "tv_noise.scanlines.spread": Effect(
+        "/rtx/post/tvNoise/scanlineSpread",
+        "omni:rtx:post:tvNoise:scanlines:spread",
+        _TV_NOISE_API,
+        TARGET_RENDER_PRODUCT,
+        KIND_FLOAT,
+        "Scanline FREQUENCY, not amplitude: the shader does "
+        "col *= 0.75 + (sin(uv.y * spread * height) + 1) * 0.25, so the swing is "
+        "always +/-25% and only the band spacing changes. 1.0 on a 540-line image "
+        "is ~86 bands (6 px apart). Public range 0.0-2.0, default 1.0.",
+    ),
+    "tv_noise.vignetting.enabled": Effect(
+        "/rtx/post/tvNoise/enableVignetting",
+        "omni:rtx:post:tvNoise:vignetting:enabled",
+        _TV_NOISE_API,
+        TARGET_RENDER_PRODUCT,
+        KIND_BOOL,
+        "Darkened border. The closest thing here to a soft lens blockage.",
+    ),
+    # The vignette is NOT normalised, which makes `size` easy to misread: the
+    # shader computes vig = uv(1-uv).x * uv(1-uv).y * (size + 14), then raises it
+    # to `strength` and MULTIPLIES the colour by it. At the image centre the uv
+    # term is 0.0625, so the centre gain is 0.0625 * (size + 14) — the shipped
+    # default of 107 multiplies the centre by ~7.6 and blows it to white. Use
+    # size 2.0 (0.0625 * 16 = 1.0) to leave the centre alone and let `strength`
+    # set how hard the edges fall off.
+    "tv_noise.vignetting.size": Effect(
+        "/rtx/post/tvNoise/vignettingSize",
+        "omni:rtx:post:tvNoise:vignetting:size",
+        _TV_NOISE_API,
+        TARGET_RENDER_PRODUCT,
+        KIND_FLOAT,
+        "Centre gain is 0.0625 * (size + 14); 2.0 keeps the centre at 1.0. "
+        "Public range 0.0-255, default 107 (which overexposes the centre).",
+    ),
+    "tv_noise.vignetting.strength": Effect(
+        "/rtx/post/tvNoise/vignettingStrength",
+        "omni:rtx:post:tvNoise:vignetting:strength",
+        _TV_NOISE_API,
+        TARGET_RENDER_PRODUCT,
+        KIND_FLOAT,
+        "Falloff exponent, applied as pow(vig, strength). Higher = darker edges. "
+        "Public range 0.0-2.0, default 0.7.",
+    ),
+    "tv_noise.vignetting.flickering.enabled": Effect(
+        "/rtx/post/tvNoise/enableVignettingFlickering",
+        "omni:rtx:post:tvNoise:vignetting:flickering:enabled",
+        _TV_NOISE_API,
+        TARGET_RENDER_PRODUCT,
+        KIND_BOOL,
+    ),
+    "tv_noise.wave_distortion.enabled": Effect(
+        "/rtx/post/tvNoise/enableWaveDistortion",
+        "omni:rtx:post:tvNoise:waveDistortion:enabled",
+        _TV_NOISE_API,
+        TARGET_RENDER_PRODUCT,
+        KIND_BOOL,
+    ),
+    "tv_noise.vertical_lines.enabled": Effect(
+        "/rtx/post/tvNoise/enableVerticalLines",
+        "omni:rtx:post:tvNoise:verticalLines:enabled",
+        _TV_NOISE_API,
+        TARGET_RENDER_PRODUCT,
+        KIND_BOOL,
+    ),
+    "tv_noise.random_splotches.enabled": Effect(
+        "/rtx/post/tvNoise/enableRandomSplotches",
+        "omni:rtx:post:tvNoise:randomSplotches:enabled",
+        _TV_NOISE_API,
+        TARGET_RENDER_PRODUCT,
+        KIND_BOOL,
+    ),
+    "tv_noise.ghost_flickering.enabled": Effect(
+        "/rtx/post/tvNoise/enableGhostFlickering",
+        "omni:rtx:post:tvNoise:ghostFlickering:enabled",
+        _TV_NOISE_API,
+        TARGET_RENDER_PRODUCT,
+        KIND_BOOL,
+    ),
+    "tv_noise.scroll_bug.enabled": Effect(
+        "/rtx/post/tvNoise/enableScrollBug",
+        "omni:rtx:post:tvNoise:scrollBug:enabled",
+        _TV_NOISE_API,
+        TARGET_RENDER_PRODUCT,
+        KIND_BOOL,
+    ),
+    # Replaces elapsed render time with a fixed seed, so two runs of the same
+    # scenario produce byte-identical noise. Required for the SRR regression
+    # harness, where a diffing run cannot tolerate per-frame randomness.
+    "tv_noise.fixed_time.seed": Effect(
+        "/rtx/post/tvNoise/fixedTimeSeed",
+        "omni:rtx:post:tvNoise:fixedTime:seed",
+        _TV_NOISE_API,
+        TARGET_RENDER_PRODUCT,
+        KIND_BOOL,
+        "Deterministic noise: freeze the time input.",
+    ),
+    "tv_noise.fixed_time.seed_count": Effect(
+        "/rtx/post/tvNoise/fixedTimeSeedCount",
+        "omni:rtx:post:tvNoise:fixedTime:seedCount",
+        _TV_NOISE_API,
+        TARGET_RENDER_PRODUCT,
+        KIND_FLOAT,
+        "The frozen time value used when fixed_time.seed is true.",
+    ),
+}
+
+# Only float effects can be driven by the per-frame animator.
+ANIMATABLE = tuple(key for key, eff in EFFECTS.items() if eff.kind == KIND_FLOAT)

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/set_preset.sh
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/set_preset.sh
@@ -18,18 +18,36 @@ if [[ ! -f "$CONFIG" ]]; then
 fi
 
 # Preset names are the keys indented exactly two spaces under `presets:`.
+#
+# A preset this misses is a preset the operator cannot select, so the match is
+# deliberately loose: names may be quoted (`"off":`, which the config tells you
+# to write for YAML's boolean words) or hyphenated, and the value may be inline
+# (`baseline: {}`) rather than a nested block. A comment at column 0 does NOT
+# end the block — only a real top-level key does.
 list_presets() {
     awk '
         /^presets:/ { inside = 1; next }
-        /^[^[:space:]]/ { inside = 0 }
-        inside && /^  [A-Za-z_][A-Za-z0-9_]*:[[:space:]]*$/ {
-            sub(/:[[:space:]]*$/, "", $1); print $1
+        /^[^[:space:]#]/ { inside = 0 }
+        inside && /^  ["'"'"']?[A-Za-z_][A-Za-z0-9_.-]*["'"'"']?:/ {
+            line = $0
+            sub(/^  ["'"'"']?/, "", line)
+            sub(/["'"'"']?:.*$/, "", line)
+            print line
         }
     ' "$CONFIG"
 }
 
+# Quotes are stripped so the value compares equal to the name the caller passed.
 active_preset() {
-    awk '/^active:/ { print $2; exit }' "$CONFIG"
+    awk '
+        /^active[[:space:]]*:/ {
+            sub(/^active[[:space:]]*:[[:space:]]*/, "")
+            sub(/[[:space:]]*(#.*)?$/, "")
+            gsub(/^["'"'"']|["'"'"']$/, "")
+            print
+            exit
+        }
+    ' "$CONFIG"
 }
 
 PRESETS="$(list_presets)"
@@ -50,7 +68,10 @@ fi
 
 TMP="$(mktemp "$(dirname "$CONFIG")/.postprocessing.yaml.XXXXXX")"
 trap 'rm -f "$TMP"' EXIT
-sed "s|^active:.*|active: $PRESET|" "$CONFIG" >"$TMP"
+# Tolerates `active : baseline` (valid YAML), which an anchored `^active:.*`
+# silently left alone. Always quoted, because an unquoted `active: off` parses
+# as the boolean False and the runner then rejects the whole file.
+sed "s|^active[[:space:]]*:.*|active: \"$PRESET\"|" "$CONFIG" >"$TMP"
 # mktemp creates the file 0600; without this the config would land unreadable
 # to the container user and show up in git as a mode change.
 chmod --reference="$CONFIG" "$TMP"
@@ -58,5 +79,14 @@ chmod --reference="$CONFIG" "$TMP"
 # inode is both safe and atomic — the runner never reads a half-written config.
 mv "$TMP" "$CONFIG"
 trap - EXIT
+
+# Read the result back rather than trust the substitution: `mv` succeeds just as
+# happily when the sed matched nothing, and a script that reports a switch it
+# did not make is worse than one that fails.
+GOT="$(active_preset)"
+if [[ "$GOT" != "$PRESET" ]]; then
+    echo "ERROR: failed to set active preset in $CONFIG (still '$GOT')" >&2
+    exit 3
+fi
 
 echo "Active preset: $PRESET"

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/set_preset.sh
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/set_preset.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Switch the live RTX post-processing preset while run_actor_sdg.py is running.
+#
+# The runner polls postprocessing.yaml, so rewriting `active:` is enough — the
+# next rendered frames carry the new look. Writes through a temp file in the
+# same directory so the runner never reads a half-written config.
+#
+#   ./set_preset.sh                 # list presets and show the active one
+#   ./set_preset.sh tv_noise        # switch
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG="${POSTPROCESSING_CONFIG:-$SCRIPT_DIR/../../configs/postprocessing.yaml}"
+
+if [[ ! -f "$CONFIG" ]]; then
+    echo "ERROR: config not found: $CONFIG" >&2
+    exit 1
+fi
+
+# Preset names are the keys indented exactly two spaces under `presets:`.
+list_presets() {
+    awk '
+        /^presets:/ { inside = 1; next }
+        /^[^[:space:]]/ { inside = 0 }
+        inside && /^  [A-Za-z_][A-Za-z0-9_]*:[[:space:]]*$/ {
+            sub(/:[[:space:]]*$/, "", $1); print $1
+        }
+    ' "$CONFIG"
+}
+
+active_preset() {
+    awk '/^active:/ { print $2; exit }' "$CONFIG"
+}
+
+PRESETS="$(list_presets)"
+PRESET="${1:-}"
+
+if [[ -z "$PRESET" ]]; then
+    echo "Active preset: $(active_preset)"
+    echo "Available:"
+    sed 's/^/  /' <<<"$PRESETS"
+    exit 0
+fi
+
+if ! grep -qxF "$PRESET" <<<"$PRESETS"; then
+    echo "ERROR: unknown preset '$PRESET'" >&2
+    echo "Available: $(tr '\n' ' ' <<<"$PRESETS")" >&2
+    exit 2
+fi
+
+TMP="$(mktemp "$(dirname "$CONFIG")/.postprocessing.yaml.XXXXXX")"
+trap 'rm -f "$TMP"' EXIT
+sed "s|^active:.*|active: $PRESET|" "$CONFIG" >"$TMP"
+# mktemp creates the file 0600; without this the config would land unreadable
+# to the container user and show up in git as a mode change.
+chmod --reference="$CONFIG" "$TMP"
+# The container mounts the whole sil/ directory, not this file, so replacing the
+# inode is both safe and atomic — the runner never reads a half-written config.
+mv "$TMP" "$CONFIG"
+trap - EXIT
+
+echo "Active preset: $PRESET"

--- a/closed-loop-testing/isaac-sim/sil/scripts/run_actor_sdg.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/run_actor_sdg.py
@@ -756,18 +756,17 @@ def _validate_postprocessing_preset(preset, config_path):
 
     "Wrong" is not only a mistyped name. `version: 2`, a setting key that does
     not exist, a string where a float belongs, an `animation` block missing
-    `frequency_hz`, a `per_camera` entry that also carries a top-level
-    `cameras:` — every one of those names a preset that IS in the file and
+    `frequency_hz` — every one of those names a preset that IS in the file and
     still produces a clean run. So this runs the controller's own
     `_select_preset` and `_validate_preset`, which is why those two are kept
     free of carb and pxr imports: they are the contract, and a second
     reimplementation here would drift from it.
 
-    What it still cannot check is camera resolution: `cameras:`/`per_camera:`
-    entries are matched against cameras.yaml and then against the prims on the
-    stage, and neither exists before Kit boots. An unknown camera name is
-    caught by the controller at apply time, where it is rejected without
-    disturbing the running preset.
+    What it still cannot check is camera resolution: `cameras:` entries are
+    matched against cameras.yaml and then against the prims on the stage, and
+    neither exists before Kit boots. An unknown camera name is caught by the
+    controller at apply time, where it is rejected without disturbing the
+    running preset.
     """
     if not preset.strip():
         # `--postprocessing-preset "$PRESET"` with PRESET unset. Not "no pin":

--- a/closed-loop-testing/isaac-sim/sil/scripts/run_actor_sdg.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/run_actor_sdg.py
@@ -60,6 +60,8 @@ class ActorSDGRunner:
         enable_forklift=True,
         enable_clock=True,
         enable_srr_gt=False,
+        postprocessing_config_path=None,
+        enable_postprocessing=True,
         vst_register_warmup_sec=1.0,
         vst_register_timeout_sec=1200.0,
     ):
@@ -111,6 +113,16 @@ class ActorSDGRunner:
         # SRR regression-harness ground-truth /gt/*/tf publisher (opt-in via
         # --srr-gt; default OFF). See action_graphs/srr_ground_truth.py.
         self.enable_srr_gt = enable_srr_gt
+
+        # In-scenario sensor-anomaly injection (low light, colour cast, flicker,
+        # sensor grain). Not an OmniGraph: RTX consumes post-processing itself,
+        # so a preset lands on the next rendered frame in the viewport, the SDG
+        # RGB output and the RTSP streams alike. Driven by configs/
+        # postprocessing.yaml and hot-reloaded from the run loop.
+        # See sil/scripts/postprocessing/README.md.
+        self.postprocessing_config_path = postprocessing_config_path
+        self.enable_postprocessing = enable_postprocessing
+        self._postprocessing = None
 
         self.output_path = None
         # NOTE(IRA 6.0): camera_placements_json, _setup_sim_sub, _setup_sim_succeed removed —
@@ -208,6 +220,24 @@ class ActorSDGRunner:
             if self.enable_srr_gt:
                 from action_graphs import build_srr_gt_graph
                 build_srr_gt_graph()
+            #   6. postprocessing applies the active RTX preset and then polls
+            #      its config, so an operator can inject or lift a sensor
+            #      anomaly mid-run. Runs after the RTSP graph so a per-camera
+            #      preset can bind to the render products that graph declares.
+            #      A bad preset must not take the SIL loop down with it, so
+            #      failures here are warnings — the run continues undegraded.
+            if self.enable_postprocessing and self.postprocessing_config_path:
+                try:
+                    from postprocessing import PostProcessingController
+
+                    self._postprocessing = PostProcessingController(
+                        self.postprocessing_config_path,
+                        cameras_config_path=self.cameras_config_path,
+                    )
+                    self._postprocessing.start()
+                except Exception as e:
+                    print(f"WARNING: post-processing disabled ({e})")
+                    self._postprocessing = None
 
             # VST Integration: registration is DEFERRED to after Play + render-warm
             # (see the run loop below). Registering here — before the RTSP encoder is
@@ -219,6 +249,7 @@ class ActorSDGRunner:
                 print("Setup complete. Waiting for manual data generation start...")
                 while not self._sim_app.is_exiting():
                     await self._sim_app.app.next_update_async()
+                    self._update_postprocessing()
                 return True
 
             # If auto-start, press Play on the timeline (RTSP + BT start ticking).
@@ -237,6 +268,7 @@ class ActorSDGRunner:
             vst_registered = False
             while not self._sim_app.is_exiting():
                 await self._sim_app.app.next_update_async()
+                self._update_postprocessing()
                 if self.enable_vst and not vst_registered and self._render_is_warm():
                     self._vst_register_cameras()
                     vst_registered = True
@@ -252,6 +284,13 @@ class ActorSDGRunner:
             return False
 
         finally:
+            # Put the renderer back as it was: a preset lives in carb settings
+            # and the session layer, both of which outlive this coroutine when
+            # Kit stays up (UI mode, setup re-entry).
+            if self._postprocessing is not None:
+                self._postprocessing.close()
+                self._postprocessing = None
+
             # VST Integration: Cleanup cameras on exit (fallback for UI / abnormal exit)
             if self.enable_vst and self._vst_manager:
                 try:
@@ -261,6 +300,21 @@ class ActorSDGRunner:
                         self._vst_cleanup_cameras()
                 except Exception as e:
                     print(f"WARNING: Finally VST cleanup failed: {e}")
+
+    def _update_postprocessing(self):
+        """Re-read the preset config when due and advance any animated effect.
+
+        Runs once per rendered frame, so an exception here would otherwise spam
+        the log at render rate; the first failure retires the controller and the
+        run continues without post-processing.
+        """
+        if self._postprocessing is None:
+            return
+        try:
+            self._postprocessing.update()
+        except Exception as e:
+            print(f"WARNING: post-processing update failed, disabling: {e}")
+            self._postprocessing = None
 
     def _extract_output_path(self, config):
         """Extract IRABasicWriter output_dir from typed RootConfig, tolerant of missing keys.
@@ -592,6 +646,9 @@ Examples:
 
   # With VST integration:
   ./python.sh run_actor_sdg.py -c config.yaml --start --enable-vst --cameras-config cameras.yaml
+
+  # Inject a sensor anomaly while the run is live (no restart):
+  ./scripts/postprocessing/set_preset.sh tv_noise
         """,
     )
     parser.add_argument("-c", "--config_file", required=True, help="Path to IRA config file (yaml)")
@@ -643,6 +700,13 @@ Examples:
                         default=False,
                         help="Build the SRR ground-truth /gt/*/tf publisher graph "
                              "(default OFF; SRR regression harness only)")
+    parser.add_argument("--postprocessing-config",
+                        help="Path to postprocessing.yaml (RTX sensor-anomaly presets). "
+                             "Defaults to configs/postprocessing.yaml when present")
+    parser.add_argument("--no-postprocessing", dest="enable_postprocessing",
+                        action="store_false", default=True,
+                        help="Skip the RTX post-processing controller (no anomaly injection, "
+                             "no config polling)")
 
     args, _ = parser.parse_known_args()
     return args
@@ -668,6 +732,13 @@ def main():
     # we still surface a clear error if the user passes a path that doesn't exist.
     if args.sensor_placement_file and not os.path.isfile(args.sensor_placement_file):
         print(f"ERROR: Sensor placement file not found: {args.sensor_placement_file}", file=sys.stderr)
+        sys.exit(1)
+
+    # Checked before SimulationApp boots: an explicitly requested preset file
+    # that does not exist is an operator error worth failing on, and failing here
+    # avoids tearing down a started Kit app.
+    if args.postprocessing_config and not os.path.isfile(args.postprocessing_config):
+        print(f"ERROR: Post-processing config not found: {args.postprocessing_config}", file=sys.stderr)
         sys.exit(1)
 
     # Resolve cameras config path
@@ -766,6 +837,20 @@ def main():
         if os.path.isfile(default_robots_yaml):
             robots_config_path = default_robots_yaml
 
+    # Resolve the post-processing preset config, same defaulting as above.
+    # Existence of an explicitly passed path was checked before Kit booted; a
+    # missing default simply leaves anomaly injection off.
+    postprocessing_config_path = None
+    if args.enable_postprocessing:
+        if args.postprocessing_config:
+            postprocessing_config_path = os.path.abspath(args.postprocessing_config)
+        else:
+            default_pp_yaml = os.path.abspath(
+                os.path.join(os.path.dirname(__file__), "..", "configs", "postprocessing.yaml")
+            )
+            if os.path.isfile(default_pp_yaml):
+                postprocessing_config_path = default_pp_yaml
+
     # Create and run SDG
     sdg = ActorSDGRunner(
         sim_app=sim_app,
@@ -785,6 +870,8 @@ def main():
         enable_forklift=args.enable_forklift,
         enable_clock=args.enable_clock,
         enable_srr_gt=args.enable_srr_gt,
+        postprocessing_config_path=postprocessing_config_path,
+        enable_postprocessing=args.enable_postprocessing,
         vst_register_warmup_sec=args.vst_register_warmup_sec,
         vst_register_timeout_sec=args.vst_register_timeout_sec,
     )

--- a/closed-loop-testing/isaac-sim/sil/scripts/run_actor_sdg.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/run_actor_sdg.py
@@ -747,12 +747,27 @@ Examples:
 def _validate_postprocessing_preset(preset, config_path):
     """Fail the run on a --postprocessing-preset the config cannot honour.
 
-    The controller rejects an unknown name too, but only as a WARNING from its
+    The controller rejects a bad preset too, but only as a WARNING from its
     poll loop: the run then streams, finishes and exits 0 with perfectly clean
-    images. A campaign that pinned an anomaly preset and mistyped the name would
+    images. A campaign that pinned an anomaly preset and got it wrong would
     score the clean run as if the fault had been injected, with nothing in the
     report saying otherwise. Refusing to boot is the only outcome an automated
     campaign can notice.
+
+    "Wrong" is not only a mistyped name. `version: 2`, a setting key that does
+    not exist, a string where a float belongs, an `animation` block missing
+    `frequency_hz`, a `per_camera` entry that also carries a top-level
+    `cameras:` — every one of those names a preset that IS in the file and
+    still produces a clean run. So this runs the controller's own
+    `_select_preset` and `_validate_preset`, which is why those two are kept
+    free of carb and pxr imports: they are the contract, and a second
+    reimplementation here would drift from it.
+
+    What it still cannot check is camera resolution: `cameras:`/`per_camera:`
+    entries are matched against cameras.yaml and then against the prims on the
+    stage, and neither exists before Kit boots. An unknown camera name is
+    caught by the controller at apply time, where it is rejected without
+    disturbing the running preset.
     """
     if not preset.strip():
         # `--postprocessing-preset "$PRESET"` with PRESET unset. Not "no pin":
@@ -768,30 +783,30 @@ def _validate_postprocessing_preset(preset, config_path):
               "config found", file=sys.stderr)
         return
 
-    try:
-        import yaml
-    except ImportError:
-        # Every other check in main() is stdlib-only, so this is the one that
-        # could depend on Kit having booted. Degrade to the controller's own
-        # (mid-run, non-fatal) rejection rather than tracebacking on a name that
-        # is probably fine.
-        print(f"WARNING: cannot validate --postprocessing-preset {preset!r} before boot "
-              "(PyYAML unavailable); an unknown name will be reported by the controller "
-              "instead", file=sys.stderr)
-        return
+    # Both imports are deliberately unguarded. PyYAML is present in the Isaac
+    # image before Kit boots (the SIL launcher and set_preset.sh both use it),
+    # and `postprocessing` sits next to this file, so neither can fail on a
+    # working install. The `except ImportError` that used to wrap the yaml
+    # import degraded this check to a WARNING — turning the hard, campaign-
+    # visible failure the function exists to produce back into exactly the soft
+    # one it exists to replace, and doing so silently.
+    import yaml
+
+    from postprocessing.controller import _select_preset, _validate_preset
 
     try:
         with open(config_path) as stream:
             config = yaml.safe_load(stream) or {}
-        presets = config.get("presets")
     except Exception as exc:
         print(f"ERROR: Cannot read post-processing config {config_path}: {exc}", file=sys.stderr)
         sys.exit(1)
 
-    if not isinstance(presets, dict) or preset not in presets:
-        known = ", ".join(sorted(presets)) if isinstance(presets, dict) else "none"
-        print(f"ERROR: Unknown post-processing preset {preset!r} in {config_path} "
-              f"(available: {known})", file=sys.stderr)
+    try:
+        name, selected = _select_preset(config, preset)
+        _validate_preset(name, selected)
+    except Exception as exc:
+        print(f"ERROR: --postprocessing-preset {preset!r} cannot be honoured by "
+              f"{config_path}: {exc}", file=sys.stderr)
         sys.exit(1)
 
 

--- a/closed-loop-testing/isaac-sim/sil/scripts/run_actor_sdg.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/run_actor_sdg.py
@@ -237,7 +237,11 @@ class ActorSDGRunner:
                     self._postprocessing.start()
                 except Exception as e:
                     print(f"WARNING: post-processing disabled ({e})")
-                    self._postprocessing = None
+                    # start() can fail with settings already written, and the
+                    # controller holds the only snapshot that undoes them.
+                    # Dropping the handle without closing it would strand the
+                    # renderer degraded for the rest of the process.
+                    self._close_postprocessing()
 
             # VST Integration: registration is DEFERRED to after Play + render-warm
             # (see the run loop below). Registering here — before the RTSP encoder is
@@ -287,9 +291,7 @@ class ActorSDGRunner:
             # Put the renderer back as it was: a preset lives in carb settings
             # and the session layer, both of which outlive this coroutine when
             # Kit stays up (UI mode, setup re-entry).
-            if self._postprocessing is not None:
-                self._postprocessing.close()
-                self._postprocessing = None
+            self._close_postprocessing()
 
             # VST Integration: Cleanup cameras on exit (fallback for UI / abnormal exit)
             if self.enable_vst and self._vst_manager:
@@ -314,6 +316,24 @@ class ActorSDGRunner:
             self._postprocessing.update()
         except Exception as e:
             print(f"WARNING: post-processing update failed, disabling: {e}")
+            # Retiring the controller means restoring the renderer first: the
+            # settings and session-layer edits an update had already made
+            # outlive the handle, and the handle is what knows how to undo them.
+            self._close_postprocessing()
+
+    def _close_postprocessing(self):
+        """Restore the renderer and drop the controller. Never raises.
+
+        The shutdown path runs it from `finally`, where an escaping exception
+        would skip the VST cleanup that follows.
+        """
+        if self._postprocessing is None:
+            return
+        try:
+            self._postprocessing.close()
+        except Exception as e:
+            print(f"WARNING: post-processing cleanup failed: {e}")
+        finally:
             self._postprocessing = None
 
     def _extract_output_path(self, config):

--- a/closed-loop-testing/isaac-sim/sil/scripts/run_actor_sdg.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/run_actor_sdg.py
@@ -62,6 +62,7 @@ class ActorSDGRunner:
         enable_srr_gt=False,
         postprocessing_config_path=None,
         enable_postprocessing=True,
+        postprocessing_preset=None,
         vst_register_warmup_sec=1.0,
         vst_register_timeout_sec=1200.0,
     ):
@@ -122,6 +123,11 @@ class ActorSDGRunner:
         # See sil/scripts/postprocessing/README.md.
         self.postprocessing_config_path = postprocessing_config_path
         self.enable_postprocessing = enable_postprocessing
+        # Pins the preset regardless of what `active:` currently says. The
+        # config file is git-tracked but set_preset.sh rewrites it live, so an
+        # unpinned run inherits whatever anomaly the previous operator left
+        # behind — reproduced on two machines. Campaign launchers pass this.
+        self.postprocessing_preset = postprocessing_preset
         self._postprocessing = None
 
         self.output_path = None
@@ -233,6 +239,7 @@ class ActorSDGRunner:
                     self._postprocessing = PostProcessingController(
                         self.postprocessing_config_path,
                         cameras_config_path=self.cameras_config_path,
+                        preset_override=self.postprocessing_preset,
                     )
                     self._postprocessing.start()
                 except Exception as e:
@@ -723,6 +730,11 @@ Examples:
     parser.add_argument("--postprocessing-config",
                         help="Path to postprocessing.yaml (RTX sensor-anomaly presets). "
                              "Defaults to configs/postprocessing.yaml when present")
+    parser.add_argument("--postprocessing-preset",
+                        help="Pin the RTX preset for this run, ignoring `active:` in the config. "
+                             "Campaign launchers should pass 'baseline' so a preset left behind "
+                             "by set_preset.sh cannot degrade the next run. An unknown name is "
+                             "an error, not a fallback")
     parser.add_argument("--no-postprocessing", dest="enable_postprocessing",
                         action="store_false", default=True,
                         help="Skip the RTX post-processing controller (no anomaly injection, "
@@ -730,6 +742,57 @@ Examples:
 
     args, _ = parser.parse_known_args()
     return args
+
+
+def _validate_postprocessing_preset(preset, config_path):
+    """Fail the run on a --postprocessing-preset the config cannot honour.
+
+    The controller rejects an unknown name too, but only as a WARNING from its
+    poll loop: the run then streams, finishes and exits 0 with perfectly clean
+    images. A campaign that pinned an anomaly preset and mistyped the name would
+    score the clean run as if the fault had been injected, with nothing in the
+    report saying otherwise. Refusing to boot is the only outcome an automated
+    campaign can notice.
+    """
+    if not preset.strip():
+        # `--postprocessing-preset "$PRESET"` with PRESET unset. Not "no pin":
+        # falling through to `active:` would hand the run whatever preset
+        # set_preset.sh last committed to the file.
+        print("ERROR: --postprocessing-preset was given an empty value", file=sys.stderr)
+        sys.exit(1)
+
+    if not config_path:
+        # No file to check the name against, and no controller either — say so,
+        # because the pin the operator asked for will not be applied.
+        print(f"WARNING: --postprocessing-preset {preset!r} ignored: no post-processing "
+              "config found", file=sys.stderr)
+        return
+
+    try:
+        import yaml
+    except ImportError:
+        # Every other check in main() is stdlib-only, so this is the one that
+        # could depend on Kit having booted. Degrade to the controller's own
+        # (mid-run, non-fatal) rejection rather than tracebacking on a name that
+        # is probably fine.
+        print(f"WARNING: cannot validate --postprocessing-preset {preset!r} before boot "
+              "(PyYAML unavailable); an unknown name will be reported by the controller "
+              "instead", file=sys.stderr)
+        return
+
+    try:
+        with open(config_path) as stream:
+            config = yaml.safe_load(stream) or {}
+        presets = config.get("presets")
+    except Exception as exc:
+        print(f"ERROR: Cannot read post-processing config {config_path}: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if not isinstance(presets, dict) or preset not in presets:
+        known = ", ".join(sorted(presets)) if isinstance(presets, dict) else "none"
+        print(f"ERROR: Unknown post-processing preset {preset!r} in {config_path} "
+              f"(available: {known})", file=sys.stderr)
+        sys.exit(1)
 
 
 def main():
@@ -760,6 +823,23 @@ def main():
     if args.postprocessing_config and not os.path.isfile(args.postprocessing_config):
         print(f"ERROR: Post-processing config not found: {args.postprocessing_config}", file=sys.stderr)
         sys.exit(1)
+
+    # Resolved here rather than next to the other config paths further down,
+    # because --postprocessing-preset can only be checked against the file that
+    # will actually be loaded, and that check has to happen before Kit boots.
+    postprocessing_config_path = None
+    if args.enable_postprocessing:
+        if args.postprocessing_config:
+            postprocessing_config_path = os.path.abspath(args.postprocessing_config)
+        else:
+            default_pp_yaml = os.path.abspath(
+                os.path.join(os.path.dirname(__file__), "..", "configs", "postprocessing.yaml")
+            )
+            if os.path.isfile(default_pp_yaml):
+                postprocessing_config_path = default_pp_yaml
+
+    if args.enable_postprocessing and args.postprocessing_preset is not None:
+        _validate_postprocessing_preset(args.postprocessing_preset, postprocessing_config_path)
 
     # Resolve cameras config path
     cameras_config_path = None
@@ -857,20 +937,6 @@ def main():
         if os.path.isfile(default_robots_yaml):
             robots_config_path = default_robots_yaml
 
-    # Resolve the post-processing preset config, same defaulting as above.
-    # Existence of an explicitly passed path was checked before Kit booted; a
-    # missing default simply leaves anomaly injection off.
-    postprocessing_config_path = None
-    if args.enable_postprocessing:
-        if args.postprocessing_config:
-            postprocessing_config_path = os.path.abspath(args.postprocessing_config)
-        else:
-            default_pp_yaml = os.path.abspath(
-                os.path.join(os.path.dirname(__file__), "..", "configs", "postprocessing.yaml")
-            )
-            if os.path.isfile(default_pp_yaml):
-                postprocessing_config_path = default_pp_yaml
-
     # Create and run SDG
     sdg = ActorSDGRunner(
         sim_app=sim_app,
@@ -892,6 +958,7 @@ def main():
         enable_srr_gt=args.enable_srr_gt,
         postprocessing_config_path=postprocessing_config_path,
         enable_postprocessing=args.enable_postprocessing,
+        postprocessing_preset=args.postprocessing_preset,
         vst_register_warmup_sec=args.vst_register_warmup_sec,
         vst_register_timeout_sec=args.vst_register_timeout_sec,
     )

--- a/closed-loop-testing/regression-reporter/scripts/run_multi.sh
+++ b/closed-loop-testing/regression-reporter/scripts/run_multi.sh
@@ -229,12 +229,19 @@ phase_start_scene() {
   # builder block (action_graphs/srr_ground_truth.py), AFTER IRA has spawned the
   # SRR char groups + runtime_patches repositioned them, then pump live Fabric
   # transforms. The flag defaults OFF, so a normal Halos run is unaffected.
+  #
+  # --postprocessing-preset pins the RTX look to the undegraded baseline.
+  # postprocessing.yaml is git-tracked but set_preset.sh rewrites it in place,
+  # so without the pin a campaign inherits whatever sensor anomaly the last
+  # interactive session left active, and every scene scores against a degraded
+  # image with nothing in the report saying so.
   docker exec -d isaac-sim bash -c "
     ./python.sh /isaac-sim/sil/scripts/run_actor_sdg.py \
       -c /isaac-sim/sil/configs/default_config_ros.yaml \
       --start --headless --enable-vst \
       --cameras-config /isaac-sim/sil/configs/cameras.yaml \
       --srr-gt \
+      --postprocessing-preset baseline \
       > $log_path 2>&1
   "
 }


### PR DESCRIPTION
The safety monitor needs regression coverage against a degraded camera, and RTX post-processing already provides the mechanism: the renderer consumes it before the encoder, so a preset lands on the viewport, the SDG RGB output and every RTSP stream at once, without a graph rebuild and without data generation having to start. What was missing was a way to drive it from a scenario.

configs/postprocessing.yaml holds the presets and names the active one; run_actor_sdg.py polls it from the run loop, so an operator injects or lifts an anomaly mid-run. Presets use logical keys validated against an allow-list, and a preset may be global (carb settings, "the lights went out") or scoped to `cameras:` (USD attributes on those cameras alone, "camera 2 is dirty"). USD authoring goes to the session layer, so a degraded run never dirties the scene on disk; a rejected edit keeps the last good preset running.

Verified by pulling frames off the RTSP streams while a scenario ran, so the numbers describe what a consumer receives after encode: low_light drops mean brightness 133 -> 36, tv_noise doubles high-frequency energy, vignette_heavy takes the centre/border ratio 0.95 -> 4.2, and one_camera_degraded moves Camera_01 by -74.7 mean while the other two streams stay within scene noise.

Three preset values are the ones measurement corrected. flicker animated exposure.time, which does nothing at global scope because the render loop rewrites /rtx/post/tonemap/exposureTime every frame; it animates ISO instead. Its 6 Hz was above half the achieved frame rate and aliased to 3 Hz, so it is now 2 Hz. vignette_heavy at strength 1.6 was a spotlight rather than a vignette, with the border at 1/17 of the centre, so it is 0.8.