### PR TITLE
fix(sil): close the error paths in the RTX anomaly-injection controller

### DIFF
--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/README.md
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/README.md
@@ -91,7 +91,16 @@ the timeline is playing.
 - **A rejected edit keeps the last good preset.** Hot reload means the config is
   edited while a scenario is mid-flight; a half-saved file must not blank the
   degradation being tested. The bad digest is remembered so the warning prints
-  once instead of at poll rate.
+  once instead of at poll rate. That covers every config error — a parse error,
+  an unknown key, a camera not on the stage — because all of them are caught
+  before anything is written.
+- **A failure *inside* the apply falls back to the baseline instead.** Applying a
+  preset starts by reverting the previous one, so once that has begun the last
+  good preset no longer exists to keep; what is on screen is half of a preset
+  that was just rejected. That case reverts to the pre-controller state, drops
+  the animation and the pending render-product writes, and forgets the last good
+  digest so putting the file back re-applies it rather than reading as
+  "unchanged".
 - **All USD authoring goes to the session layer.** A preset never dirties the
   scene `.usd` on disk and never survives a restart, so a degraded run cannot
   leak into the next one through version control.

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/README.md
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/README.md
@@ -38,7 +38,27 @@ cd closed-loop-testing/isaac-sim/sil/scripts/postprocessing
 ```
 
 Editing `active:` in the YAML by hand does the same thing — the script only
-exists so a campaign runner does not have to do string surgery.
+exists so a campaign runner does not have to do string surgery. Both are inert
+against a run launched with `--postprocessing-preset`: that run pins its preset
+for its whole lifetime and never consults `active:` again.
+
+`postprocessing.yaml` is git-tracked, and `set_preset.sh` rewrites it in place:
+the preset is state that outlives the run that set it. Anything scripted has to
+put it back, or the next run — which nobody thinks of as an anomaly run — starts
+degraded:
+
+```bash
+PP=closed-loop-testing/isaac-sim/sil/scripts/postprocessing/set_preset.sh
+trap '"$PP" baseline' EXIT
+"$PP" low_light
+```
+
+A campaign should not depend on that discipline at all. Pass
+`--postprocessing-preset baseline` to `run_actor_sdg.py` and the run pins its
+own preset, ignoring `active:` entirely — `run_multi.sh` does this. A pinned run
+chooses its anomaly at launch (pass the preset you want instead of `baseline`)
+rather than mid-run; an unknown name is rejected before Kit boots, not silently
+ignored — a mistyped anomaly would otherwise score a clean run as a fault run.
 
 Turn the whole thing off with `--no-postprocessing`, or point it at a different
 preset file with `--postprocessing-config`.

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/controller.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/controller.py
@@ -155,29 +155,70 @@ class PostProcessingController:
         if digest in (self._digest, self._rejected_digest):
             return
 
+        # Set immediately BEFORE the call, not inside it: _apply() starts by
+        # reverting, so a raise anywhere in it means the renderer is already
+        # dirty. Everything above it is pure config work that touches nothing.
+        entered_apply = False
         try:
             import yaml
 
             config = yaml.safe_load(raw) or {}
             name, preset = _select_preset(config)
             _validate_preset(name, preset)
-            # Resolved here, before anything is reverted: a bad camera name has
-            # to be rejected like any other config error, leaving the preset
-            # that is currently degrading the scene untouched.
+            # Resolved before anything is reverted: a bad camera name has to be
+            # rejected like any other config error, leaving the preset that is
+            # currently degrading the scene untouched.
             camera_prim_paths = self._resolve_scope(preset)
+            # Inside the try as well, because the apply layer raises too (a
+            # KIND_COLOR3 value carb refuses, a closed stage, a USD authoring
+            # error).
+            entered_apply = True
+            self._apply(name, preset, camera_prim_paths)
         except Exception as exc:
             # Remember the bad digest so a broken edit is reported once instead
-            # of every poll, and keep serving the last good preset.
+            # of every poll — which also keeps a failing apply from retrying at
+            # render rate.
             self._rejected_digest = digest
+
+            if not entered_apply:
+                # Config error: nothing was touched, so the anomaly under test
+                # keeps running. _digest still describes what is live, which is
+                # what makes restoring the file early-return correctly.
+                _say(f"WARNING: rejected {self.config_path}: {exc}; active preset is {self._active_name!r}")
+                return
+
+            # A failure part-way through _apply cannot leave the last good preset
+            # standing, because applying starts by reverting: what is on screen is
+            # half of a preset that was just rejected, a look nothing in the file
+            # describes. Go back to the baseline instead. This also drops the
+            # _pending_rp_settings the failed apply queued, which would otherwise
+            # be authored onto the render products on the first tick after Play —
+            # silently installing the very preset rejected here.
+            try:
+                self._revert()
+            except Exception as revert_exc:
+                _say(f"WARNING: could not fully restore renderer state: {revert_exc}")
+            # The rejected preset's animation would keep driving a value every
+            # frame, and a stale name would make active_preset lie about it.
+            self._animation = None
+            self._active_name = None
+            # Forget the last good digest too. The usual recovery is to put the
+            # file back the way it was, and that content still matches _digest —
+            # it would early-return as "unchanged" and strand the scene on the
+            # baseline for the rest of the run. _rejected_digest still absorbs
+            # every re-read of the broken file, so this cannot become a retry
+            # storm.
+            self._digest = None
             _say(
                 f"WARNING: rejected {self.config_path}: {exc}; "
-                f"keeping preset {self._active_name!r}"
+                "reverted the renderer to its pre-preset state"
             )
             return
 
+        # Committed only once the preset is actually live, so a rejected edit
+        # cannot make the controller believe it applied something it did not.
         self._digest = digest
         self._rejected_digest = None
-        self._apply(name, preset, camera_prim_paths)
 
     # -- apply / revert ----------------------------------------------------
 

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/controller.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/controller.py
@@ -207,20 +207,25 @@ class PostProcessingController:
         _say(f"Applied preset {name!r} ({detail})")
 
     def _revert(self):
-        for path, value in self._carb_snapshot.items():
-            if value is _MISSING:
-                destroy = getattr(self._settings, "destroy_item", None)
-                if destroy is not None:
-                    destroy(path)
-            else:
-                self._settings.set(path, value)
+        # Two phases, and the USD one must not be hostage to the carb one: a
+        # single failing settings path would otherwise leave the previous
+        # preset's per-camera attributes authored on the stage, which both
+        # close() and the _apply() preset switch promise to clear.
+        try:
+            for path, value in self._carb_snapshot.items():
+                if value is _MISSING:
+                    destroy = getattr(self._settings, "destroy_item", None)
+                    if destroy is not None:
+                        destroy(path)
+                else:
+                    self._settings.set(path, value)
+        finally:
+            if self._authored_attrs or self._authored_apis:
+                self._clear_authored_usd()
 
-        if self._authored_attrs or self._authored_apis:
-            self._clear_authored_usd()
-
-        self._pending_rp_settings = []
-        self._pending_warned = False
-        self._camera_prim_paths = []
+            self._pending_rp_settings = []
+            self._pending_warned = False
+            self._camera_prim_paths = []
 
     def _snapshot_carb(self):
         for key, effect in EFFECTS.items():

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/controller.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/controller.py
@@ -268,12 +268,21 @@ class PostProcessingController:
                 else:
                     self._settings.set(path, value)
         finally:
-            if self._authored_attrs or self._authored_apis:
-                self._clear_authored_usd()
-
-            self._pending_rp_settings = []
-            self._pending_warned = False
-            self._camera_prim_paths = []
+            # Three phases, not two, and for the same reason: the state resets
+            # below must not be hostage to the USD cleanup either. A raise from
+            # _clear_authored_usd() used to skip them, leaving the reverted
+            # preset's DEFERRED render-product writes queued -- and update()
+            # authors those onto the render products on the first tick after
+            # Play, installing a preset that active_preset reports as gone. The
+            # raise still propagates once the resets have run, so close() and
+            # _reload_if_changed() still log the cleanup failure.
+            try:
+                if self._authored_attrs or self._authored_apis:
+                    self._clear_authored_usd()
+            finally:
+                self._pending_rp_settings = []
+                self._pending_warned = False
+                self._camera_prim_paths = []
 
     def _snapshot_carb(self):
         for key, effect in EFFECTS.items():

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/controller.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/controller.py
@@ -413,14 +413,19 @@ class PostProcessingController:
                 self._authored_apis.append((prim_path, effect.usd_api))
 
             attr = prim.CreateAttribute(effect.usd_attr, _sdf_type(Sdf, effect.kind))
-            attr.Set(_usd_value(effect.kind, value))
 
-        # An animated per-camera preset re-authors the same attribute on every
-        # frame, so this has to record it once rather than append 60 times a
-        # second for as long as the scenario runs.
-        entry = (prim_path, effect.usd_attr)
-        if entry not in self._authored_attrs:
-            self._authored_attrs.append(entry)
+            # Record before writing, not after. CreateAttribute is what puts the
+            # attribute on the prim, so a Set() that raises would otherwise leave
+            # it on the stage and out of the ledger -- surviving every _revert()
+            # and close() for the rest of the process, while active_preset
+            # reports None. An animated preset re-authors the same attribute
+            # every frame, so record it once rather than append 60 times a
+            # second for as long as the scenario runs.
+            entry = (prim_path, effect.usd_attr)
+            if entry not in self._authored_attrs:
+                self._authored_attrs.append(entry)
+
+            attr.Set(_usd_value(effect.kind, value))
 
     def _clear_authored_usd(self):
         """Remove every attribute and API schema this controller authored.

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/controller.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/controller.py
@@ -78,12 +78,19 @@ class PostProcessingController:
         config_path=DEFAULT_CONFIG,
         *,
         cameras_config_path=None,
+        preset_override=None,
         poll_interval_sec=0.5,
         settings=None,
         clock=None,
     ):
         self.config_path = os.path.abspath(config_path)
         self.cameras_config_path = cameras_config_path
+        # Pins the preset for the whole run, ignoring `active:` in the file.
+        # postprocessing.yaml is git-tracked but set_preset.sh rewrites it in
+        # place, so without a pin the last anomaly an operator injected is what
+        # the NEXT run starts in. Polling stays on: an unrelated edit to the
+        # file still re-applies this preset, which is a no-op look-wise.
+        self.preset_override = preset_override
         # Sub-100ms polling would stat the file several times per rendered
         # frame for no operator-visible benefit.
         self.poll_interval_sec = max(float(poll_interval_sec), 0.1)
@@ -163,7 +170,7 @@ class PostProcessingController:
             import yaml
 
             config = yaml.safe_load(raw) or {}
-            name, preset = _select_preset(config)
+            name, preset = _select_preset(config, self.preset_override)
             _validate_preset(name, preset)
             # Resolved before anything is reverted: a bad camera name has to be
             # rejected like any other config error, leaving the preset that is
@@ -489,7 +496,7 @@ def _is_number(value):
     return isinstance(value, (int, float)) and not isinstance(value, bool)
 
 
-def _select_preset(config):
+def _select_preset(config, override=None):
     if not isinstance(config, dict):
         raise ValueError("top level must be a mapping")
     if config.get("version") != 1:
@@ -499,7 +506,21 @@ def _select_preset(config):
     if not isinstance(presets, dict) or not presets:
         raise ValueError("'presets' must be a non-empty mapping")
 
-    active = config.get("active")
+    if override is not None and not str(override).strip():
+        # `--postprocessing-preset "$PRESET"` with PRESET unset arrives as an
+        # empty string. Falling back to `active:` there would hand the run
+        # whatever preset set_preset.sh last wrote — the exact leak the pin
+        # exists to prevent — so treat it as the launcher bug it is.
+        raise ValueError("--postprocessing-preset was given an empty value")
+
+    active = override or config.get("active")
+    if override and override not in presets:
+        # Named against the flag, not the file: a launcher pinning a preset that
+        # the config does not define is a launcher bug, and pointing the
+        # operator at `active:` would send them editing the wrong thing.
+        raise ValueError(
+            f"--postprocessing-preset {override!r} not in presets ({', '.join(sorted(presets))})"
+        )
     if isinstance(active, bool):
         # YAML 1.1 reads off/no/false as booleans, so `active: off` silently
         # becomes False and no preset matches. Name presets in words instead.

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/set_preset.sh
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/set_preset.sh
@@ -18,18 +18,36 @@ if [[ ! -f "$CONFIG" ]]; then
 fi
 
 # Preset names are the keys indented exactly two spaces under `presets:`.
+#
+# A preset this misses is a preset the operator cannot select, so the match is
+# deliberately loose: names may be quoted (`"off":`, which the config tells you
+# to write for YAML's boolean words) or hyphenated, and the value may be inline
+# (`baseline: {}`) rather than a nested block. A comment at column 0 does NOT
+# end the block — only a real top-level key does.
 list_presets() {
     awk '
         /^presets:/ { inside = 1; next }
-        /^[^[:space:]]/ { inside = 0 }
-        inside && /^  [A-Za-z_][A-Za-z0-9_]*:[[:space:]]*$/ {
-            sub(/:[[:space:]]*$/, "", $1); print $1
+        /^[^[:space:]#]/ { inside = 0 }
+        inside && /^  ["'"'"']?[A-Za-z_][A-Za-z0-9_.-]*["'"'"']?:/ {
+            line = $0
+            sub(/^  ["'"'"']?/, "", line)
+            sub(/["'"'"']?:.*$/, "", line)
+            print line
         }
     ' "$CONFIG"
 }
 
+# Quotes are stripped so the value compares equal to the name the caller passed.
 active_preset() {
-    awk '/^active:/ { print $2; exit }' "$CONFIG"
+    awk '
+        /^active[[:space:]]*:/ {
+            sub(/^active[[:space:]]*:[[:space:]]*/, "")
+            sub(/[[:space:]]*(#.*)?$/, "")
+            gsub(/^["'"'"']|["'"'"']$/, "")
+            print
+            exit
+        }
+    ' "$CONFIG"
 }
 
 PRESETS="$(list_presets)"
@@ -50,7 +68,10 @@ fi
 
 TMP="$(mktemp "$(dirname "$CONFIG")/.postprocessing.yaml.XXXXXX")"
 trap 'rm -f "$TMP"' EXIT
-sed "s|^active:.*|active: $PRESET|" "$CONFIG" >"$TMP"
+# Tolerates `active : baseline` (valid YAML), which an anchored `^active:.*`
+# silently left alone. Always quoted, because an unquoted `active: off` parses
+# as the boolean False and the runner then rejects the whole file.
+sed "s|^active[[:space:]]*:.*|active: \"$PRESET\"|" "$CONFIG" >"$TMP"
 # mktemp creates the file 0600; without this the config would land unreadable
 # to the container user and show up in git as a mode change.
 chmod --reference="$CONFIG" "$TMP"
@@ -58,5 +79,14 @@ chmod --reference="$CONFIG" "$TMP"
 # inode is both safe and atomic — the runner never reads a half-written config.
 mv "$TMP" "$CONFIG"
 trap - EXIT
+
+# Read the result back rather than trust the substitution: `mv` succeeds just as
+# happily when the sed matched nothing, and a script that reports a switch it
+# did not make is worse than one that fails.
+GOT="$(active_preset)"
+if [[ "$GOT" != "$PRESET" ]]; then
+    echo "ERROR: failed to set active preset in $CONFIG (still '$GOT')" >&2
+    exit 3
+fi
 
 echo "Active preset: $PRESET"

--- a/closed-loop-testing/isaac-sim/sil/scripts/run_actor_sdg.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/run_actor_sdg.py
@@ -756,18 +756,17 @@ def _validate_postprocessing_preset(preset, config_path):
 
     "Wrong" is not only a mistyped name. `version: 2`, a setting key that does
     not exist, a string where a float belongs, an `animation` block missing
-    `frequency_hz`, a `per_camera` entry that also carries a top-level
-    `cameras:` — every one of those names a preset that IS in the file and
+    `frequency_hz` — every one of those names a preset that IS in the file and
     still produces a clean run. So this runs the controller's own
     `_select_preset` and `_validate_preset`, which is why those two are kept
     free of carb and pxr imports: they are the contract, and a second
     reimplementation here would drift from it.
 
-    What it still cannot check is camera resolution: `cameras:`/`per_camera:`
-    entries are matched against cameras.yaml and then against the prims on the
-    stage, and neither exists before Kit boots. An unknown camera name is
-    caught by the controller at apply time, where it is rejected without
-    disturbing the running preset.
+    What it still cannot check is camera resolution: `cameras:` entries are
+    matched against cameras.yaml and then against the prims on the stage, and
+    neither exists before Kit boots. An unknown camera name is caught by the
+    controller at apply time, where it is rejected without disturbing the
+    running preset.
     """
     if not preset.strip():
         # `--postprocessing-preset "$PRESET"` with PRESET unset. Not "no pin":

--- a/closed-loop-testing/isaac-sim/sil/scripts/run_actor_sdg.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/run_actor_sdg.py
@@ -747,12 +747,27 @@ Examples:
 def _validate_postprocessing_preset(preset, config_path):
     """Fail the run on a --postprocessing-preset the config cannot honour.
 
-    The controller rejects an unknown name too, but only as a WARNING from its
+    The controller rejects a bad preset too, but only as a WARNING from its
     poll loop: the run then streams, finishes and exits 0 with perfectly clean
-    images. A campaign that pinned an anomaly preset and mistyped the name would
+    images. A campaign that pinned an anomaly preset and got it wrong would
     score the clean run as if the fault had been injected, with nothing in the
     report saying otherwise. Refusing to boot is the only outcome an automated
     campaign can notice.
+
+    "Wrong" is not only a mistyped name. `version: 2`, a setting key that does
+    not exist, a string where a float belongs, an `animation` block missing
+    `frequency_hz`, a `per_camera` entry that also carries a top-level
+    `cameras:` — every one of those names a preset that IS in the file and
+    still produces a clean run. So this runs the controller's own
+    `_select_preset` and `_validate_preset`, which is why those two are kept
+    free of carb and pxr imports: they are the contract, and a second
+    reimplementation here would drift from it.
+
+    What it still cannot check is camera resolution: `cameras:`/`per_camera:`
+    entries are matched against cameras.yaml and then against the prims on the
+    stage, and neither exists before Kit boots. An unknown camera name is
+    caught by the controller at apply time, where it is rejected without
+    disturbing the running preset.
     """
     if not preset.strip():
         # `--postprocessing-preset "$PRESET"` with PRESET unset. Not "no pin":
@@ -768,30 +783,30 @@ def _validate_postprocessing_preset(preset, config_path):
               "config found", file=sys.stderr)
         return
 
-    try:
-        import yaml
-    except ImportError:
-        # Every other check in main() is stdlib-only, so this is the one that
-        # could depend on Kit having booted. Degrade to the controller's own
-        # (mid-run, non-fatal) rejection rather than tracebacking on a name that
-        # is probably fine.
-        print(f"WARNING: cannot validate --postprocessing-preset {preset!r} before boot "
-              "(PyYAML unavailable); an unknown name will be reported by the controller "
-              "instead", file=sys.stderr)
-        return
+    # Both imports are deliberately unguarded. PyYAML is present in the Isaac
+    # image before Kit boots (the SIL launcher and set_preset.sh both use it),
+    # and `postprocessing` sits next to this file, so neither can fail on a
+    # working install. The `except ImportError` that used to wrap the yaml
+    # import degraded this check to a WARNING — turning the hard, campaign-
+    # visible failure the function exists to produce back into exactly the soft
+    # one it exists to replace, and doing so silently.
+    import yaml
+
+    from postprocessing.controller import _select_preset, _validate_preset
 
     try:
         with open(config_path) as stream:
             config = yaml.safe_load(stream) or {}
-        presets = config.get("presets")
     except Exception as exc:
         print(f"ERROR: Cannot read post-processing config {config_path}: {exc}", file=sys.stderr)
         sys.exit(1)
 
-    if not isinstance(presets, dict) or preset not in presets:
-        known = ", ".join(sorted(presets)) if isinstance(presets, dict) else "none"
-        print(f"ERROR: Unknown post-processing preset {preset!r} in {config_path} "
-              f"(available: {known})", file=sys.stderr)
+    try:
+        name, selected = _select_preset(config, preset)
+        _validate_preset(name, selected)
+    except Exception as exc:
+        print(f"ERROR: --postprocessing-preset {preset!r} cannot be honoured by "
+              f"{config_path}: {exc}", file=sys.stderr)
         sys.exit(1)
 
 

--- a/closed-loop-testing/isaac-sim/sil/scripts/run_actor_sdg.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/run_actor_sdg.py
@@ -237,7 +237,11 @@ class ActorSDGRunner:
                     self._postprocessing.start()
                 except Exception as e:
                     print(f"WARNING: post-processing disabled ({e})")
-                    self._postprocessing = None
+                    # start() can fail with settings already written, and the
+                    # controller holds the only snapshot that undoes them.
+                    # Dropping the handle without closing it would strand the
+                    # renderer degraded for the rest of the process.
+                    self._close_postprocessing()
 
             # VST Integration: registration is DEFERRED to after Play + render-warm
             # (see the run loop below). Registering here — before the RTSP encoder is
@@ -287,9 +291,7 @@ class ActorSDGRunner:
             # Put the renderer back as it was: a preset lives in carb settings
             # and the session layer, both of which outlive this coroutine when
             # Kit stays up (UI mode, setup re-entry).
-            if self._postprocessing is not None:
-                self._postprocessing.close()
-                self._postprocessing = None
+            self._close_postprocessing()
 
             # VST Integration: Cleanup cameras on exit (fallback for UI / abnormal exit)
             if self.enable_vst and self._vst_manager:
@@ -314,6 +316,24 @@ class ActorSDGRunner:
             self._postprocessing.update()
         except Exception as e:
             print(f"WARNING: post-processing update failed, disabling: {e}")
+            # Retiring the controller means restoring the renderer first: the
+            # settings and session-layer edits an update had already made
+            # outlive the handle, and the handle is what knows how to undo them.
+            self._close_postprocessing()
+
+    def _close_postprocessing(self):
+        """Restore the renderer and drop the controller. Never raises.
+
+        The shutdown path runs it from `finally`, where an escaping exception
+        would skip the VST cleanup that follows.
+        """
+        if self._postprocessing is None:
+            return
+        try:
+            self._postprocessing.close()
+        except Exception as e:
+            print(f"WARNING: post-processing cleanup failed: {e}")
+        finally:
             self._postprocessing = None
 
     def _extract_output_path(self, config):

--- a/closed-loop-testing/isaac-sim/sil/scripts/run_actor_sdg.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/run_actor_sdg.py
@@ -62,6 +62,7 @@ class ActorSDGRunner:
         enable_srr_gt=False,
         postprocessing_config_path=None,
         enable_postprocessing=True,
+        postprocessing_preset=None,
         vst_register_warmup_sec=1.0,
         vst_register_timeout_sec=1200.0,
     ):
@@ -122,6 +123,11 @@ class ActorSDGRunner:
         # See sil/scripts/postprocessing/README.md.
         self.postprocessing_config_path = postprocessing_config_path
         self.enable_postprocessing = enable_postprocessing
+        # Pins the preset regardless of what `active:` currently says. The
+        # config file is git-tracked but set_preset.sh rewrites it live, so an
+        # unpinned run inherits whatever anomaly the previous operator left
+        # behind — reproduced on two machines. Campaign launchers pass this.
+        self.postprocessing_preset = postprocessing_preset
         self._postprocessing = None
 
         self.output_path = None
@@ -233,6 +239,7 @@ class ActorSDGRunner:
                     self._postprocessing = PostProcessingController(
                         self.postprocessing_config_path,
                         cameras_config_path=self.cameras_config_path,
+                        preset_override=self.postprocessing_preset,
                     )
                     self._postprocessing.start()
                 except Exception as e:
@@ -723,6 +730,11 @@ Examples:
     parser.add_argument("--postprocessing-config",
                         help="Path to postprocessing.yaml (RTX sensor-anomaly presets). "
                              "Defaults to configs/postprocessing.yaml when present")
+    parser.add_argument("--postprocessing-preset",
+                        help="Pin the RTX preset for this run, ignoring `active:` in the config. "
+                             "Campaign launchers should pass 'baseline' so a preset left behind "
+                             "by set_preset.sh cannot degrade the next run. An unknown name is "
+                             "an error, not a fallback")
     parser.add_argument("--no-postprocessing", dest="enable_postprocessing",
                         action="store_false", default=True,
                         help="Skip the RTX post-processing controller (no anomaly injection, "
@@ -730,6 +742,57 @@ Examples:
 
     args, _ = parser.parse_known_args()
     return args
+
+
+def _validate_postprocessing_preset(preset, config_path):
+    """Fail the run on a --postprocessing-preset the config cannot honour.
+
+    The controller rejects an unknown name too, but only as a WARNING from its
+    poll loop: the run then streams, finishes and exits 0 with perfectly clean
+    images. A campaign that pinned an anomaly preset and mistyped the name would
+    score the clean run as if the fault had been injected, with nothing in the
+    report saying otherwise. Refusing to boot is the only outcome an automated
+    campaign can notice.
+    """
+    if not preset.strip():
+        # `--postprocessing-preset "$PRESET"` with PRESET unset. Not "no pin":
+        # falling through to `active:` would hand the run whatever preset
+        # set_preset.sh last committed to the file.
+        print("ERROR: --postprocessing-preset was given an empty value", file=sys.stderr)
+        sys.exit(1)
+
+    if not config_path:
+        # No file to check the name against, and no controller either — say so,
+        # because the pin the operator asked for will not be applied.
+        print(f"WARNING: --postprocessing-preset {preset!r} ignored: no post-processing "
+              "config found", file=sys.stderr)
+        return
+
+    try:
+        import yaml
+    except ImportError:
+        # Every other check in main() is stdlib-only, so this is the one that
+        # could depend on Kit having booted. Degrade to the controller's own
+        # (mid-run, non-fatal) rejection rather than tracebacking on a name that
+        # is probably fine.
+        print(f"WARNING: cannot validate --postprocessing-preset {preset!r} before boot "
+              "(PyYAML unavailable); an unknown name will be reported by the controller "
+              "instead", file=sys.stderr)
+        return
+
+    try:
+        with open(config_path) as stream:
+            config = yaml.safe_load(stream) or {}
+        presets = config.get("presets")
+    except Exception as exc:
+        print(f"ERROR: Cannot read post-processing config {config_path}: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if not isinstance(presets, dict) or preset not in presets:
+        known = ", ".join(sorted(presets)) if isinstance(presets, dict) else "none"
+        print(f"ERROR: Unknown post-processing preset {preset!r} in {config_path} "
+              f"(available: {known})", file=sys.stderr)
+        sys.exit(1)
 
 
 def main():
@@ -760,6 +823,23 @@ def main():
     if args.postprocessing_config and not os.path.isfile(args.postprocessing_config):
         print(f"ERROR: Post-processing config not found: {args.postprocessing_config}", file=sys.stderr)
         sys.exit(1)
+
+    # Resolved here rather than next to the other config paths further down,
+    # because --postprocessing-preset can only be checked against the file that
+    # will actually be loaded, and that check has to happen before Kit boots.
+    postprocessing_config_path = None
+    if args.enable_postprocessing:
+        if args.postprocessing_config:
+            postprocessing_config_path = os.path.abspath(args.postprocessing_config)
+        else:
+            default_pp_yaml = os.path.abspath(
+                os.path.join(os.path.dirname(__file__), "..", "configs", "postprocessing.yaml")
+            )
+            if os.path.isfile(default_pp_yaml):
+                postprocessing_config_path = default_pp_yaml
+
+    if args.enable_postprocessing and args.postprocessing_preset is not None:
+        _validate_postprocessing_preset(args.postprocessing_preset, postprocessing_config_path)
 
     # Resolve cameras config path
     cameras_config_path = None
@@ -857,20 +937,6 @@ def main():
         if os.path.isfile(default_robots_yaml):
             robots_config_path = default_robots_yaml
 
-    # Resolve the post-processing preset config, same defaulting as above.
-    # Existence of an explicitly passed path was checked before Kit booted; a
-    # missing default simply leaves anomaly injection off.
-    postprocessing_config_path = None
-    if args.enable_postprocessing:
-        if args.postprocessing_config:
-            postprocessing_config_path = os.path.abspath(args.postprocessing_config)
-        else:
-            default_pp_yaml = os.path.abspath(
-                os.path.join(os.path.dirname(__file__), "..", "configs", "postprocessing.yaml")
-            )
-            if os.path.isfile(default_pp_yaml):
-                postprocessing_config_path = default_pp_yaml
-
     # Create and run SDG
     sdg = ActorSDGRunner(
         sim_app=sim_app,
@@ -892,6 +958,7 @@ def main():
         enable_srr_gt=args.enable_srr_gt,
         postprocessing_config_path=postprocessing_config_path,
         enable_postprocessing=args.enable_postprocessing,
+        postprocessing_preset=args.postprocessing_preset,
         vst_register_warmup_sec=args.vst_register_warmup_sec,
         vst_register_timeout_sec=args.vst_register_timeout_sec,
     )

--- a/closed-loop-testing/regression-reporter/scripts/run_multi.sh
+++ b/closed-loop-testing/regression-reporter/scripts/run_multi.sh
@@ -229,12 +229,19 @@ phase_start_scene() {
   # builder block (action_graphs/srr_ground_truth.py), AFTER IRA has spawned the
   # SRR char groups + runtime_patches repositioned them, then pump live Fabric
   # transforms. The flag defaults OFF, so a normal Halos run is unaffected.
+  #
+  # --postprocessing-preset pins the RTX look to the undegraded baseline.
+  # postprocessing.yaml is git-tracked but set_preset.sh rewrites it in place,
+  # so without the pin a campaign inherits whatever sensor anomaly the last
+  # interactive session left active, and every scene scores against a degraded
+  # image with nothing in the report saying so.
   docker exec -d isaac-sim bash -c "
     ./python.sh /isaac-sim/sil/scripts/run_actor_sdg.py \
       -c /isaac-sim/sil/configs/default_config_ros.yaml \
       --start --headless --enable-vst \
       --cameras-config /isaac-sim/sil/configs/cameras.yaml \
       --srr-gt \
+      --postprocessing-preset baseline \
       > $log_path 2>&1
   "
 }


### PR DESCRIPTION
Fixes for the error paths in #58, stacked on top of it rather than rewritten into it.
Targets `feat/post_processing_runtime`. Merge this first and #58 carries it into `develop`.

The architecture is not in question — the allow-list of logical keys means a typo is rejected by name, USD authoring goes into the session layer so a degraded run never dirties the scene `.usd`, and the revert removes the applied API schema rather than just the attribute, without which the prim would fall back to a schema default and quietly override the next global preset. Three preset values in the file were corrected by measurement rather than guessed. What follows is entirely about what happens when something fails.

## Four bugs on the failure paths

| Commit | What breaks |
|---|---|
| `keep the cleanup path alive after the first failure` | The `except` around the per-frame update set `self._postprocessing = None` — the same handle `finally` checks before calling `close()`. One transient failure therefore disabled shutdown cleanup and the degradation stayed on the renderer for the rest of the run, the opposite of what the docstring promises. |
| `reject a bad preset without half-applying it` | `_apply` sat outside the `try`, and the config digest was committed before it. The "a rejected preset leaves the running one alone" guarantee therefore did not cover the apply itself: a failure part-way through left half a preset on screen, a look nothing in the file describes. |
| `stop set_preset.sh hiding presets and faking success` | The `awk` in `list_presets` rejected valid presets, including the quoted `"off"` form the config file itself recommends, and a comment in column 0 hid every preset after it. The script also reported success without checking that the write had happened. |
| `pin the active preset from the command line` | `postprocessing.yaml` is git-tracked but `set_preset.sh` rewrites it in place, so an unpinned run inherits whatever anomaly the previous operator left behind — reproduced on two machines. `--postprocessing-preset` pins it for the whole run, and `run_multi.sh` pins `baseline`. |

## Three more found while fixing those

**`clear the deferred render-product writes when a revert fails`** — `_clear_authored_usd()` ran first in `_revert()`'s `finally` without a `try` of its own, so when it raised, the resets below it never ran. The render-product writes queued by the *rejected* preset survived, and `update()` flushed them on the first tick after Play — silently installing the preset that had just been refused, while `active_preset` reported `None`.

**`validate the pinned preset with the real validator`** — the pre-boot check only tested membership. `version: 2`, an unknown setting key, a string where a float belongs, an `animation` block missing `frequency_hz`: each of those names a preset that *is* in the file, so the run booted, warned once mid-run, and exited 0 with perfectly clean images. A campaign that pinned an anomaly preset and got it wrong would have scored that clean run as though the fault had been injected. It now calls the controller's own `_select_preset` and `_validate_preset`, which is why those two are deliberately free of carb and pxr imports: they are the contract, and a second implementation here would drift from it.

**`record the authored attribute before writing it`** — `_authored_apis` was recorded before `AddAppliedSchema`, but `_authored_attrs` was recorded after `attr.Set()`. `CreateAttribute` is what puts the attribute on the prim, so a `Set()` that raised left it on the stage and out of the ledger, where it survived every `_revert()` and `close()` for the rest of the process while `active_preset` reported `None` — the exact inverse of the state the cleanup exists to prevent.

## Verification

Measured on two machines against RTSP after H.264 encode, at native 1920×1080, with the forklift driving.

- Presets: `low_light` mean 122 → 34 · `tv_noise` high-frequency energy 16 → 37 · `vignette_heavy` centre/edge 4.7 · `hue_shift` R/B ratio 0.99 → 1.49 · `one_camera_degraded` degrades its own camera and leaves the other two at baseline.
- Negative paths, 7/7: unknown preset name, `active: off`, malformed YAML (warns once, not once per poll), a camera that is not on the stage, `active :` with a space, presets hidden behind a column-0 comment, and re-apply on an unrelated edit.
- Pinning: a file saying `tv_noise` with `--postprocessing-preset baseline` renders clean (hf 16.0/16.9/16.3); the same file without the flag renders grainy (36.0/35.1/36.6).
- Pre-boot rejection: `version: 2`, a wrong value type, an unknown setting key and an empty pin each exit 1 within a second, with zero new lines in the Kit log and no banner — so the validator is verified to run before Kit boots rather than merely asserted to.
- Frame rate: unchanged, 12.50/12.50 against 12.53/12.93 for the unmodified branch on the same host in the same session, inside the ~3% run-to-run noise.

The last fix touches `_author()`, which runs for every authored attribute and, under an animated preset, every frame — so it was measured separately, against an arm differing by that one hunk and nothing else:

- The cleanup ledger stays flat. An animated camera-prim preset holds 4 entries across 150-second windows and an animated render-product preset holds 3 across 200 seconds, with the entry count equal to the distinct-entry count throughout — roughly 3700 `_author()` calls to a ledger that stays four entries long. The render-product path is the one that could have degraded, since its prim path comes from traversing the stage each frame rather than from `cameras.yaml`; it does not.
- Frame rate stays inside the noise: 12.40 against 12.54 on an animated preset, with a 1.9% spread within a single arm.
- Forcing `attr.Set()` to raise leaves `exposure:iso` on the stage and out of the ledger before the fix, surviving `_revert()`; after it, nothing is orphaned.

## Known gaps

- **Shutdown cleanup is not directly observable.** `close()` is silent on success, so the log cannot distinguish "ran cleanly" from "did not run at all". The only positive signal is the absence of a cleanup warning. A success log line would make it verifiable; not added here, to keep this PR to the bugs.
- **No unit tests in this PR.** They land with the per-camera PR that follows, because they exercise the multi-scope apply and revert paths that PR introduces — including one that fails if the `_author()` ordering fix above is reverted.
- **One symptom is reported but did not reproduce.** Switching from a global `tv_noise` preset to a per-camera one and back to `baseline` was once seen to leave grain on the cameras *outside* the scope. Five sequences across two machines, on this branch and on the unmodified one, all reverted clean. Three candidate mechanisms were checked and none survived: the carb restore never takes the `destroy_item` path (every setting already exists at snapshot time, so it always restores by value), and the two USD explanations both predict the *in-scope* camera sticking, which is the opposite of what was reported. Recorded here rather than dropped, in case it returns.
- **`exposure.f_stop` does nothing at global scope**, though it works per camera. `exposure.time` carries a warning in the allow-list for exactly this trap; `f_stop` has none.

