### PR TITLE
feat(sil): per-camera anomaly presets, each camera with its own fault

### DIFF
--- a/closed-loop-testing/isaac-sim/sil/configs/postprocessing.yaml
+++ b/closed-loop-testing/isaac-sim/sil/configs/postprocessing.yaml
@@ -164,6 +164,19 @@ presets:
       tv_noise.film_grain.enabled: true
       tv_noise.film_grain.amount: 0.15
 
+  # Several cameras, one shared fault. The `cameras:` list takes as many names
+  # as you like and they all read the same `settings` block, so this is the
+  # preset shape for "the whole fleet is grainy" without reaching for the carb
+  # scope and dragging the viewport along with it. Compare with mixed_faults
+  # below: same three-camera idea, opposite meaning.
+  all_cameras_grainy:
+    description: Every listed camera carries the same sensor grain.
+    cameras: [Camera, Camera_01, Camera_02]
+    settings:
+      tv_noise.enabled: true
+      tv_noise.film_grain.enabled: true
+      tv_noise.film_grain.amount: 0.15
+
   # Two cameras, two different faults, at the same time. `cameras:` cannot do
   # this: it has one `settings` block, so every camera it lists gets the same
   # degradation — and because only one preset is active, applying a Camera_01

--- a/closed-loop-testing/isaac-sim/sil/configs/postprocessing.yaml
+++ b/closed-loop-testing/isaac-sim/sil/configs/postprocessing.yaml
@@ -60,14 +60,19 @@ presets:
 
   # Mains flicker / failing luminaire: sensor gain swings around its base.
   #
-  # Keep frequency_hz below half the rate the renderer actually achieves, or the
-  # anomaly you ship is not the anomaly the consumer sees. The animation is
-  # sampled once per rendered frame, and this warehouse renders at 8-9 fps on
-  # the SIL box (the RTSP stream declares 30 fps but delivers ~8). Measured on a
-  # continuous capture, 1 Hz and 2 Hz requests read back at 1.0 and 1.8 Hz — the
-  # residual is the error in estimating the achieved frame rate — while 6 Hz
-  # folds down to an unambiguous 3.0 Hz. Raise this only after checking the
-  # frame rate the scene actually achieves.
+  # Keep frequency_hz below half the rate that is actually achieved, or the
+  # anomaly you ship is not the anomaly the consumer sees. TWO rates are in play
+  # and they are not the same number.
+  #
+  # The animation is sampled once per RENDERED frame. This warehouse measured
+  # 17.8 fps on both SIL boxes, so the injected sine itself holds up to ~8.9 Hz.
+  # What a consumer can reconstruct is bounded by what its capture DELIVERS,
+  # which is lower: the RTSP stream declares 30 fps and delivered ~8 when this
+  # was captured. On that capture 1 Hz and 2 Hz requests read back at 1.0 and
+  # 1.8 Hz — the residual is the error in estimating the delivered rate — while
+  # 6 Hz folded to an unambiguous 3.0 Hz. A 6 Hz signal folding to 3.0 Hz is the
+  # signature of sampling near 9 Hz, which is the DELIVERY ceiling, not the
+  # render one. Check both before raising this.
   #
   # This animates ISO, not shutter, and that is deliberate. The obvious knob,
   # exposure.time, does nothing at global scope in a running sim: something in
@@ -213,10 +218,15 @@ presets:
           tv_noise.film_grain.enabled: true
           tv_noise.film_grain.amount: 0.18
 
-  # Two independent frequencies on the same target. Note 3 Hz is at the edge of
-  # what this scene can carry: the sine is sampled once per rendered frame and
-  # the SIL warehouse renders at 8-9 fps, so 3 Hz has only ~3 samples per cycle.
-  # It is measurable but coarse; above this it aliases (6 Hz folds to 3 Hz).
+  # Two independent frequencies on the same target. The sine is sampled once per
+  # rendered frame, so the achieved frame rate sets the ceiling: this warehouse
+  # measured 17.8 fps on both SIL boxes, putting the alias threshold near 8.9 Hz
+  # and giving this preset's 3 Hz about 5.9 samples per cycle -- comfortably
+  # resolved. Samples per cycle is just achieved_fps / frequency_hz: below 2 the
+  # signal folds to a different frequency, and only a little above 2 it is
+  # coarse. The ceiling belongs to the host, not the scene, so check the rate
+  # yours achieves. See the note on `flicker` above: what a CONSUMER can
+  # reconstruct is bounded by the delivered rate instead, which is lower.
   anim_two_freq:
     description: Camera_01 flickers at 1 Hz, Camera_02 at 3 Hz, same target.
     per_camera:

--- a/closed-loop-testing/isaac-sim/sil/configs/postprocessing.yaml
+++ b/closed-loop-testing/isaac-sim/sil/configs/postprocessing.yaml
@@ -16,6 +16,8 @@
 # "camera 2 is dirty", which is the case an anomaly campaign usually wants.
 # `per_camera:` goes one step further and gives every camera its own settings
 # block, for "camera 1 went dark WHILE camera 2 went grainy" — see mixed_faults.
+# Each `per_camera:` entry can also carry its own `animation:` block, so cameras
+# can flicker at different rates or out of phase — see anim_* below.
 #
 # Per-camera caveat: exposure lives on the camera prim and applies at once, but
 # grain / scanlines / vignetting / colour grading live on the RENDER PRODUCT,
@@ -162,7 +164,8 @@ presets:
   # degradation — and because only one preset is active, applying a Camera_01
   # preset and then a Camera_02 preset reverts the first. `per_camera:` gives
   # each camera its own block and applies them in one pass. It cannot be
-  # combined with `cameras:`/`settings:`/`animation:`.
+  # combined with the TOP-LEVEL `cameras:`/`settings:`/`animation:` keys —
+  # `settings:` and `animation:` go inside each per_camera entry instead.
   mixed_faults:
     description: Camera_01 goes dark while Camera_02 goes grainy, together.
     per_camera:
@@ -175,3 +178,118 @@ presets:
           tv_noise.enabled: true
           tv_noise.film_grain.enabled: true
           tv_noise.film_grain.amount: 0.18
+
+  # --- Animated per-camera presets -------------------------------------------
+  # Every per_camera entry can carry its own `animation:` block, so one camera
+  # can flicker while another sits still, or two can flicker out of step. All
+  # groups share one clock origin, latched at apply, and `phase_deg` (optional,
+  # default 0, range [0, 360)) offsets one against another:
+  #
+  #     value = base * (1 + amplitude_fraction * sin(2*pi*f*(t - t0) + phase_deg))
+  #
+  # `auto_exposure.enabled: false` has to be repeated in EVERY entry that
+  # animates exposure — there is no top-level `settings:` in a per_camera preset
+  # to put it in, and with auto-exposure left on the histogram pulls the image
+  # back to normal brightness in about a second and the flicker vanishes.
+
+  # Cross-term check: does an animated group leak onto a static one? Camera_01
+  # flickers, Camera_02 holds a fixed grain level and must not move with it.
+  anim_mixed:
+    description: Camera_01 flickers at 1 Hz while Camera_02 sits at static grain.
+    per_camera:
+      Camera_01:
+        settings:
+          auto_exposure.enabled: false
+          exposure.iso: 100.0
+        animation:
+          target: exposure.iso
+          waveform: sine
+          base: 100.0
+          amplitude_fraction: 0.35
+          frequency_hz: 1.0
+      Camera_02:
+        settings:
+          tv_noise.enabled: true
+          tv_noise.film_grain.enabled: true
+          tv_noise.film_grain.amount: 0.18
+
+  # Two independent frequencies on the same target. Note 3 Hz is at the edge of
+  # what this scene can carry: the sine is sampled once per rendered frame and
+  # the SIL warehouse renders at 8-9 fps, so 3 Hz has only ~3 samples per cycle.
+  # It is measurable but coarse; above this it aliases (6 Hz folds to 3 Hz).
+  anim_two_freq:
+    description: Camera_01 flickers at 1 Hz, Camera_02 at 3 Hz, same target.
+    per_camera:
+      Camera_01:
+        settings:
+          auto_exposure.enabled: false
+          exposure.iso: 100.0
+        animation:
+          target: exposure.iso
+          waveform: sine
+          base: 100.0
+          amplitude_fraction: 0.35
+          frequency_hz: 1.0
+      Camera_02:
+        settings:
+          auto_exposure.enabled: false
+          exposure.iso: 100.0
+        animation:
+          target: exposure.iso
+          waveform: sine
+          base: 100.0
+          amplitude_fraction: 0.35
+          frequency_hz: 3.0
+
+  # Antiphase: same frequency, half a cycle apart, so Camera_01 is at its
+  # brightest exactly when Camera_02 is at its dimmest. This is the case a
+  # shared clock origin alone cannot produce — both groups are applied in the
+  # same tick, so without `phase_deg` they would be locked in step.
+  anim_antiphase:
+    description: Both cameras flicker at 1 Hz, 180 degrees apart.
+    per_camera:
+      Camera_01:
+        settings:
+          auto_exposure.enabled: false
+          exposure.iso: 100.0
+        animation:
+          target: exposure.iso
+          waveform: sine
+          base: 100.0
+          amplitude_fraction: 0.35
+          frequency_hz: 1.0
+          phase_deg: 0
+      Camera_02:
+        settings:
+          auto_exposure.enabled: false
+          exposure.iso: 100.0
+        animation:
+          target: exposure.iso
+          waveform: sine
+          base: 100.0
+          amplitude_fraction: 0.35
+          frequency_hz: 1.0
+          phase_deg: 180
+
+  # Breathing grain rather than breathing brightness. This is the EXPENSIVE
+  # shape and the controller says so on load: grain lives on the render product,
+  # which is found by traversing the stage, so an animated render-product target
+  # at per-camera scope traverses once per animated scope per frame. A preset of
+  # this shape previously measured -7.0% FPS with the robot driving. It is a
+  # warning, not a rejection — animating grain on one camera is a real anomaly.
+  # tv_noise.enabled and film_grain.enabled must both be on, or animating the
+  # amount drives a pass that is switched off.
+  anim_rp_target:
+    description: Camera_01 grain breathes at 0.5 Hz (render-product target — costly).
+    per_camera:
+      Camera_01:
+        settings:
+          tv_noise.enabled: true
+          tv_noise.film_grain.enabled: true
+          tv_noise.film_grain.amount: 0.12
+        animation:
+          target: tv_noise.film_grain.amount
+          waveform: sine
+          base: 0.12
+          amplitude_fraction: 0.6
+          frequency_hz: 0.5

--- a/closed-loop-testing/isaac-sim/sil/configs/postprocessing.yaml
+++ b/closed-loop-testing/isaac-sim/sil/configs/postprocessing.yaml
@@ -14,6 +14,8 @@
 # viewport and every camera — "the whole site went dark". Adding `cameras:`
 # authors USD attributes on those cameras instead, so only they degrade —
 # "camera 2 is dirty", which is the case an anomaly campaign usually wants.
+# `per_camera:` goes one step further and gives every camera its own settings
+# block, for "camera 1 went dark WHILE camera 2 went grainy" — see mixed_faults.
 #
 # Per-camera caveat: exposure lives on the camera prim and applies at once, but
 # grain / scanlines / vignetting / colour grading live on the RENDER PRODUCT,
@@ -154,3 +156,22 @@ presets:
       tv_noise.enabled: true
       tv_noise.film_grain.enabled: true
       tv_noise.film_grain.amount: 0.15
+
+  # Two cameras, two different faults, at the same time. `cameras:` cannot do
+  # this: it has one `settings` block, so every camera it lists gets the same
+  # degradation — and because only one preset is active, applying a Camera_01
+  # preset and then a Camera_02 preset reverts the first. `per_camera:` gives
+  # each camera its own block and applies them in one pass. It cannot be
+  # combined with `cameras:`/`settings:`/`animation:`.
+  mixed_faults:
+    description: Camera_01 goes dark while Camera_02 goes grainy, together.
+    per_camera:
+      Camera_01:
+        settings:
+          auto_exposure.enabled: false
+          exposure.iso: 12.0
+      Camera_02:
+        settings:
+          tv_noise.enabled: true
+          tv_noise.film_grain.enabled: true
+          tv_noise.film_grain.amount: 0.18

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/README.md
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/README.md
@@ -97,6 +97,19 @@ gets an identical look; and exactly one preset is active at a time, with
 `huy-rtx-5070`: after step two, Camera_01 was mean 125.1 / hf 17.4 against a
 baseline of 120.0 / 17.0 — fully reverted, by design rather than by leak.
 
+The shipped presets cover each shape, so the difference can be run rather than
+only read:
+
+| Shape | Preset | What it does |
+|---|---|---|
+| global | `low_light`, `tv_noise` | viewport and every camera |
+| `cameras:`, one name | `one_camera_degraded` | that camera degrades, the rest stay clean |
+| `cameras:`, several names | `all_cameras_grainy` | every listed camera, **the same** fault |
+| `per_camera:` | `mixed_faults` | every listed camera, **a different** fault |
+
+The last two are the pair worth running back to back: they name the same three
+cameras and mean opposite things.
+
 `per_camera:` is mutually exclusive with the **top-level** `cameras:`,
 `settings:` and `animation:` keys; declaring both is rejected rather than
 silently resolved, because those name a scope too and quietly ignoring them

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/README.md
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/README.md
@@ -226,15 +226,33 @@ the timeline is playing.
   writes are deferred, and as an append-only list they grew one entry per frame
   while the flush traversed the stage once per entry. Keying on
   `(cameras, setting)` keeps the pending set bounded by the preset's size.
+  Measured on the shipped `anim_rp_target` (`test_controller.py`): **3 pending
+  entries and 4 stage traversals per pre-Play frame** — 3 flush plus 1 animate —
+  flat however long Play is delayed. A grain preset always carries
+  `tv_noise.enabled` and `film_grain.enabled` next to the animated amount, and
+  those defer too; the smaller figure of 1 entry / 2 traversals quoted in the
+  original commit describes a preset with the grain pass switched off, which
+  renders no grain at all. **After** Play the queue is empty and only the
+  animator traverses, which is the one-per-animated-scope cost the load-time
+  WARNING quotes.
 - **Animate ISO for flicker, not shutter.** `/rtx/post/tonemap/exposureTime` is
   rewritten by the render loop on every frame — it mirrors `cameraShutter`, the
   same quantity expressed as 1/s — so a global write never reaches the
   tonemapper and the flicker silently does nothing. `exposure:time` on a camera
   prim does work, so shutter flicker is available at per-camera scope.
 - **Animation frequency is bounded by the frame rate, not by the config.** The
-  sine is sampled once per rendered frame, so a request above half the achieved
-  rate aliases: on the SIL box (8–9 fps for this warehouse) 6 Hz comes back as
-  3 Hz. Check the achieved rate before raising `frequency_hz`.
+  sine is sampled once per rendered frame, so the achieved rate sets the
+  ceiling — and it belongs to the machine, not to the scene. This warehouse
+  measured **17.8 fps** on both SIL boxes, which puts the alias threshold at
+  **~8.9 Hz**. Use samples per cycle rather than a verdict on any one
+  frequency: it is `achieved_fps / frequency_hz`, below 2 the signal folds to a
+  different frequency entirely, and a little above 2 it is recoverable but
+  coarse (6 Hz at 17.8 fps is 3.0 samples per cycle — the frequency you asked
+  for, sampled about as thinly as is still meaningful). Two rates matter and
+  they are not the same number: the render loop's, which is what the sine is
+  sampled at, and the rate a consumer's capture *delivers*, which is what
+  bounds the frequency that consumer can reconstruct. The RTSP side has
+  measured well below the render side. Read both on the box you are on.
 - **`tv_noise_deterministic` exists for regression runs.** `fixed_time.seed`
   freezes the renderer's time input, the intent being that two runs of one
   scenario produce identical noise; per-frame randomness would otherwise defeat

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/README.md
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/README.md
@@ -63,7 +63,7 @@ ignored — a mistyped anomaly would otherwise score a clean run as a fault run.
 Turn the whole thing off with `--no-postprocessing`, or point it at a different
 preset file with `--postprocessing-config`.
 
-## Two scopes, and why the difference matters
+## Three scopes, and why the difference matters
 
 A preset with no `cameras:` key writes **carb settings**, which the renderer
 applies to the viewport and every camera. That models an environment-wide event
@@ -73,6 +73,34 @@ A preset **with** `cameras:` authors **USD attributes** on those cameras
 instead, which override the carb value for them alone. That models the case an
 anomaly campaign actually cares about: one camera degrades while the others stay
 clean, so you can assert the monitor still covers the zone.
+
+A preset with `per_camera:` authors the same USD attributes, but takes **one
+settings block per camera**, so different cameras can carry different faults in
+the same apply:
+
+```yaml
+mixed_faults:
+  per_camera:
+    Camera_01:
+      settings: {auto_exposure.enabled: false, exposure.iso: 12.0}
+    Camera_02:
+      settings: {tv_noise.enabled: true, tv_noise.film_grain.enabled: true, tv_noise.film_grain.amount: 0.18}
+```
+
+`cameras:` cannot express that, and neither can applying two presets in
+sequence. `cameras:` has a single `settings` block, so every camera it lists
+gets an identical look; and exactly one preset is active at a time, with
+`_apply` reverting before it applies, so `set_preset.sh cam1_dark` followed by
+`set_preset.sh cam2_noise` leaves Camera_01 back at baseline. Measured on
+`huy-rtx-5070`: after step two, Camera_01 was mean 125.1 / hf 17.4 against a
+baseline of 120.0 / 17.0 — fully reverted, by design rather than by leak.
+
+`per_camera:` is mutually exclusive with `cameras:`, `settings:` and
+`animation:`; declaring both is rejected rather than silently resolved. Every
+camera is resolved to a prim path *before* the revert, so one unknown name
+rejects the whole edit and leaves the running preset in place. Animation inside
+a `per_camera` entry is **not supported yet** and is rejected explicitly —
+`animation:` at preset top level, with `cameras:`, still works.
 
 The USD attribute names are not a rename of the carb paths, and the split is
 easy to get wrong:
@@ -118,7 +146,7 @@ the timeline is playing.
   preset starts by reverting the previous one, so once that has begun the last
   good preset no longer exists to keep; what is on screen is half of a preset
   that was just rejected. That case reverts to the pre-controller state, drops
-  the animation and the pending render-product writes, and forgets the last good
+  the animations and the pending render-product writes, and forgets the last good
   digest so putting the file back re-applies it rather than reading as
   "unchanged".
 - **All USD authoring goes to the session layer.** A preset never dirties the

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/README.md
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/README.md
@@ -21,6 +21,7 @@ and the IRA visual-noise example.
 | `effects.py` | `EFFECTS` | Allow-list mapping a stable logical key (`tv_noise.film_grain.amount`) to its carb setting, its USD attribute, and which prim carries it. |
 | `controller.py` | `PostProcessingController` | Loads the active preset, applies it globally or per camera, polls the config for live edits, drives animated effects, and restores the renderer on shutdown. |
 | `set_preset.sh` | — | Switches the live preset by rewriting `active:` atomically. Run it from the host while the sim is running. |
+| `test_animation.py` | `python3 -m postprocessing.test_animation` | Validates every shipped preset and checks the animator math on a synthetic clock. Stdlib only — no Kit, no numpy, no pytest; run it from `sil/scripts/` on any machine. |
 
 Presets live in [`../../configs/postprocessing.yaml`](../../configs/postprocessing.yaml).
 
@@ -75,8 +76,8 @@ anomaly campaign actually cares about: one camera degrades while the others stay
 clean, so you can assert the monitor still covers the zone.
 
 A preset with `per_camera:` authors the same USD attributes, but takes **one
-settings block per camera**, so different cameras can carry different faults in
-the same apply:
+settings block per camera** — and, optionally, one `animation` block per camera
+— so different cameras can carry different faults in the same apply:
 
 ```yaml
 mixed_faults:
@@ -95,12 +96,61 @@ gets an identical look; and exactly one preset is active at a time, with
 `huy-rtx-5070`: after step two, Camera_01 was mean 125.1 / hf 17.4 against a
 baseline of 120.0 / 17.0 — fully reverted, by design rather than by leak.
 
-`per_camera:` is mutually exclusive with `cameras:`, `settings:` and
-`animation:`; declaring both is rejected rather than silently resolved. Every
-camera is resolved to a prim path *before* the revert, so one unknown name
-rejects the whole edit and leaves the running preset in place. Animation inside
-a `per_camera` entry is **not supported yet** and is rejected explicitly —
-`animation:` at preset top level, with `cameras:`, still works.
+`per_camera:` is mutually exclusive with the **top-level** `cameras:`,
+`settings:` and `animation:` keys; declaring both is rejected rather than
+silently resolved, because those name a scope too and quietly ignoring them
+would apply a preset the file does not describe. `settings:` and `animation:`
+move *inside* each `per_camera` entry. Every camera is resolved to a prim path
+*before* the revert, so one unknown name rejects the whole edit and leaves the
+running preset in place.
+
+### Animation, and animation per camera
+
+`animation:` drives one float effect on a sine, sampled once per rendered frame:
+
+```
+value = base * (1 + amplitude_fraction * sin(2*pi*frequency_hz*(t - t0) + radians(phase_deg)))
+```
+
+It can sit at preset top level (global, or scoped by `cameras:`) or inside a
+`per_camera` entry — the same block, validated by the same rule, so what one
+accepts the other accepts. `phase_deg` is optional, defaults to `0.0`, and must
+be in `[0, 360)`.
+
+**All animated groups share one clock origin**, latched when the preset is
+applied. That is deliberate rather than a limitation: every group of a preset is
+applied in the same call, so per-group origins would be identical by
+construction and would add bookkeeping without adding expressiveness. `phase_deg`
+is what pulls two cameras apart, and unlike a start-time race it is explicit in
+the file and reproducible across runs:
+
+```yaml
+anim_antiphase:
+  per_camera:
+    Camera_01:
+      settings: {auto_exposure.enabled: false, exposure.iso: 100.0}
+      animation: {target: exposure.iso, base: 100.0, amplitude_fraction: 0.35, frequency_hz: 1.0, phase_deg: 0}
+    Camera_02:
+      settings: {auto_exposure.enabled: false, exposure.iso: 100.0}
+      animation: {target: exposure.iso, base: 100.0, amplitude_fraction: 0.35, frequency_hz: 1.0, phase_deg: 180}
+```
+
+Camera_01 peaks exactly when Camera_02 troughs. `anim_two_freq` does the same
+with 1 Hz against 3 Hz, and `anim_mixed` animates one camera while the other
+holds a static fault.
+
+Repeat `auto_exposure.enabled: false` in **every** entry that animates exposure.
+There is no top-level `settings:` in a `per_camera` preset to put it in once, and
+with auto-exposure left on the histogram claws the image back inside a second.
+
+> **Cost warning.** Animating a **render-product** effect (grain, scanlines,
+> vignetting, colour grading) at per-camera scope makes the controller traverse
+> the whole stage once per animated scope **per frame**, because render products
+> are located by traversal rather than by name. A preset of that shape measured
+> **−7.0% FPS** with the robot driving. The controller logs a WARNING naming the
+> preset when it loads one; it does **not** reject it, because breathing grain on
+> one camera is a real anomaly. Camera-prim effects (`exposure.*`) are free —
+> the prim path is already known. See `anim_rp_target`.
 
 The USD attribute names are not a rename of the carb paths, and the split is
 easy to get wrong:
@@ -159,9 +209,22 @@ the timeline is playing.
 - **Auto-exposure is switched off in every exposure preset.** Left on, the
   histogram adapts and claws a darkened image back to normal brightness within
   about a second, so the anomaly quietly disappears.
-- **One animated float, sine only.** Enough for mains flicker, which is the
-  time-varying anomaly that comes up; anything richer belongs in a scenario
-  script rather than a preset file.
+- **One animated float, sine only — but one per scope.** Enough for mains
+  flicker, which is the time-varying anomaly that comes up; anything richer
+  belongs in a scenario script rather than a preset file. Each `per_camera`
+  entry gets its own sine, so "one flickering camera among steady ones" and
+  "two cameras out of step" are both preset-level facts.
+- **One shared clock origin plus `phase_deg`, not one origin per camera.** All
+  groups are applied in the same call, so per-group origins would be equal by
+  construction — they would express nothing a single origin cannot. An explicit
+  phase offset does add something, and it is reproducible: the same file gives
+  the same relative timing on every run, where a per-group origin would inherit
+  whatever the apply order happened to be.
+- **Deferred render-product writes are keyed, not queued.** An animated
+  render-product effect re-writes the same key every frame; before Play those
+  writes are deferred, and as an append-only list they grew one entry per frame
+  while the flush traversed the stage once per entry. Keying on
+  `(cameras, setting)` keeps the pending set bounded by the preset's size.
 - **Animate ISO for flicker, not shutter.** `/rtx/post/tonemap/exposureTime` is
   rewritten by the render loop on every frame — it mirrors `cameraShutter`, the
   same quantity expressed as 1/s — so a global write never reaches the

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/README.md
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/README.md
@@ -22,6 +22,7 @@ and the IRA visual-noise example.
 | `controller.py` | `PostProcessingController` | Loads the active preset, applies it globally or per camera, polls the config for live edits, drives animated effects, and restores the renderer on shutdown. |
 | `set_preset.sh` | — | Switches the live preset by rewriting `active:` atomically. Run it from the host while the sim is running. |
 | `test_animation.py` | `python3 -m postprocessing.test_animation` | Validates every shipped preset and checks the animator math on a synthetic clock. Stdlib only — no Kit, no numpy, no pytest; run it from `sil/scripts/` on any machine. |
+| `test_controller.py` | `python3 -m postprocessing.test_controller` | The state the animation suite cannot reach: `_apply`, `_revert`, `_resolve_groups` and the deferred render-product store, all running for real against fake `pxr` / `omni.usd` modules and a fake stage that counts traversals. Covers what is authored versus deferred, flush scoping, cleanup after a *failing* revert, and the reject paths. Stdlib only; same machine requirements. |
 
 Presets live in [`../../configs/postprocessing.yaml`](../../configs/postprocessing.yaml).
 

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/controller.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/controller.py
@@ -125,6 +125,16 @@ class PostProcessingController:
         # every frame — as a list that grew one entry per frame before Play, and
         # the flush traverses the stage once per entry, so the cost was
         # quadratic in the number of pre-Play frames.
+        #
+        # Keyed, the size is the preset's, not the frame count's. Measured on
+        # the shipped `anim_rp_target` by test_controller.py: 3 pending entries
+        # and 4 stage traversals per pre-Play frame (3 flush + 1 animate), flat
+        # for as long as Play is delayed. Not 1 and 2 — that pair describes a
+        # preset that animates the grain amount WITHOUT switching the grain pass
+        # on, which renders no grain at all; every usable one carries
+        # tv_noise.enabled and film_grain.enabled alongside it, and those defer
+        # too. After Play the queue is empty and only the animator traverses,
+        # which is the 1-per-animated-scope figure the load-time WARNING quotes.
         self._pending_rp_settings = {}
         self._pending_warned = False
 

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/controller.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/controller.py
@@ -16,11 +16,17 @@ Two scopes, chosen per preset:
     alone. Use it for "camera 2 is degraded", the case an anomaly campaign
     actually cares about.
   * per camera, one look each (`per_camera:` in the preset) — the same USD
-    authoring, but every camera carries its own `settings` block. Use it for
-    "camera 1 went dark WHILE camera 2 went grainy", which `cameras:` cannot
-    express: one `settings` block means every listed camera gets the same
-    degradation, and only one preset is active at a time, so applying two
-    single-camera presets in turn reverts the first.
+    authoring, but every camera carries its own `settings` block and, if it
+    wants one, its own `animation` block. Use it for "camera 1 went dark WHILE
+    camera 2 went grainy", which `cameras:` cannot express: one `settings`
+    block means every listed camera gets the same degradation, and only one
+    preset is active at a time, so applying two single-camera presets in turn
+    reverts the first.
+
+Animated groups share one clock origin, latched when the preset is applied, and
+offset against each other with `animation.phase_deg`. Two cameras flickering at
+1 Hz 180 degrees apart is then a property of the preset file rather than of when
+each group happened to start.
 
 Per-camera scoping has one timing quirk worth knowing: the RTSP graph creates
 render products through `IsaacCreateRenderProduct`, which only runs on the
@@ -113,12 +119,20 @@ class PostProcessingController:
         self._authored_attrs = []   # (prim_path, attr_name)
         self._authored_apis = []    # (prim_path, api_name)
 
-        # (camera_prim_paths, key, value) — carries its own scope, because two
-        # cameras in the same preset can now be waiting on different settings.
-        self._pending_rp_settings = []
+        # (camera_prim_paths, key) -> value. Keyed rather than appended for two
+        # reasons: two cameras in the same preset can be waiting on different
+        # settings, and an ANIMATED render-product effect re-writes the same key
+        # every frame — as a list that grew one entry per frame before Play, and
+        # the flush traverses the stage once per entry, so the cost was
+        # quadratic in the number of pre-Play frames.
+        self._pending_rp_settings = {}
         self._pending_warned = False
 
         self._animations = []       # (camera_prim_paths, animation)
+        # One clock origin for every group. All groups are applied in the same
+        # _apply call, so per-group origins would be identical by construction
+        # and add nothing; `animation.phase_deg` is how a preset offsets one
+        # camera against another, explicitly and measurably.
         self._animation_t0 = 0.0
 
     @property
@@ -222,7 +236,7 @@ class PostProcessingController:
             # branch exists: update() flushes them on the first tick after Play,
             # which would install the very preset just rejected.
             self._animations = []
-            self._pending_rp_settings = []
+            self._pending_rp_settings = {}
             self._active_name = None
             # Forget the last good digest too. The usual recovery is to put the
             # file back the way it was, and that content still matches _digest —
@@ -269,7 +283,15 @@ class PostProcessingController:
         # are separated by "; " so the log distinguishes "these cameras share a
         # look" from "each camera has its own".
         detail = f"{total} setting(s), scope={'; '.join(scopes)}"
-        animating = ", ".join(anim["target"] for _, anim in self._animations)
+        if len(self._animations) > 1:
+            # Several scopes can animate the same target at different phases or
+            # frequencies, so the bare target name would read as a duplicate.
+            animating = ", ".join(
+                f"{anim['target']} on {', '.join(paths) or 'global'}"
+                for paths, anim in self._animations
+            )
+        else:
+            animating = ", ".join(anim["target"] for _, anim in self._animations)
         if animating:
             detail += f", animating {animating}"
         _say(f"Applied preset {name!r} ({detail})")
@@ -304,7 +326,7 @@ class PostProcessingController:
                 if self._authored_attrs or self._authored_apis:
                     self._clear_authored_usd()
             finally:
-                self._pending_rp_settings = []
+                self._pending_rp_settings = {}
                 self._pending_warned = False
                 # Must be cleared here, not only in _apply: the animation list is
                 # appended to, so a preset switch would otherwise keep driving the
@@ -412,7 +434,9 @@ class PostProcessingController:
         # defer instead of failing and let update() pick them up.
         products = self._render_products(prim_paths)
         if not products:
-            self._pending_rp_settings.append((tuple(prim_paths), key, value))
+            # Keyed, so an animated effect overwrites its own pending value
+            # every frame instead of queueing a new one.
+            self._pending_rp_settings[(tuple(prim_paths), key)] = value
             return
         for prim in products:
             self._author(prim, effect, value)
@@ -420,13 +444,13 @@ class PostProcessingController:
     def _flush_pending_render_product_settings(self):
         # Each entry keeps its own scope, so a preset where camera 1 needs a
         # render product and camera 2 does not cannot flush one onto the other.
-        still_pending = []
+        still_pending = {}
         flushed = 0
         touched = set()
-        for prim_paths, key, value in self._pending_rp_settings:
+        for (prim_paths, key), value in self._pending_rp_settings.items():
             products = self._render_products(prim_paths)
             if not products:
-                still_pending.append((prim_paths, key, value))
+                still_pending[(prim_paths, key)] = value
                 continue
             for prim in products:
                 self._author(prim, EFFECTS[key], value)
@@ -438,7 +462,7 @@ class PostProcessingController:
             _say(f"Applied {flushed} deferred setting(s) to {len(touched)} render product(s)")
         if still_pending and not self._pending_warned:
             self._pending_warned = True
-            keys = ", ".join(key for _, key, _ in still_pending)
+            keys = ", ".join(key for _, key in still_pending)
             _say(
                 f"{len(still_pending)} setting(s) waiting for render "
                 f"products (created on the first tick after Play): {keys}"
@@ -527,12 +551,20 @@ class PostProcessingController:
     # -- animation ---------------------------------------------------------
 
     def _advance_animation(self, now):
-        """Drive one float effect per frame, for flicker-style anomalies."""
+        """Drive one float effect per frame per scope, for flicker anomalies.
+
+        Every group reads the same `_animation_t0`, so two cameras asked for the
+        same frequency stay locked together; `phase_deg` is what pulls them
+        apart. 180 degrees gives the antiphase case — camera 1 at its brightest
+        exactly when camera 2 is at its dimmest — which a shared-t0-only design
+        could not express at all.
+        """
         for prim_paths, animation in self._animations:
             base = float(animation["base"])
             amplitude = float(animation["amplitude_fraction"])
             frequency = float(animation["frequency_hz"])
-            phase = 2.0 * math.pi * frequency * (now - self._animation_t0)
+            offset = math.radians(float(animation.get("phase_deg", 0.0)))
+            phase = 2.0 * math.pi * frequency * (now - self._animation_t0) + offset
             value = base * (1.0 + amplitude * math.sin(phase))
 
             key = animation["target"]
@@ -655,11 +687,11 @@ def _validate_preset(name, preset):
         if not all(isinstance(entry, str) and entry for entry in cameras):
             raise ValueError(f"preset {name!r}: 'cameras' entries must be names or prim paths")
 
-    _validate_animation(name, preset.get("animation"))
+    _validate_animation(name, preset.get("animation"), scoped=bool(cameras))
 
 
 def _validate_per_camera(name, preset, per_camera):
-    """Check a `per_camera:` preset — one settings block per camera."""
+    """Check a `per_camera:` preset — one settings/animation block per camera."""
     # Refusing the mixture is not pedantry: `cameras:`/`settings:` name a scope
     # too, and silently ignoring them would apply a preset the file does not
     # describe.
@@ -686,15 +718,12 @@ def _validate_per_camera(name, preset, per_camera):
         unknown = set(body) - {"description", "settings", "animation"}
         if unknown:
             raise ValueError(f"preset {where!r} has unsupported keys: {sorted(unknown)}")
-        if body.get("animation") is not None:
-            # Deliberately unsupported rather than half-supported: the phase
-            # clock and the flush path are shared, and an animated per_camera
-            # block has no test coverage. See README.
-            raise ValueError(
-                f"preset {where!r}: 'animation' inside per_camera is not supported yet; "
-                f"use a single-camera preset with 'cameras:' to animate"
-            )
         _validate_settings(where, body.get("settings"))
+        # The same rule as a classic preset's `animation:`, deliberately not a
+        # second one — a per_camera entry is just a scope, so its animation
+        # block has to accept and reject exactly what the top-level block does.
+        # `scoped=True` because a per_camera entry always names a camera.
+        _validate_animation(where, body.get("animation"), scoped=True)
 
 
 def _validate_settings(where, settings):
@@ -716,13 +745,26 @@ def _validate_settings(where, settings):
             raise ValueError(f"preset {where!r}: {key} must be three numbers")
 
 
-def _validate_animation(name, animation):
+def _validate_animation(name, animation, *, scoped=False):
+    """Check one `animation:` block, wherever it sits.
+
+    `scoped` says the block belongs to a group that names cameras — either
+    `cameras:` at preset level or a `per_camera:` entry — which is what makes
+    the render-product cost warning below apply.
+    """
     if animation is None:
         return
     if not isinstance(animation, dict):
         raise ValueError(f"preset {name!r}: 'animation' must be a mapping")
 
-    unknown = set(animation) - {"target", "waveform", "base", "amplitude_fraction", "frequency_hz"}
+    unknown = set(animation) - {
+        "target",
+        "waveform",
+        "base",
+        "amplitude_fraction",
+        "frequency_hz",
+        "phase_deg",
+    }
     if unknown:
         raise ValueError(f"preset {name!r}: animation has unsupported keys: {sorted(unknown)}")
 
@@ -742,3 +784,25 @@ def _validate_animation(name, animation):
         raise ValueError(f"preset {name!r}: animation.amplitude_fraction must be in [0, 1)")
     if animation["frequency_hz"] <= 0:
         raise ValueError(f"preset {name!r}: animation.frequency_hz must be > 0")
+
+    # Optional, default 0. Kept to one turn so two presets cannot describe the
+    # same offset two ways (350 and -10), which would make captures harder to
+    # compare than the field is worth.
+    phase_deg = animation.get("phase_deg", 0.0)
+    if not _is_number(phase_deg):
+        raise ValueError(f"preset {name!r}: animation.phase_deg must be a number")
+    if not 0 <= phase_deg < 360:
+        raise ValueError(f"preset {name!r}: animation.phase_deg must be in [0, 360)")
+
+    # A warning, not a rejection: it is a legal preset and someone will want a
+    # grain level that breathes on one camera. But it is the expensive corner of
+    # the design, so it should not be chosen by accident.
+    if scoped and EFFECTS[target].target == TARGET_RENDER_PRODUCT:
+        _say(
+            f"WARNING: preset {name!r}: animating {target} at per-camera scope costs a "
+            f"full stage traversal per animated scope PER FRAME, because render products "
+            f"are found by traversal rather than by name. A preset of this shape "
+            f"previously measured -7.0% FPS with the robot driving. Animate a "
+            f"camera-prim effect (exposure.iso) instead, or animate this one globally "
+            f"(drop cameras:/per_camera:), unless the per-camera scope is the point."
+        )

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/controller.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/controller.py
@@ -240,11 +240,13 @@ class PostProcessingController:
                 _say(f"WARNING: could not fully restore renderer state: {revert_exc}")
             # The rejected preset's animations would keep driving a value every
             # frame, and a stale name would make active_preset lie about it.
-            # Cleared here as well as in _revert(), because _clear_authored_usd()
-            # runs first in that finally and can raise before the resets below
-            # it — and the queued render-product writes are the reason this
-            # branch exists: update() flushes them on the first tick after Play,
-            # which would install the very preset just rejected.
+            # _revert() already clears both, and its state resets now run in
+            # their own finally, so they hold even when _clear_authored_usd()
+            # raises — this is belt and braces, not the guarantee it once was.
+            # Kept so the branch does not silently depend on that finally
+            # staying nested the way it is: what the queue holds is what
+            # update() would flush onto the render products on the first tick
+            # after Play, installing the very preset just rejected.
             self._animations = []
             self._pending_rp_settings = {}
             self._active_name = None

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/controller.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/controller.py
@@ -15,6 +15,12 @@ Two scopes, chosen per preset:
     prim and render product, which override the carb value for that camera
     alone. Use it for "camera 2 is degraded", the case an anomaly campaign
     actually cares about.
+  * per camera, one look each (`per_camera:` in the preset) — the same USD
+    authoring, but every camera carries its own `settings` block. Use it for
+    "camera 1 went dark WHILE camera 2 went grainy", which `cameras:` cannot
+    express: one `settings` block means every listed camera gets the same
+    degradation, and only one preset is active at a time, so applying two
+    single-camera presets in turn reverts the first.
 
 Per-camera scoping has one timing quirk worth knowing: the RTSP graph creates
 render products through `IsaacCreateRenderProduct`, which only runs on the
@@ -107,11 +113,12 @@ class PostProcessingController:
         self._authored_attrs = []   # (prim_path, attr_name)
         self._authored_apis = []    # (prim_path, api_name)
 
-        self._camera_prim_paths = []
+        # (camera_prim_paths, key, value) — carries its own scope, because two
+        # cameras in the same preset can now be waiting on different settings.
         self._pending_rp_settings = []
         self._pending_warned = False
 
-        self._animation = None
+        self._animations = []       # (camera_prim_paths, animation)
         self._animation_t0 = 0.0
 
     @property
@@ -145,7 +152,7 @@ class PostProcessingController:
             self._revert()
         except Exception as exc:
             _say(f"WARNING: could not fully restore renderer state: {exc}")
-        self._animation = None
+        self._animations = []
         self._active_name = None
 
     # -- config ------------------------------------------------------------
@@ -174,13 +181,15 @@ class PostProcessingController:
             _validate_preset(name, preset)
             # Resolved before anything is reverted: a bad camera name has to be
             # rejected like any other config error, leaving the preset that is
-            # currently degrading the scene untouched.
-            camera_prim_paths = self._resolve_scope(preset)
+            # currently degrading the scene untouched. Every group is resolved,
+            # not just the first, so one bad name in a `per_camera:` preset
+            # cannot strip the running preset off the other cameras.
+            groups = self._resolve_groups(preset)
             # Inside the try as well, because the apply layer raises too (a
             # KIND_COLOR3 value carb refuses, a closed stage, a USD authoring
             # error).
             entered_apply = True
-            self._apply(name, preset, camera_prim_paths)
+            self._apply(name, groups)
         except Exception as exc:
             # Remember the bad digest so a broken edit is reported once instead
             # of every poll — which also keeps a failing apply from retrying at
@@ -205,9 +214,15 @@ class PostProcessingController:
                 self._revert()
             except Exception as revert_exc:
                 _say(f"WARNING: could not fully restore renderer state: {revert_exc}")
-            # The rejected preset's animation would keep driving a value every
+            # The rejected preset's animations would keep driving a value every
             # frame, and a stale name would make active_preset lie about it.
-            self._animation = None
+            # Cleared here as well as in _revert(), because _clear_authored_usd()
+            # runs first in that finally and can raise before the resets below
+            # it — and the queued render-product writes are the reason this
+            # branch exists: update() flushes them on the first tick after Play,
+            # which would install the very preset just rejected.
+            self._animations = []
+            self._pending_rp_settings = []
             self._active_name = None
             # Forget the last good digest too. The usual recovery is to put the
             # file back the way it was, and that content still matches _digest —
@@ -229,30 +244,39 @@ class PostProcessingController:
 
     # -- apply / revert ----------------------------------------------------
 
-    def _apply(self, name, preset, camera_prim_paths):
+    def _apply(self, name, groups):
         # Revert first: switching presets must not leak the previous one's ISO,
         # gain or noise toggles into the new look.
         self._revert()
 
-        settings = preset.get("settings") or {}
-        self._camera_prim_paths = camera_prim_paths
-
-        if self._camera_prim_paths:
+        total = 0
+        scopes = []
+        for prim_paths, settings, animation in groups:
+            total += len(settings)
             for key, value in settings.items():
-                self._write_scoped(key, value)
-        else:
-            for key, value in settings.items():
-                self._settings.set(EFFECTS[key].carb_path, value)
+                if prim_paths:
+                    self._write_scoped(key, value, prim_paths)
+                else:
+                    self._settings.set(EFFECTS[key].carb_path, value)
+            if animation:
+                self._animations.append((prim_paths, animation))
+            scopes.append(", ".join(prim_paths) if prim_paths else "global")
 
-        self._animation = preset.get("animation")
         self._animation_t0 = self._clock()
         self._active_name = name
 
-        scope = ", ".join(self._camera_prim_paths) if self._camera_prim_paths else "global"
-        detail = f"{len(settings)} setting(s), scope={scope}"
-        if self._animation:
-            detail += f", animating {self._animation['target']}"
+        # One group keeps the historical wording byte for byte; several groups
+        # are separated by "; " so the log distinguishes "these cameras share a
+        # look" from "each camera has its own".
+        detail = f"{total} setting(s), scope={'; '.join(scopes)}"
+        animating = ", ".join(anim["target"] for _, anim in self._animations)
+        if animating:
+            detail += f", animating {animating}"
         _say(f"Applied preset {name!r} ({detail})")
+        if len(groups) > 1:
+            for prim_paths, settings, _ in groups:
+                keys = ", ".join(sorted(settings)) or "nothing"
+                _say(f"  {', '.join(prim_paths) or 'global'}: {keys}")
 
     def _revert(self):
         # Two phases, and the USD one must not be hostage to the carb one: a
@@ -282,7 +306,10 @@ class PostProcessingController:
             finally:
                 self._pending_rp_settings = []
                 self._pending_warned = False
-                self._camera_prim_paths = []
+                # Must be cleared here, not only in _apply: the animation list is
+                # appended to, so a preset switch would otherwise keep driving the
+                # previous preset's target on top of the new one.
+                self._animations = []
 
     def _snapshot_carb(self):
         for key, effect in EFFECTS.items():
@@ -291,37 +318,60 @@ class PostProcessingController:
 
     # -- per-camera authoring ---------------------------------------------
 
-    def _resolve_scope(self, preset):
-        """Camera prim paths for a per-camera preset; empty list means global.
+    def _resolve_groups(self, preset):
+        """Resolve every scope of a preset to (prim_paths, settings, animation).
 
-        Also proves the prims exist, so `_apply` cannot fail halfway through
-        and leave the scene wearing half a preset.
+        `prim_paths` is empty for a global group. Resolving all of them up
+        front proves the prims exist, so `_apply` cannot fail halfway through
+        and leave the scene wearing half a preset — and, for `per_camera:`, so
+        one unknown camera name rejects the whole edit instead of degrading
+        some cameras and not others.
         """
-        cameras = preset.get("cameras") or []
-        if not cameras:
-            return []
-        paths = self._resolve_camera_prims(cameras)
-        stage = self._stage()
-        missing = [p for p in paths if not stage.GetPrimAtPath(p).IsValid()]
-        if missing:
-            raise ValueError(f"camera prim(s) not on stage: {', '.join(missing)}")
-        return paths
+        by_name = {}
+        resolved = []
+        seen = {}
+        groups = _preset_groups(preset)
+        for cameras, settings, animation in groups:
+            if not cameras:
+                resolved.append(([], settings, animation))
+                continue
+            paths = self._resolve_camera_prims(cameras, by_name)
+            stage = self._stage()
+            missing = [p for p in paths if not stage.GetPrimAtPath(p).IsValid()]
+            if missing:
+                raise ValueError(f"camera prim(s) not on stage: {', '.join(missing)}")
+            if len(groups) > 1:
+                # Two per_camera keys can name the same camera (a name and its
+                # prim path), and the loser would be silently overwritten.
+                for path, entry in zip(paths, cameras):
+                    if path in seen:
+                        raise ValueError(
+                            f"per_camera entries {seen[path]!r} and {entry!r} "
+                            f"both resolve to {path}"
+                        )
+                    seen[path] = entry
+            resolved.append((paths, settings, animation))
+        return resolved
 
-    def _resolve_camera_prims(self, cameras):
+    def _resolve_camera_prims(self, cameras, by_name=None):
         """Map preset `cameras:` entries to camera prim paths.
 
         An entry starting with "/" is taken as a prim path; anything else is
         looked up as a camera `name` in cameras.yaml, so a preset can say
         `Camera_01` instead of repeating the full prim path.
+
+        `by_name` is a cache shared across the groups of one preset, so a
+        `per_camera:` block does not re-read cameras.yaml once per camera.
         """
         paths = []
-        by_name = None
+        if by_name is None:
+            by_name = {}
         for entry in cameras:
             if entry.startswith("/"):
                 paths.append(entry)
                 continue
-            if by_name is None:
-                by_name = self._load_camera_name_map()
+            if not by_name:
+                by_name.update(self._load_camera_name_map())
             prim_path = by_name.get(entry)
             if prim_path is None:
                 known = ", ".join(sorted(by_name)) or "none"
@@ -347,11 +397,11 @@ class PostProcessingController:
             if "name" in cam and "camera_prim" in cam
         }
 
-    def _write_scoped(self, key, value):
+    def _write_scoped(self, key, value, prim_paths):
         effect = EFFECTS[key]
         if effect.target == TARGET_CAMERA:
             stage = self._stage()
-            for prim_path in self._camera_prim_paths:
+            for prim_path in prim_paths:
                 prim = stage.GetPrimAtPath(prim_path)
                 if not prim or not prim.IsValid():
                     raise RuntimeError(f"camera prim missing on stage: {prim_path}")
@@ -360,35 +410,44 @@ class PostProcessingController:
 
         # Render products do not exist until the first tick after Play, so
         # defer instead of failing and let update() pick them up.
-        products = self._render_products()
+        products = self._render_products(prim_paths)
         if not products:
-            self._pending_rp_settings.append((key, value))
+            self._pending_rp_settings.append((tuple(prim_paths), key, value))
             return
         for prim in products:
             self._author(prim, effect, value)
 
     def _flush_pending_render_product_settings(self):
-        products = self._render_products()
-        if not products:
-            if not self._pending_warned:
-                self._pending_warned = True
-                keys = ", ".join(key for key, _ in self._pending_rp_settings)
-                _say(
-                    f"{len(self._pending_rp_settings)} setting(s) waiting for render "
-                    f"products (created on the first tick after Play): {keys}"
-                )
-            return
-
-        pending, self._pending_rp_settings = self._pending_rp_settings, []
-        for key, value in pending:
+        # Each entry keeps its own scope, so a preset where camera 1 needs a
+        # render product and camera 2 does not cannot flush one onto the other.
+        still_pending = []
+        flushed = 0
+        touched = set()
+        for prim_paths, key, value in self._pending_rp_settings:
+            products = self._render_products(prim_paths)
+            if not products:
+                still_pending.append((prim_paths, key, value))
+                continue
             for prim in products:
                 self._author(prim, EFFECTS[key], value)
-        _say(f"Applied {len(pending)} deferred setting(s) to {len(products)} render product(s)")
+                touched.add(str(prim.GetPath()))
+            flushed += 1
+        self._pending_rp_settings = still_pending
 
-    def _render_products(self):
-        """Render product prims bound to the preset's cameras."""
+        if flushed:
+            _say(f"Applied {flushed} deferred setting(s) to {len(touched)} render product(s)")
+        if still_pending and not self._pending_warned:
+            self._pending_warned = True
+            keys = ", ".join(key for _, key, _ in still_pending)
+            _say(
+                f"{len(still_pending)} setting(s) waiting for render "
+                f"products (created on the first tick after Play): {keys}"
+            )
+
+    def _render_products(self, prim_paths):
+        """Render product prims bound to the given cameras."""
         stage = self._stage()
-        wanted = set(self._camera_prim_paths)
+        wanted = set(prim_paths)
         found = []
         for prim in stage.Traverse():
             if prim.GetTypeName() != "RenderProduct":
@@ -469,19 +528,18 @@ class PostProcessingController:
 
     def _advance_animation(self, now):
         """Drive one float effect per frame, for flicker-style anomalies."""
-        if not self._animation:
-            return
-        base = float(self._animation["base"])
-        amplitude = float(self._animation["amplitude_fraction"])
-        frequency = float(self._animation["frequency_hz"])
-        phase = 2.0 * math.pi * frequency * (now - self._animation_t0)
-        value = base * (1.0 + amplitude * math.sin(phase))
+        for prim_paths, animation in self._animations:
+            base = float(animation["base"])
+            amplitude = float(animation["amplitude_fraction"])
+            frequency = float(animation["frequency_hz"])
+            phase = 2.0 * math.pi * frequency * (now - self._animation_t0)
+            value = base * (1.0 + amplitude * math.sin(phase))
 
-        key = self._animation["target"]
-        if self._camera_prim_paths:
-            self._write_scoped(key, value)
-        else:
-            self._settings.set(EFFECTS[key].carb_path, value)
+            key = animation["target"]
+            if prim_paths:
+                self._write_scoped(key, value, prim_paths)
+            else:
+                self._settings.set(EFFECTS[key].carb_path, value)
 
 
 # -- helpers ---------------------------------------------------------------
@@ -554,26 +612,41 @@ def _select_preset(config, override=None):
     return active, preset
 
 
+def _preset_groups(preset):
+    """Split a preset into its scopes: [(cameras, settings, animation)].
+
+    A classic preset is one group — global when `cameras:` is absent, one
+    shared per-camera group when it is present. A `per_camera:` preset is one
+    group per camera, which is what lets camera 1 go dark while camera 2 goes
+    grainy in the same apply. Pure data, no Kit: the caller resolves the camera
+    entries to prim paths.
+    """
+    per_camera = preset.get("per_camera")
+    if per_camera:
+        return [
+            ([camera], (body or {}).get("settings") or {}, (body or {}).get("animation"))
+            for camera, body in per_camera.items()
+        ]
+    return [
+        (
+            list(preset.get("cameras") or []),
+            preset.get("settings") or {},
+            preset.get("animation"),
+        )
+    ]
+
+
 def _validate_preset(name, preset):
-    unknown = set(preset) - {"description", "settings", "cameras", "animation"}
+    unknown = set(preset) - {"description", "settings", "cameras", "animation", "per_camera"}
     if unknown:
         raise ValueError(f"preset {name!r} has unsupported keys: {sorted(unknown)}")
 
-    settings = preset.get("settings") or {}
-    if not isinstance(settings, dict):
-        raise ValueError(f"preset {name!r}: 'settings' must be a mapping")
-    for key, value in settings.items():
-        effect = EFFECTS.get(key)
-        if effect is None:
-            raise ValueError(f"preset {name!r}: unknown setting {key!r}")
-        if effect.kind == KIND_BOOL and not isinstance(value, bool):
-            raise ValueError(f"preset {name!r}: {key} must be true or false")
-        if effect.kind == KIND_FLOAT and not _is_number(value):
-            raise ValueError(f"preset {name!r}: {key} must be a number")
-        if effect.kind == KIND_COLOR3 and not (
-            isinstance(value, (list, tuple)) and len(value) == 3 and all(_is_number(v) for v in value)
-        ):
-            raise ValueError(f"preset {name!r}: {key} must be three numbers")
+    per_camera = preset.get("per_camera")
+    if per_camera is not None:
+        _validate_per_camera(name, preset, per_camera)
+        return
+
+    _validate_settings(name, preset.get("settings"))
 
     cameras = preset.get("cameras")
     if cameras is not None:
@@ -582,7 +655,68 @@ def _validate_preset(name, preset):
         if not all(isinstance(entry, str) and entry for entry in cameras):
             raise ValueError(f"preset {name!r}: 'cameras' entries must be names or prim paths")
 
-    animation = preset.get("animation")
+    _validate_animation(name, preset.get("animation"))
+
+
+def _validate_per_camera(name, preset, per_camera):
+    """Check a `per_camera:` preset — one settings block per camera."""
+    # Refusing the mixture is not pedantry: `cameras:`/`settings:` name a scope
+    # too, and silently ignoring them would apply a preset the file does not
+    # describe.
+    conflicting = sorted(k for k in ("cameras", "settings", "animation") if k in preset)
+    if conflicting:
+        raise ValueError(
+            f"preset {name!r}: 'per_camera' cannot be combined with {conflicting}; "
+            f"move each of those under a per_camera entry"
+        )
+    if not isinstance(per_camera, dict) or not per_camera:
+        raise ValueError(
+            f"preset {name!r}: 'per_camera' must be a non-empty mapping of "
+            f"camera name or prim path to {{settings: ...}}"
+        )
+
+    for camera, body in per_camera.items():
+        where = f"{name}.per_camera.{camera}"
+        if not isinstance(camera, str) or not camera:
+            raise ValueError(f"preset {name!r}: per_camera keys must be names or prim paths")
+        if body is None:
+            body = {}
+        if not isinstance(body, dict):
+            raise ValueError(f"preset {where!r}: must be a mapping")
+        unknown = set(body) - {"description", "settings", "animation"}
+        if unknown:
+            raise ValueError(f"preset {where!r} has unsupported keys: {sorted(unknown)}")
+        if body.get("animation") is not None:
+            # Deliberately unsupported rather than half-supported: the phase
+            # clock and the flush path are shared, and an animated per_camera
+            # block has no test coverage. See README.
+            raise ValueError(
+                f"preset {where!r}: 'animation' inside per_camera is not supported yet; "
+                f"use a single-camera preset with 'cameras:' to animate"
+            )
+        _validate_settings(where, body.get("settings"))
+
+
+def _validate_settings(where, settings):
+    if settings is None:
+        settings = {}
+    if not isinstance(settings, dict):
+        raise ValueError(f"preset {where!r}: 'settings' must be a mapping")
+    for key, value in settings.items():
+        effect = EFFECTS.get(key)
+        if effect is None:
+            raise ValueError(f"preset {where!r}: unknown setting {key!r}")
+        if effect.kind == KIND_BOOL and not isinstance(value, bool):
+            raise ValueError(f"preset {where!r}: {key} must be true or false")
+        if effect.kind == KIND_FLOAT and not _is_number(value):
+            raise ValueError(f"preset {where!r}: {key} must be a number")
+        if effect.kind == KIND_COLOR3 and not (
+            isinstance(value, (list, tuple)) and len(value) == 3 and all(_is_number(v) for v in value)
+        ):
+            raise ValueError(f"preset {where!r}: {key} must be three numbers")
+
+
+def _validate_animation(name, animation):
     if animation is None:
         return
     if not isinstance(animation, dict):

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/controller.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/controller.py
@@ -668,6 +668,24 @@ def _preset_groups(preset):
     ]
 
 
+def _fold_camera_key(entry):
+    """Fold the spellings of one camera entry that are equal without a stage.
+
+    Returns `(folded, is_prim_path)`. Surrounding whitespace goes, and a prim
+    path loses its repeated and trailing slashes, so `/World/Cameras/Camera_01`,
+    `/World/Cameras/Camera_01/` and `//World//Cameras/Camera_01` fold together.
+    A bare name is only stripped: turning it into a path needs cameras.yaml.
+
+    Only used for duplicate detection, never for resolution — Kit resolves the
+    entry as written, and a folded form that differed from it would quietly
+    mean something else.
+    """
+    entry = entry.strip()
+    if not entry.startswith("/"):
+        return entry, False
+    return "/" + "/".join(part for part in entry.split("/") if part), True
+
+
 def _validate_preset(name, preset):
     unknown = set(preset) - {"description", "settings", "cameras", "animation", "per_camera"}
     if unknown:
@@ -707,10 +725,28 @@ def _validate_per_camera(name, preset, per_camera):
             f"camera name or prim path to {{settings: ...}}"
         )
 
+    # Two keys naming one camera means one of the two blocks is silently
+    # discarded — the second `_apply` write wins and nothing says so. Kit
+    # catches every spelling of it in `_resolve_groups`, but only once a stage
+    # is open, which is too late to be a lint. Fold what can be folded without
+    # a stage here, and say plainly below what is left over.
+    seen = {}
+    by_basename = {}
+
     for camera, body in per_camera.items():
         where = f"{name}.per_camera.{camera}"
         if not isinstance(camera, str) or not camera:
             raise ValueError(f"preset {name!r}: per_camera keys must be names or prim paths")
+
+        folded, is_path = _fold_camera_key(camera)
+        if folded in seen:
+            raise ValueError(
+                f"preset {name!r}: per_camera entries {seen[folded]!r} and {camera!r} "
+                f"name the same camera"
+            )
+        seen[folded] = camera
+        by_basename.setdefault(folded.rsplit("/", 1)[-1], []).append((camera, is_path))
+
         if body is None:
             body = {}
         if not isinstance(body, dict):
@@ -724,6 +760,25 @@ def _validate_per_camera(name, preset, per_camera):
         # block has to accept and reject exactly what the top-level block does.
         # `scoped=True` because a per_camera entry always names a camera.
         _validate_animation(where, body.get("animation"), scoped=True)
+
+    # The case this layer cannot decide: a bare name resolves through
+    # cameras.yaml, which is not read here, so `Camera_01` and
+    # `/World/Cameras/Camera_01` MIGHT be the same prim or might not. Rejecting
+    # on the matching last path component would refuse presets Kit accepts,
+    # which is worse than the miss — an offline check that is stricter than the
+    # runtime stops being usable as a lint. Warn and name both keys instead;
+    # `_resolve_groups` still rejects it for certain, on a stage.
+    for basename, entries in by_basename.items():
+        forms = {is_path for _camera, is_path in entries}
+        if len(forms) > 1:
+            spellings = ", ".join(repr(camera) for camera, _is_path in entries)
+            _say(
+                f"WARNING: preset {name!r}: per_camera entries {spellings} both end in "
+                f"{basename!r}. If cameras.yaml maps that name to that prim path they are "
+                f"one camera with two blocks, and only one of them will apply — this check "
+                f"cannot tell without a stage, so the run rejects the preset at apply time. "
+                f"Spell every entry the same way."
+            )
 
 
 def _validate_settings(where, settings):

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/test_animation.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/test_animation.py
@@ -1,0 +1,295 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Pure-Python checks for the per-camera animator. No Kit, no numpy, no pytest.
+
+Run it from `sil/scripts/`:
+
+    python3 -m postprocessing.test_animation
+
+The controller's config layer (`_select_preset`, `_validate_preset`,
+`_preset_groups`, `_validate_*`) and `_advance_animation` deliberately import
+nothing from carb or pxr, which is what makes this runnable on a laptop. The
+Kit-only paths are stubbed: `_write_scoped` is replaced with a recorder, so the
+groups carry fake prim paths and no stage is needed.
+
+These are checks of the animator MATH under a synthetic clock. They say nothing
+about what an RTSP consumer receives — that needs a live capture.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import sys
+
+from .controller import (
+    PostProcessingController,
+    _preset_groups,
+    _select_preset,
+    _validate_preset,
+)
+
+CONFIG = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "configs",
+    "postprocessing.yaml",
+)
+
+
+def _load_presets(path=CONFIG):
+    import yaml
+
+    with open(path) as stream:
+        return yaml.safe_load(stream) or {}
+
+
+class _Recorder:
+    """Stands in for the whole Kit side: records what the animator would write."""
+
+    def __init__(self):
+        self.writes = []  # (t, prim_paths, key, value)
+        self.now = 0.0
+
+    def set(self, path, value):  # carb settings surface, for global groups
+        self.writes.append((self.now, (), path, value))
+
+
+def _controller_for(preset, recorder):
+    """A controller wired to a fake clock, with the groups injected directly.
+
+    `_resolve_groups` is skipped on purpose: it needs a USD stage to prove the
+    camera prims exist. The animator does not care what the paths are, so the
+    preset's camera names are used as the paths.
+    """
+    controller = PostProcessingController(
+        config_path=CONFIG, settings=recorder, clock=lambda: recorder.now
+    )
+    controller._animations = [
+        (list(cameras), animation)
+        for cameras, _settings, animation in _preset_groups(preset)
+        if animation
+    ]
+    controller._animation_t0 = 0.0
+
+    def _record(key, value, prim_paths):
+        recorder.writes.append((recorder.now, tuple(prim_paths), key, value))
+
+    controller._write_scoped = _record
+    return controller
+
+
+def _sample(preset, times):
+    """Run `_advance_animation` at each t; return {prim_paths: [(t, value)]}."""
+    recorder = _Recorder()
+    controller = _controller_for(preset, recorder)
+    for t in times:
+        recorder.now = t
+        controller._advance_animation(t)
+
+    series = {}
+    for t, prim_paths, _key, value in recorder.writes:
+        series.setdefault(prim_paths, []).append((t, value))
+    return series
+
+
+def _dft_magnitude(values, sample_rate, frequency):
+    """One bin of a DFT, evaluated directly. Five lines instead of a numpy dep."""
+    mean = sum(values) / len(values)
+    real = imag = 0.0
+    for index, value in enumerate(values):
+        angle = 2.0 * math.pi * frequency * index / sample_rate
+        centred = value - mean
+        real += centred * math.cos(angle)
+        imag -= centred * math.sin(angle)
+    return math.hypot(real, imag) / len(values)
+
+
+# -- checks ----------------------------------------------------------------
+
+
+def check_backward_compatible(presets):
+    """`flicker` has no phase_deg, so it must be bit-identical to the old math."""
+    preset = presets["flicker"]
+    times = [i / 30.0 for i in range(90)]
+    series = _sample(preset, times)
+    assert list(series) == [()], f"flicker must stay a single global group, got {list(series)}"
+
+    worst = 0.0
+    for t, value in series[()]:
+        expected = 100.0 * (1.0 + 0.35 * math.sin(2.0 * math.pi * 2.0 * t))
+        worst = max(worst, abs(value - expected))
+    assert worst == 0.0, f"flicker drifted from the pre-phase_deg formula by {worst}"
+    print(f"  flicker (global, no phase_deg): max deviation from old formula {worst:.1e}")
+
+
+def check_antiphase(presets):
+    """Two 1 Hz groups 180 deg apart must stay symmetric about base."""
+    preset = presets["anim_antiphase"]
+    # 37 samples over one cycle, offset so none lands on a zero crossing.
+    times = [0.013 + i / 36.0 for i in range(37)]
+    series = _sample(preset, times)
+    assert len(series) == 2, f"expected two scopes, got {list(series)}"
+
+    (paths_a, first), (paths_b, second) = sorted(series.items())
+    base = 100.0
+    worst_residual = 0.0
+    worst_at = None
+    for (t, value_a), (_, value_b) in zip(first, second):
+        residual = abs(value_a + value_b - 2.0 * base)
+        if residual > worst_residual:
+            worst_residual, worst_at = residual, t
+
+    values_a = [v for _, v in first]
+    swing_a = max(values_a) - min(values_a)
+    values_b = [v for _, v in second]
+    swing_b = max(values_b) - min(values_b)
+
+    print(
+        f"  {paths_a[0]} vs {paths_b[0]}: max |v1+v2-2*base| = {worst_residual:.3e} "
+        f"(at t={worst_at:.4f}s) over {len(first)} samples"
+    )
+    # The continuous swing is 2*0.35*100 = 70.0; 37 samples per cycle never land
+    # exactly on the crest, so the observed swing sits just under it. What
+    # matters is that it is nowhere near zero — otherwise "symmetric about base"
+    # would be true of two flat lines.
+    print(
+        f"    peak-to-peak swing {swing_a:.3f} and {swing_b:.3f} ISO "
+        f"(continuous ideal 70.000; discrete sampling misses the crest)"
+    )
+    assert worst_residual < 1e-9, f"antiphase residual too large: {worst_residual}"
+    assert swing_a > 69.0 and swing_b > 69.0, "signal did not actually swing"
+
+
+def check_two_frequencies(presets):
+    """Two groups at 1 Hz and 3 Hz must show up as exactly those, independently."""
+    preset = presets["anim_two_freq"]
+    # fs = 60 Hz, N = 600 -> 0.1 Hz bin spacing, so 1.0 and 3.0 are exact bins.
+    sample_rate, count = 60.0, 600
+    times = [i / sample_rate for i in range(count)]
+    series = _sample(preset, times)
+    assert len(series) == 2, f"expected two scopes, got {list(series)}"
+
+    for paths, samples in sorted(series.items()):
+        values = [v for _, v in samples]
+        bins = [(k * 0.1, _dft_magnitude(values, sample_rate, k * 0.1)) for k in range(1, 100)]
+        bins.sort(key=lambda item: item[1], reverse=True)
+        (peak_hz, peak_mag), (next_hz, next_mag) = bins[0], bins[1]
+        ratio = peak_mag / next_mag if next_mag else float("inf")
+        print(
+            f"  {paths[0]}: peak {peak_hz:.1f} Hz mag {peak_mag:.4f}; "
+            f"runner-up {next_hz:.1f} Hz mag {next_mag:.2e} (ratio {ratio:.3g}x)"
+        )
+        expected = 1.0 if paths[0].endswith("01") else 3.0
+        assert abs(peak_hz - expected) < 1e-9, f"{paths[0]} peaked at {peak_hz}, want {expected}"
+        assert ratio > 1e6, f"{paths[0]} spectrum is not clean: ratio {ratio}"
+
+
+def check_cross_term(presets):
+    """An animated group must not write to a group that only has static settings."""
+    preset = presets["anim_mixed"]
+    series = _sample(preset, [i / 30.0 for i in range(60)])
+    scopes = sorted(series)
+    print(f"  animated scopes touched by anim_mixed: {[s[0] for s in scopes]}")
+    assert scopes == [("Camera_01",)], f"animator touched an unanimated camera: {scopes}"
+
+
+def check_rp_warning(presets):
+    """`anim_rp_target` must validate (not reject) and emit exactly one WARNING."""
+    import io
+    import contextlib
+
+    captured = io.StringIO()
+    with contextlib.redirect_stdout(captured):
+        _validate_preset("anim_rp_target", presets["anim_rp_target"])
+    lines = [line for line in captured.getvalue().splitlines() if "WARNING" in line]
+    assert len(lines) == 1, f"expected exactly one WARNING, got {len(lines)}"
+    assert "-7.0% FPS" in lines[0], "the warning must quote the measured cost"
+    print(f"  accepted with 1 warning: {lines[0][:96]}...")
+
+    # The same target animated GLOBALLY is not expensive and must stay quiet.
+    quiet = io.StringIO()
+    with contextlib.redirect_stdout(quiet):
+        _validate_preset(
+            "global_grain",
+            {
+                "settings": {"tv_noise.enabled": True},
+                "animation": {
+                    "target": "tv_noise.film_grain.amount",
+                    "base": 0.12,
+                    "amplitude_fraction": 0.5,
+                    "frequency_hz": 0.5,
+                },
+            },
+        )
+    assert "WARNING" not in quiet.getvalue(), "global scope must not warn"
+    print("  same target at global scope: no warning (correct — no traversal)")
+
+
+def check_phase_validation():
+    """phase_deg is optional, numeric and bounded."""
+    def build(**animation):
+        block = {
+            "target": "exposure.iso",
+            "base": 100.0,
+            "amplitude_fraction": 0.35,
+            "frequency_hz": 1.0,
+        }
+        block.update(animation)
+        return {"settings": {}, "animation": block}
+
+    _validate_preset("ok_default", build())
+    _validate_preset("ok_zero", build(phase_deg=0))
+    _validate_preset("ok_high", build(phase_deg=359.9))
+    for bad in (360, -1, "90", True):
+        try:
+            _validate_preset("bad", build(phase_deg=bad))
+        except ValueError:
+            continue
+        raise AssertionError(f"phase_deg={bad!r} should have been rejected")
+    print("  phase_deg: default/0/359.9 accepted; 360, -1, '90', true rejected")
+
+
+def check_every_preset(config):
+    """Every preset in the shipped config must validate."""
+    ok, bad = [], []
+    for name, preset in config["presets"].items():
+        try:
+            _validate_preset(name, preset or {})
+            ok.append(name)
+        except Exception as exc:  # noqa: BLE001 - report, do not raise
+            bad.append((name, exc))
+    print(f"  {len(ok)} preset(s) valid, {len(bad)} rejected")
+    for name, exc in bad:
+        print(f"    REJECTED {name}: {exc}")
+    assert not bad, "shipped config has invalid presets"
+
+    name, preset = _select_preset(config)
+    print(f"  active preset {name!r} selects cleanly ({len(_preset_groups(preset))} group(s))")
+
+
+def main():
+    config = _load_presets()
+    presets = config["presets"]
+    checks = (
+        ("every shipped preset validates", lambda: check_every_preset(config)),
+        ("backward compatibility (flicker)", lambda: check_backward_compatible(presets)),
+        ("antiphase symmetry", lambda: check_antiphase(presets)),
+        ("two independent frequencies", lambda: check_two_frequencies(presets)),
+        ("no cross-term onto a static camera", lambda: check_cross_term(presets)),
+        ("render-product cost warning", lambda: check_rp_warning(presets)),
+        ("phase_deg validation", check_phase_validation),
+    )
+    failed = 0
+    for title, run in checks:
+        print(f"[{title}]")
+        try:
+            run()
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL: {exc}")
+    print(f"\n{len(checks) - failed}/{len(checks)} checks passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/test_animation.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/test_animation.py
@@ -249,6 +249,48 @@ def check_phase_validation():
     print("  phase_deg: default/0/359.9 accepted; 360, -1, '90', true rejected")
 
 
+def check_duplicate_camera_keys():
+    """Two per_camera keys naming one camera: rejected when that is decidable."""
+    def preset(*cameras):
+        return {"per_camera": {camera: {"settings": {"exposure.iso": 50.0}} for camera in cameras}}
+
+    decidable = [
+        ("trailing slash", "/World/Cameras/Camera_01", "/World/Cameras/Camera_01/"),
+        ("doubled slash", "/World/Cameras/Camera_01", "//World//Cameras/Camera_01"),
+        ("padded name", "Camera_01", " Camera_01"),
+    ]
+    for label, first, second in decidable:
+        try:
+            _validate_preset("dup", preset(first, second))
+        except ValueError as exc:
+            assert "name the same camera" in str(exc), f"{label}: wrong error {exc}"
+            continue
+        raise AssertionError(f"{label}: {first!r} + {second!r} should have been rejected")
+    print(f"  rejected {len(decidable)} decidable duplicate spelling(s): "
+          f"{', '.join(label for label, _f, _s in decidable)}")
+
+    # Not decidable without cameras.yaml: warn, do not reject. Rejecting would
+    # make the offline layer refuse presets Kit accepts.
+    import io
+    import contextlib
+
+    captured = io.StringIO()
+    with contextlib.redirect_stdout(captured):
+        _validate_preset("maybe_dup", preset("Camera_01", "/World/Cameras/Camera_01"))
+    warnings = [line for line in captured.getvalue().splitlines() if "WARNING" in line]
+    assert len(warnings) == 1, f"expected one warning, got {warnings}"
+    assert "Camera_01" in warnings[0], warnings[0]
+    print("  name-vs-prim-path pair: accepted with 1 warning (Kit decides), not rejected")
+
+    # Two genuinely different cameras that share a last path component must
+    # stay silent, or the warning is noise.
+    quiet = io.StringIO()
+    with contextlib.redirect_stdout(quiet):
+        _validate_preset("distinct", preset("/World/A/Camera_01", "/World/B/Camera_01"))
+    assert "WARNING" not in quiet.getvalue(), quiet.getvalue()
+    print("  two prim paths sharing a leaf name: no warning (correct — different prims)")
+
+
 def check_every_preset(config):
     """Every preset in the shipped config must validate."""
     ok, bad = [], []
@@ -278,6 +320,7 @@ def main():
         ("no cross-term onto a static camera", lambda: check_cross_term(presets)),
         ("render-product cost warning", lambda: check_rp_warning(presets)),
         ("phase_deg validation", check_phase_validation),
+        ("duplicate per_camera keys", check_duplicate_camera_keys),
     )
     failed = 0
     for title, run in checks:

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/test_controller.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/test_controller.py
@@ -13,7 +13,8 @@ real and Kit is replaced at the module boundary instead: fake `pxr` and
 `omni.usd` modules are installed in `sys.modules`, so `_stage`, `_author`,
 `_clear_authored_usd` and `_render_products` are the shipped implementations
 running against a fake stage. That matters for the bookkeeping they own — the
-`_authored_attrs` dedupe under animation, and the pending store's size — which a
+`_authored_attrs` dedupe under animation, the order that ledger is written in
+relative to the write it describes, and the pending store's size — which a
 hand-written stub would have to re-implement to test, and would then be testing
 itself.
 
@@ -45,6 +46,9 @@ class _FakeAttribute:
         self._name = name
 
     def Set(self, value):
+        error = self._prim.set_errors.get(self._name)
+        if error is not None:
+            raise error
         self._prim.attributes[self._name] = value
 
 
@@ -68,6 +72,10 @@ class _FakePrim:
         self.removed_properties = []
         self.removed_schemas = []
         self.remove_property_error = None
+        # attr name -> exception, raised from Set(). The attribute is still
+        # created first, because CreateAttribute is what authors it in USD and
+        # that is what a failed write leaves behind.
+        self.set_errors = {}
         self._camera_target = camera_target
 
     # -- read
@@ -574,6 +582,54 @@ def check_reject_mid_apply_reverts():
         harness.close()
 
 
+def check_failed_usd_write_is_recorded_before_it_runs():
+    """A USD write that raises must already be in the ledger when it does.
+
+    `CreateAttribute` is what authors the attribute, not `Set()`, so a `Set()`
+    that raises leaves the attribute on the prim. Bookkeeping that runs after
+    the write therefore misses exactly the attribute the failure left behind:
+    `_clear_authored_usd()` never sees it, and it outlives every `_revert()`
+    and `close()` for the life of the process while `active_preset` reports
+    None -- one camera quietly degraded, nothing in the logs naming it.
+
+    The check above drives its mid-apply failure through carb at global scope,
+    which never enters `_author()` at all, so it holds whichever order the two
+    lines are in. This one fails if they are swapped back.
+    """
+    harness = _Harness(config_text=MIXED_CONFIG, with_render_products=True)
+    try:
+        controller = harness.controller
+        cam1 = harness.stage.prims[CAM1]
+        iso_attr = EFFECTS["exposure.iso"].usd_attr
+        # The second write on this camera, so one attribute is already recorded
+        # and what is measured is the failing write rather than an empty ledger.
+        cam1.set_errors[iso_attr] = RuntimeError("USD refused the value")
+
+        log = harness.start()
+
+        assert "reverted the renderer" in log, log
+        assert controller.active_preset is None, controller.active_preset
+        # What the revert removed is what the ledger held: _clear_authored_usd()
+        # walks _authored_attrs and nothing else.
+        assert iso_attr in cam1.removed_properties, (
+            f"the failed write was never recorded: the revert removed "
+            f"{cam1.removed_properties} and left {iso_attr} behind"
+        )
+        orphans = sorted(cam1.attributes)
+        assert not orphans, (
+            f"{orphans} survived the revert: CreateAttribute authored {iso_attr} "
+            f"before Set() raised, so recording it only after Set() returns puts "
+            f"it out of reach of every later cleanup"
+        )
+        assert not cam1.schemas, f"applied API schemas survived: {cam1.schemas}"
+        print(
+            f"  Set() raised on {iso_attr}: recorded before the write, "
+            f"removed by the revert, prim clean"
+        )
+    finally:
+        harness.close()
+
+
 def check_config_error_keeps_running_preset():
     """A config error before the apply must leave the live preset alone."""
     harness = _Harness(config_text=MIXED_CONFIG, with_render_products=True)
@@ -628,6 +684,7 @@ def main():
         ("revert clears carb, USD, pending and animations", check_revert_clears_everything),
         ("pending cleared when the USD cleanup raises", check_pending_cleared_when_usd_cleanup_raises),
         ("mid-apply failure reverts to the baseline", check_reject_mid_apply_reverts),
+        ("a failed USD write is recorded before it runs", check_failed_usd_write_is_recorded_before_it_runs),
         ("config error keeps the running preset", check_config_error_keeps_running_preset),
     )
     failed = 0

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/test_controller.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/test_controller.py
@@ -1,0 +1,646 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Pure-Python checks for apply / revert / deferred-write bookkeeping.
+
+Run it from `sil/scripts/`:
+
+    python3 -m postprocessing.test_controller
+
+`test_animation.py` injects `_animations` directly, so it never executes
+`_apply`, `_revert`, `_resolve_groups` or the pending render-product store —
+which is exactly the state this module is about. Here the controller runs for
+real and Kit is replaced at the module boundary instead: fake `pxr` and
+`omni.usd` modules are installed in `sys.modules`, so `_stage`, `_author`,
+`_clear_authored_usd` and `_render_products` are the shipped implementations
+running against a fake stage. That matters for the bookkeeping they own — the
+`_authored_attrs` dedupe under animation, and the pending store's size — which a
+hand-written stub would have to re-implement to test, and would then be testing
+itself.
+
+The fake stage counts `Traverse()` calls, because "one traversal per animated
+render-product scope per frame" is a claim in the README, the config comments
+and the load-time WARNING, and it is the kind of claim that rots silently.
+
+These checks say nothing about what Kit does with the values, only about what
+the controller asks it to do, when, and how many times.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import sys
+import tempfile
+import types
+
+from .effects import EFFECTS
+
+# -- fake Kit ---------------------------------------------------------------
+
+
+class _FakeAttribute:
+    def __init__(self, prim, name):
+        self._prim = prim
+        self._name = name
+
+    def Set(self, value):
+        self._prim.attributes[self._name] = value
+
+
+class _FakeRelationship:
+    def __init__(self, targets):
+        self._targets = list(targets)
+
+    def GetTargets(self):
+        return list(self._targets)
+
+
+class _FakePrim:
+    """Enough of Usd.Prim for the controller's authoring and traversal paths."""
+
+    def __init__(self, path, type_name="Camera", valid=True, camera_target=None):
+        self.path = path
+        self.type_name = type_name
+        self.valid = valid
+        self.attributes = {}
+        self.schemas = []
+        self.removed_properties = []
+        self.removed_schemas = []
+        self.remove_property_error = None
+        self._camera_target = camera_target
+
+    # -- read
+    def GetPath(self):
+        return self.path
+
+    def IsValid(self):
+        return self.valid
+
+    def GetTypeName(self):
+        return self.type_name
+
+    def GetAppliedSchemas(self):
+        return list(self.schemas)
+
+    def GetRelationship(self, name):
+        if name == "camera" and self._camera_target is not None:
+            return _FakeRelationship([self._camera_target])
+        return None
+
+    # -- write
+    def AddAppliedSchema(self, name):
+        self.schemas.append(name)
+
+    def CreateAttribute(self, name, _sdf_type):
+        self.attributes.setdefault(name, None)
+        return _FakeAttribute(self, name)
+
+    def RemoveProperty(self, name):
+        if self.remove_property_error is not None:
+            raise self.remove_property_error
+        self.removed_properties.append(name)
+        self.attributes.pop(name, None)
+
+    def RemoveAppliedSchema(self, name):
+        self.removed_schemas.append(name)
+        if name in self.schemas:
+            self.schemas.remove(name)
+
+
+class _FakeStage:
+    def __init__(self):
+        self.prims = {}
+        self.traversals = 0
+
+    def add(self, prim):
+        self.prims[prim.path] = prim
+        return prim
+
+    def GetPrimAtPath(self, path):
+        return self.prims.get(path) or _FakePrim(path, valid=False)
+
+    def Traverse(self):
+        self.traversals += 1
+        return list(self.prims.values())
+
+    def GetSessionLayer(self):
+        return "session-layer"
+
+
+class _FakeSettings:
+    """carb.settings surface: get/set, plus destroy_item for the _MISSING case."""
+
+    def __init__(self):
+        self.values = {}
+        self.destroyed = []
+        self.set_error_paths = set()
+
+    def get(self, path):
+        return self.values.get(path)
+
+    def set(self, path, value):
+        if path in self.set_error_paths:
+            raise RuntimeError(f"carb refused {path}")
+        self.values[path] = value
+
+    def destroy_item(self, path):
+        self.destroyed.append(path)
+        self.values.pop(path, None)
+
+
+def _install_fake_kit(stage):
+    """Put fake `pxr` and `omni.usd` in sys.modules; return an undo callable.
+
+    Installed unconditionally rather than only when the real ones are absent:
+    the point is that this file behaves the same on a laptop and inside the
+    Isaac container, so a check that passes here cannot be a property of
+    whichever Kit happened to be importable.
+    """
+    saved = {name: sys.modules.get(name) for name in ("pxr", "omni", "omni.usd")}
+
+    class _EditContext:
+        def __init__(self, *_args):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+    pxr = types.ModuleType("pxr")
+    pxr.Sdf = types.SimpleNamespace(
+        ValueTypeNames=types.SimpleNamespace(Bool="bool", Float="float", Color3f="color3f")
+    )
+    pxr.Usd = types.SimpleNamespace(EditContext=_EditContext)
+    pxr.Gf = types.SimpleNamespace(Vec3f=lambda *values: tuple(values))
+
+    omni = types.ModuleType("omni")
+    omni_usd = types.ModuleType("omni.usd")
+    omni_usd.get_context = lambda: types.SimpleNamespace(get_stage=lambda: stage)
+    omni.usd = omni_usd
+
+    sys.modules["pxr"] = pxr
+    sys.modules["omni"] = omni
+    sys.modules["omni.usd"] = omni_usd
+
+    def undo():
+        for name, module in saved.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+    return undo
+
+
+# -- fixtures ---------------------------------------------------------------
+
+CAM1 = "/World/Cameras/Camera_01"
+CAM2 = "/World/Cameras/Camera_02"
+
+SHIPPED_CONFIG = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "configs",
+    "postprocessing.yaml",
+)
+
+# Camera_01 authors on the camera prim (immediate); Camera_02 wants the render
+# product (deferred until Play). Both halves are needed: a preset that only
+# defers leaves `_authored_attrs` empty, and `_revert()` then skips
+# `_clear_authored_usd()` entirely — so a check built on such a preset would
+# pass whether or not the cleanup path is guarded.
+MIXED_CONFIG = f"""
+version: 1
+active: mixed_scope
+presets:
+  mixed_scope:
+    description: One camera dimmed and flickering, one camera grainy.
+    per_camera:
+      {CAM1}:
+        settings:
+          auto_exposure.enabled: false
+          exposure.iso: 60.0
+        animation:
+          target: exposure.iso
+          waveform: sine
+          base: 60.0
+          amplitude_fraction: 0.4
+          frequency_hz: 1.0
+      {CAM2}:
+        settings:
+          tv_noise.enabled: true
+          tv_noise.film_grain.enabled: true
+          tv_noise.film_grain.amount: 0.2
+"""
+
+
+class _Harness:
+    """A controller with a fake clock, fake carb and a fake stage."""
+
+    def __init__(self, config_text=None, config_path=None, preset=None, with_render_products=False):
+        from .controller import PostProcessingController
+
+        self.stage = _FakeStage()
+        self.stage.add(_FakePrim(CAM1))
+        self.stage.add(_FakePrim(CAM2))
+        self.render_products = {}
+        if with_render_products:
+            self.add_render_products()
+
+        self._undo_kit = _install_fake_kit(self.stage)
+        self._tempdir = None
+        if config_text is not None:
+            self._tempdir = tempfile.TemporaryDirectory()
+            config_path = os.path.join(self._tempdir.name, "postprocessing.yaml")
+            with open(config_path, "w") as stream:
+                stream.write(config_text)
+
+        self.settings = _FakeSettings()
+        self.now = 0.0
+        self.controller = PostProcessingController(
+            config_path=config_path,
+            preset_override=preset,
+            # The poll is not what these checks are about, and a reload
+            # part-way through one would re-read the file and re-apply,
+            # contaminating every count taken after it.
+            poll_interval_sec=10**9,
+            settings=self.settings,
+            clock=lambda: self.now,
+        )
+        # cameras.yaml is a plain file read, not a Kit call, but the shipped
+        # presets name cameras rather than prim paths, so it has to resolve.
+        self.controller._load_camera_name_map = lambda: {
+            "Camera_01": CAM1,
+            "Camera_02": CAM2,
+        }
+
+    def add_render_products(self):
+        for index, camera in enumerate((CAM1, CAM2), start=1):
+            path = f"/Render/RenderProduct_{index:02d}"
+            prim = _FakePrim(path, type_name="RenderProduct", camera_target=camera)
+            self.stage.add(prim)
+            self.render_products[camera] = prim
+
+    def start(self, quiet=True):
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer) if quiet else contextlib.nullcontext():
+            self.controller.start()
+        return buffer.getvalue()
+
+    def tick(self, dt=1.0 / 30.0, quiet=True):
+        """One run-loop frame. Never reloads: poll_interval_sec is effectively
+        infinite, so `update()` exercises the flush and the animator only."""
+        self.now += dt
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer) if quiet else contextlib.nullcontext():
+            self.controller.update()
+        return buffer.getvalue()
+
+    def close(self):
+        self._undo_kit()
+        if self._tempdir is not None:
+            self._tempdir.cleanup()
+
+
+# -- checks -----------------------------------------------------------------
+
+
+def check_apply_authors_and_defers():
+    """`_apply` writes camera-prim effects now and queues render-product ones."""
+    harness = _Harness(config_text=MIXED_CONFIG)
+    try:
+        harness.start()
+        controller = harness.controller
+
+        assert controller.active_preset == "mixed_scope", controller.active_preset
+        cam1 = harness.stage.prims[CAM1]
+        assert cam1.attributes, "camera-prim effects must be authored immediately"
+        assert EFFECTS["auto_exposure.enabled"].usd_attr in cam1.attributes, sorted(cam1.attributes)
+
+        cam2 = harness.stage.prims[CAM2]
+        assert not cam2.attributes, f"render-product effects must not land on the camera prim: {cam2.attributes}"
+
+        pending = controller._pending_rp_settings
+        assert isinstance(pending, dict), type(pending)
+        assert len(pending) == 3, f"expected 3 deferred settings, got {sorted(pending)}"
+        assert all(paths == (CAM2,) for paths, _key in pending), sorted(pending)
+        print(
+            f"  authored {len(cam1.attributes)} attr(s) on Camera_01, "
+            f"deferred {len(pending)} setting(s) for Camera_02"
+        )
+    finally:
+        harness.close()
+
+
+def check_pending_is_bounded_before_play():
+    """The pending store must not grow one entry per pre-Play frame.
+
+    This is the list -> dict change, and the reason for it: an ANIMATED
+    render-product target re-writes the same key every frame, and the flush
+    traverses the stage once per entry, so an append-only store cost
+    O(frames^2) traversals before Play.
+    """
+    harness = _Harness(config_path=SHIPPED_CONFIG, preset="anim_rp_target")
+    try:
+        harness.start()
+        controller = harness.controller
+        after_apply = len(controller._pending_rp_settings)
+
+        sizes = []
+        for _ in range(120):
+            harness.tick()
+            sizes.append(len(controller._pending_rp_settings))
+
+        assert max(sizes) == min(sizes) == after_apply, (
+            f"pending store changed size across frames: {min(sizes)}..{max(sizes)}"
+        )
+        assert after_apply == 3, f"anim_rp_target should defer 3 settings, got {after_apply}"
+        print(
+            f"  anim_rp_target: {after_apply} deferred setting(s), unchanged over "
+            f"{len(sizes)} pre-Play frames (append-only would have reached {after_apply + len(sizes)})"
+        )
+    finally:
+        harness.close()
+
+
+def measure_traversal_cost():
+    """Count stage traversals per frame for the shipped `anim_rp_target`.
+
+    Reported rather than merely asserted, because the number is quoted in the
+    README, in postprocessing.yaml and in the load-time WARNING, and quoting a
+    number nothing measures is how it drifts.
+    """
+    harness = _Harness(config_path=SHIPPED_CONFIG, preset="anim_rp_target")
+    try:
+        before = harness.stage.traversals
+        harness.start()
+        apply_frame = harness.stage.traversals - before
+
+        per_frame = []
+        for _ in range(10):
+            mark = harness.stage.traversals
+            harness.tick()
+            per_frame.append(harness.stage.traversals - mark)
+
+        entries = len(harness.controller._pending_rp_settings)
+        steady = set(per_frame)
+        assert len(steady) == 1, f"traversals per frame not steady: {sorted(steady)}"
+        steady_state = per_frame[0]
+        print(
+            f"  anim_rp_target pre-Play: {entries} pending entry/entries, "
+            f"{steady_state} stage traversals per frame "
+            f"({entries} flush + 1 animate); the apply frame itself costs {apply_frame}"
+        )
+        # 3 settings, all render-product targets, one of them animated. The
+        # figure quoted in bf9434c's commit message (1 entry, 2 traversals)
+        # describes a preset that animates grain WITHOUT switching the grain
+        # pass on -- i.e. one that renders no grain at all.
+        assert entries == 3, entries
+        assert steady_state == entries + 1, (steady_state, entries)
+        return entries, steady_state, apply_frame
+    finally:
+        harness.close()
+
+
+def check_flush_respects_scope():
+    """A deferred write must reach its own camera's render product only."""
+    harness = _Harness(config_text=MIXED_CONFIG)
+    try:
+        harness.start()
+        controller = harness.controller
+        assert len(controller._pending_rp_settings) == 3
+
+        # Play: IsaacCreateRenderProduct creates the products on the first tick.
+        harness.add_render_products()
+        harness.tick()
+
+        assert not controller._pending_rp_settings, controller._pending_rp_settings
+        rp2 = harness.render_products[CAM2]
+        rp1 = harness.render_products[CAM1]
+        assert rp2.attributes, "Camera_02's deferred settings never reached its render product"
+        assert not rp1.attributes, (
+            f"Camera_02's settings leaked onto Camera_01's render product: {sorted(rp1.attributes)}"
+        )
+        print(
+            f"  flushed {len(rp2.attributes)} setting(s) onto Camera_02's render product, "
+            f"{len(rp1.attributes)} onto Camera_01's"
+        )
+    finally:
+        harness.close()
+
+
+def check_animation_does_not_grow_authored_list():
+    """Re-authoring the same attribute every frame must record it once."""
+    harness = _Harness(config_text=MIXED_CONFIG, with_render_products=True)
+    try:
+        harness.start()
+        controller = harness.controller
+        after_apply = len(controller._authored_attrs)
+        for _ in range(200):
+            harness.tick()
+        after_frames = len(controller._authored_attrs)
+        assert after_frames == after_apply, (
+            f"_authored_attrs grew from {after_apply} to {after_frames} under animation"
+        )
+        print(
+            f"  {after_frames} tracked attribute(s) after 200 animated frames "
+            f"(one per attribute, not one per write)"
+        )
+    finally:
+        harness.close()
+
+
+def check_revert_clears_everything():
+    """`_revert` must undo carb, USD and both pieces of pending state."""
+    harness = _Harness(config_text=MIXED_CONFIG, with_render_products=True)
+    try:
+        harness.start()
+        harness.tick()  # flush the deferred writes onto the render products
+        controller = harness.controller
+        cam1 = harness.stage.prims[CAM1]
+        rp2 = harness.render_products[CAM2]
+        assert cam1.attributes and rp2.attributes
+
+        controller._revert()
+
+        assert not controller._authored_attrs, controller._authored_attrs
+        assert not controller._authored_apis, controller._authored_apis
+        assert not controller._pending_rp_settings, controller._pending_rp_settings
+        assert not controller._animations, controller._animations
+        assert not cam1.attributes, f"camera prim still degraded: {sorted(cam1.attributes)}"
+        assert not rp2.attributes, f"render product still degraded: {sorted(rp2.attributes)}"
+        assert not cam1.schemas and not rp2.schemas, "applied API schemas survived the revert"
+        print(
+            f"  removed {len(cam1.removed_properties) + len(rp2.removed_properties)} attribute(s) "
+            f"and {len(cam1.removed_schemas) + len(rp2.removed_schemas)} API schema(s); "
+            f"pending and animations empty"
+        )
+    finally:
+        harness.close()
+
+
+def check_pending_cleared_when_usd_cleanup_raises():
+    """B1: a raising `_clear_authored_usd()` must not strand the pending writes.
+
+    `_revert()` runs the USD cleanup inside its `finally`, ahead of the state
+    resets. If that cleanup raises and the resets are not themselves protected,
+    `_pending_rp_settings` survives a revert -- and `update()` then authors the
+    reverted preset onto the render products on the first tick after Play,
+    while `active_preset` reports None.
+
+    Driven through `_revert()` directly, which is the door `close()` and a
+    direct call use. The `_reload_if_changed` rejection path resets the pending
+    store itself, so a check driven through it would pass either way.
+    """
+    harness = _Harness(config_text=MIXED_CONFIG)
+    try:
+        harness.start()
+        controller = harness.controller
+        assert controller._pending_rp_settings, "fixture must have deferred writes to strand"
+        assert controller._authored_attrs, "fixture must have authored attrs, or cleanup is skipped"
+
+        # A USD cleanup failure, raised from inside the shipped
+        # _clear_authored_usd() rather than by replacing it.
+        harness.stage.prims[CAM1].remove_property_error = RuntimeError("stage closed mid-revert")
+
+        raised = None
+        try:
+            controller._revert()
+        except Exception as exc:  # noqa: BLE001 - the caller logs this and carries on
+            raised = exc
+        assert raised is not None, "fixture did not actually make the cleanup fail"
+
+        stranded = sorted(key for _paths, key in controller._pending_rp_settings)
+        stranded_animations = len(controller._animations)
+
+        # The tick after Play: the render products now exist, so anything left
+        # pending is authored here -- which is the consequence that matters, so
+        # it is measured before anything is asserted rather than after.
+        harness.add_render_products()
+        harness.tick()
+        leaked = sorted(harness.render_products[CAM2].attributes)
+
+        assert not leaked, (
+            f"the reverted preset was flushed onto the render product on the tick after "
+            f"Play: {leaked} (active_preset={controller.active_preset!r}); "
+            f"{len(stranded)} setting(s) had survived the failed revert: {stranded}"
+        )
+        assert not stranded, f"{len(stranded)} deferred setting(s) survived the failed revert: {stranded}"
+        assert not stranded_animations, "animations survived the failed revert"
+        print(
+            f"  cleanup raised {raised.__class__.__name__}; pending empty afterwards and the "
+            f"next tick authored nothing onto the render products"
+        )
+    finally:
+        harness.close()
+
+
+def check_reject_mid_apply_reverts():
+    """A failure inside `_apply` must fall back to the baseline, not half a look."""
+    harness = _Harness(config_text=MIXED_CONFIG, with_render_products=True)
+    try:
+        harness.start()
+        controller = harness.controller
+        assert controller.active_preset == "mixed_scope"
+
+        # Rewrite the file so the next poll applies a preset whose camera does
+        # not exist on the stage... that is a resolve error, which must NOT
+        # revert. Make the apply itself fail instead: carb refuses a global
+        # write. Global settings go through _settings.set inside _apply.
+        harness.settings.set_error_paths.add("/rtx/post/histogram/enabled")
+        with open(controller.config_path, "w") as stream:
+            stream.write(
+                "version: 1\n"
+                "active: global_dark\n"
+                "presets:\n"
+                "  global_dark:\n"
+                "    settings:\n"
+                "      auto_exposure.enabled: false\n"
+            )
+        harness.now += 10**9  # force the poll
+        log = harness.tick()
+
+        assert "reverted the renderer" in log, log
+        assert controller.active_preset is None, controller.active_preset
+        assert controller._digest is None, "the last good digest must be forgotten"
+        assert not controller._pending_rp_settings, controller._pending_rp_settings
+        assert not controller._animations, controller._animations
+        cam1 = harness.stage.prims[CAM1]
+        assert not cam1.attributes, f"half a preset left on the stage: {sorted(cam1.attributes)}"
+        print("  mid-apply failure: reverted, digest forgotten, pending and animations empty")
+    finally:
+        harness.close()
+
+
+def check_config_error_keeps_running_preset():
+    """A config error before the apply must leave the live preset alone."""
+    harness = _Harness(config_text=MIXED_CONFIG, with_render_products=True)
+    try:
+        harness.start()
+        harness.tick()
+        controller = harness.controller
+        cam1 = harness.stage.prims[CAM1]
+        # Keys, not values: the preset animates exposure.iso, so the value on
+        # the prim is expected to differ every frame. What must not change is
+        # WHICH attributes are authored, and that the animation is still driving
+        # them at all.
+        authored = sorted(cam1.attributes)
+        assert authored
+
+        with open(controller.config_path, "w") as stream:
+            stream.write(
+                "version: 1\n"
+                "active: broken\n"
+                "presets:\n"
+                "  broken:\n"
+                "    settings:\n"
+                "      exposure.iso: not-a-number\n"
+            )
+        harness.now += 10**9
+        iso_attr = EFFECTS["exposure.iso"].usd_attr
+        iso_before = cam1.attributes[iso_attr]
+        log = harness.tick()
+
+        assert "active preset is 'mixed_scope'" in log, log
+        assert controller.active_preset == "mixed_scope", controller.active_preset
+        assert sorted(cam1.attributes) == authored, "a config error disturbed the running preset"
+        assert len(controller._animations) == 1, "the running preset stopped animating"
+        assert cam1.attributes[iso_attr] != iso_before, (
+            "the animation stalled, so the preset is frozen rather than running"
+        )
+        print(
+            f"  config error: {len(authored)} authored attribute(s) unchanged, "
+            f"animation still driving exposure.iso"
+        )
+    finally:
+        harness.close()
+
+
+def main():
+    checks = (
+        ("apply authors camera effects and defers render-product ones", check_apply_authors_and_defers),
+        ("pending store stays bounded before Play", check_pending_is_bounded_before_play),
+        ("traversal cost of anim_rp_target (measurement)", measure_traversal_cost),
+        ("deferred writes flush to their own scope", check_flush_respects_scope),
+        ("animation does not grow the authored-attribute list", check_animation_does_not_grow_authored_list),
+        ("revert clears carb, USD, pending and animations", check_revert_clears_everything),
+        ("pending cleared when the USD cleanup raises", check_pending_cleared_when_usd_cleanup_raises),
+        ("mid-apply failure reverts to the baseline", check_reject_mid_apply_reverts),
+        ("config error keeps the running preset", check_config_error_keeps_running_preset),
+    )
+    failed = 0
+    for title, run in checks:
+        print(f"[{title}]")
+        try:
+            run()
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL: {exc}")
+    print(f"\n{len(checks) - failed}/{len(checks)} checks passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/closed-loop-testing/isaac-sim/sil/scripts/run_actor_sdg.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/run_actor_sdg.py
@@ -756,17 +756,18 @@ def _validate_postprocessing_preset(preset, config_path):
 
     "Wrong" is not only a mistyped name. `version: 2`, a setting key that does
     not exist, a string where a float belongs, an `animation` block missing
-    `frequency_hz` — every one of those names a preset that IS in the file and
+    `frequency_hz`, a `per_camera` entry that also carries a top-level
+    `cameras:` — every one of those names a preset that IS in the file and
     still produces a clean run. So this runs the controller's own
     `_select_preset` and `_validate_preset`, which is why those two are kept
     free of carb and pxr imports: they are the contract, and a second
     reimplementation here would drift from it.
 
-    What it still cannot check is camera resolution: `cameras:` entries are
-    matched against cameras.yaml and then against the prims on the stage, and
-    neither exists before Kit boots. An unknown camera name is caught by the
-    controller at apply time, where it is rejected without disturbing the
-    running preset.
+    What it still cannot check is camera resolution: `cameras:`/`per_camera:`
+    entries are matched against cameras.yaml and then against the prims on the
+    stage, and neither exists before Kit boots. An unknown camera name is
+    caught by the controller at apply time, where it is rejected without
+    disturbing the running preset.
     """
     if not preset.strip():
         # `--postprocessing-preset "$PRESET"` with PRESET unset. Not "no pin":


### PR DESCRIPTION
## The gap this closes

A preset's `cameras:` list shares one `settings` block, so every camera in it gets the same degradation. And only one preset is active at a time — `_apply()` begins by reverting, deliberately, so that switching presets cannot leak the previous one's ISO or noise toggles into the new look. Applying two single-camera presets in turn therefore reverts the first.

The consequence is that "camera 1 went dark **while** camera 2 went grainy" could not be expressed at all — which is the case an anomaly campaign actually cares about, since a fault that hits every camera identically is not the interesting one. Three ways around it were tried and measured; none produce it. Listing both cameras gives both cameras both effects. Rewriting the config twice in quick succession applies only the last preset. Mixing a global and a per-camera scope in one preset is structurally impossible, because the scope branch is either/or.

## What this adds

```yaml
mixed_faults:
  per_camera:
    Camera_01: {settings: {auto_exposure.enabled: false, exposure.iso: 12.0}}
    Camera_02: {settings: {tv_noise.enabled: true, tv_noise.film_grain.enabled: true,
                           tv_noise.film_grain.amount: 0.18}}
```

Each camera carries its own `settings` and, if it wants one, its own `animation`. `per_camera:` is mutually exclusive with the preset-level `cameras:`/`settings:`/`animation:` keys, and saying both is rejected with a reason.

The core is `_preset_groups()`, a pure-Python normaliser that turns any preset into a list of `(cameras, settings, animation)` groups. A classic preset normalises to exactly one group, so the existing paths are unchanged by construction rather than by care — which is also why `_select_preset` and `_validate_preset` stay free of carb and pxr imports and can be called by the pre-boot validator.

Animated groups share one clock origin, latched when the preset is applied, and are offset against each other with `animation.phase_deg`. Two cameras flickering a second apart is then a property of the preset file rather than of the moment each group happened to start.

## Measured

Three cameras, one capture: `Camera_01` at 34 mean / 10.4 high-frequency energy — dark and **not** grainy; `Camera_02` at 153 / 38.3 — grainy and **not** dark; `Camera` clean. The cross-terms are the point; they are what distinguishes this from applying both effects to both cameras. Scene noise from moving people and vehicles is ±11%, and every delta here sits far outside it. Reproduced on a second machine: 34.2 / 10.5 and 153.6 / 41.7, holding across four captures.

Animation: an anti-phase preset measures 180.13° apart with a Pearson correlation of −1.000; a two-frequency preset separates 1.04 Hz and 3.04 Hz by 126× and 62×.

Frame-rate cost turns out to have three tiers, and the number of animated groups is not what drives it — the target does. A static preset is free. Animating an attribute on the camera prim costs 0.16–0.36%. Animating one on the render product costs about 7%, because the flush traverses the stage; measured independently on a second machine at −8.6%. The load-time warning says so for presets that animate a render-product target, and `postprocessing.yaml` documents the tiers.

Backward compatibility: global presets behave identically, `cameras:` presets match their pre-change numbers, and `per_camera` mixed with `cameras:`, an unknown camera name, and two keys naming the same prim are each rejected — with the running preset left intact through all three rejections, verified by pixel measurement after each.

## Also in here

- **Tests.** `test_controller.py` exercises the shipped `_apply`/`_revert`/`_resolve_groups`/`_author`/`_clear_authored_usd` against a fake USD stage, and `test_animation.py` covers the phase and frequency arithmetic. One check is deliberately built to fail if the `_author()` ordering fix from #59 is reverted — the previous suite passed either way, so nothing was holding that fix in place.
- **Two documentation corrections.** The traversal counts quoted in the controller and README described a preset that animates the grain amount *without* switching the grain pass on, which renders no grain at all; the shipped `anim_rp_target` costs 3 pending entries and 4 traversals per pre-Play frame, not 1 and 2. And the frequency-aliasing guidance was derived from an 8–9 fps assumption when the measured render rate is 17.8, so the advice was steering readers away from frequencies that work.
- **A comment corrected rather than deleted.** The reject path's defensive clear of the pending render-product writes is kept, but the reason given for it stopped being true once `_revert()` gained its own `try`/`finally` in #59.

## Known gaps

- **`per_camera` cannot be combined with a global scope in one preset.** "The whole site went dark, and camera 2 is also grainy" still needs a separate `global:` key alongside it. Not added here.
- **The render-product deferral path is exercised offline, not on hardware.** Render products do not exist until the first tick after Play, so settings that live on them stay pending until then; the retry and per-scope flush are covered by the fake-stage tests and by measurement of the ledger under an animated render-product preset, but not by a scenario that deliberately delays Play.
- **The grain-leak bug reported in #59 is unchanged here** — going from a global `tv_noise` preset to a per-camera one and then back to `baseline` leaves grain on the cameras outside the scope until Isaac restarts. It predates both PRs.
