### PR TITLE
docs(postprocessing): catalogue the effect keys, and ship the CRT artefacts

### DIFF
--- a/closed-loop-testing/isaac-sim/sil/configs/postprocessing.yaml
+++ b/closed-loop-testing/isaac-sim/sil/configs/postprocessing.yaml
@@ -108,6 +108,35 @@ presets:
       tv_noise.scanlines.enabled: true
       tv_noise.scanlines.spread: 1.0
 
+  # CRT/analog artefacts: the five sub-effects of the tvNoise pass that are not
+  # grain and not scanlines. Every one of them renders on Isaac Sim 6.0.0.
+  #
+  # READ THIS BEFORE CONCLUDING ONE IS BROKEN. Two of them fire on a fraction of
+  # frames, not continuously: the vertical roll on roughly a quarter of frames
+  # and the ghosting on about one frame in twenty. A single screenshot of this
+  # preset will very often look completely clean, and looking at a still is how
+  # all five were once written off as dead. Watch a clip, not a frame.
+  #
+  # The three geometric/compositing ones are also invisible to the obvious
+  # metrics. A vertical roll does not change high-frequency energy, and ghosting
+  # is an alpha blend that lowers it; both read as "no change" to a sharpness or
+  # brightness measure. Detect the roll with frame-to-frame correlation, the
+  # ghost with edge sharpness, the wave with a temporal-median residual over a
+  # static part of the frame.
+  #
+  # None of these five has a magnitude knob -- they are booleans in the renderer
+  # itself, so there is nothing to turn up if the effect looks weak.
+  crt_artifacts:
+    description: Analog CRT artefacts — roll, ghosting, wave, lines, splotches.
+    settings:
+      tv_noise.enabled: true
+      tv_noise.film_grain.enabled: false
+      tv_noise.scroll_bug.enabled: true
+      tv_noise.ghost_flickering.enabled: true
+      tv_noise.wave_distortion.enabled: true
+      tv_noise.vertical_lines.enabled: true
+      tv_noise.random_splotches.enabled: true
+
   # Soft lens obstruction: a heavy vignette pinches the usable image down to
   # the centre. Not a true blockage — an opaque occluder prim in front of the
   # lens is still the only way to model that — but it degrades the frame

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/README.md
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/README.md
@@ -65,6 +65,65 @@ ignored — a mistyped anomaly would otherwise score a clean run as a fault run.
 Turn the whole thing off with `--no-postprocessing`, or point it at a different
 preset file with `--postprocessing-config`.
 
+## What you can set
+
+Twenty-seven keys, transcribed from the Kit renderer source into `effects.py`.
+A preset may only use these; anything else is rejected by name rather than
+quietly becoming a dead carb key.
+
+**lives on** decides *when* a per-camera setting takes effect. Camera-prim
+settings apply immediately; render-product settings stay pending until the
+first tick after Play, because that is when the RTSP graph creates the render
+products.
+
+### Exposure
+
+| key | lives on | type | notes |
+|---|---|---|---|
+| `auto_exposure.enabled` | camera prim | bool |  |
+| `exposure.iso` | camera prim | float |  |
+| `exposure.time` | camera prim | float | **per-camera only** — the carb key is rewritten every frame |
+| `exposure.f_stop` | camera prim | float | **per-camera only**, same reason. Tonemapper aperture, *not* depth of field |
+
+### Colour grading
+
+| key | lives on | type | notes |
+|---|---|---|---|
+| `grade.enabled` | render product | bool |  |
+| `grade.gain` | render product | rgb |  |
+| `grade.gamma` | render product | rgb |  |
+| `grade.contrast` | render product | rgb |  |
+
+### TV noise
+
+| key | lives on | type | notes |
+|---|---|---|---|
+| `tv_noise.enabled` | render product | bool |  |
+| `tv_noise.film_grain.enabled` | render product | bool |  |
+| `tv_noise.film_grain.amount` | render product | float |  |
+| `tv_noise.film_grain.size` | render product | float |  |
+| `tv_noise.color_amount` | render product | float |  |
+| `tv_noise.lum_amount` | render product | float |  |
+| `tv_noise.scanlines.enabled` | render product | bool |  |
+| `tv_noise.scanlines.spread` | render product | float |  |
+| `tv_noise.vignetting.enabled` | render product | bool |  |
+| `tv_noise.vignetting.size` | render product | float |  |
+| `tv_noise.vignetting.strength` | render product | float |  |
+| `tv_noise.vignetting.flickering.enabled` | render product | bool |  |
+| `tv_noise.wave_distortion.enabled` | render product | bool | geometric warp — invisible to sharpness/brightness measures |
+| `tv_noise.vertical_lines.enabled` | render product | bool | no detector known yet; confirmed by eye on video |
+| `tv_noise.random_splotches.enabled` | render product | bool | no detector known yet; confirmed by eye on video |
+| `tv_noise.ghost_flickering.enabled` | render product | bool | alpha-blended echo. **~1 frame in 20**; *lowers* sharpness |
+| `tv_noise.scroll_bug.enabled` | render product | bool | vertical roll. **Fires on ~1 frame in 4** — a still often looks clean |
+| `tv_noise.fixed_time.seed` | render product | bool | freezes the noise pattern; determinism not yet proven |
+| `tv_noise.fixed_time.seed_count` | render product | float |  |
+
+The five CRT artefacts — roll, ghosting, wave, vertical lines, splotches — are
+**booleans in the renderer**, with no magnitude parameter anywhere on either the
+carb or the USD side, so if one looks weak there is nothing to turn up. Two of
+them are intermittent, so judge them from a clip rather than a screenshot; the
+`crt_artifacts` preset turns on all five.
+
 ## Three scopes, and why the difference matters
 
 A preset with no `cameras:` key writes **carb settings**, which the renderer

--- a/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/effects.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/postprocessing/effects.py
@@ -102,7 +102,12 @@ EFFECTS = {
         _CAM_EXPOSURE_API,
         TARGET_CAMERA,
         KIND_FLOAT,
-        "Aperture. Larger numbers darken the image.",
+        "Aperture. Larger numbers darken the image. PER-CAMERA ONLY, the same "
+        "way exposure.time is: the carb key does not reach the tonemapper in a "
+        "running sim. Measured: a global write left RTSP brightness at 122.8 "
+        "(unchanged), while the same value on the camera prim took it to 15.1. "
+        "Note this is the tonemapper's aperture, not depth of field -- it "
+        "changes exposure, it does not defocus.",
     ),
     # --- Color grading: the "hue shift" / white-balance-drift family. -----
     "grade.enabled": Effect(


### PR DESCRIPTION
The allow-list in `effects.py` has twenty-seven keys, and until now the only way to find out what you could write in a preset was to read the Python. This adds the catalogue to the README, groups it by family, and carries the column that matters at authoring time: whether a key lives on the **camera prim** (applies immediately) or on the **render product** (stays pending until the first tick after Play, because that is when the RTSP graph creates the render products).

### The five keys with no preset

Five keys had no shipped preset at all — the CRT artefacts of the tvNoise pass: vertical roll, ghosting, wave distortion, vertical lines, random splotches. `crt_artifacts` turns on all five.

Its comment carries the thing that cost the most to learn:

> The roll fires on roughly **one frame in four** and the ghosting on about **one in twenty**. A single screenshot of this preset will very often look completely clean.

Judging them from a still is how all five were once written off as rendering nothing. Three of them are also invisible to the obvious measures — a vertical roll does not change high-frequency energy, and ghosting is an alpha blend that *lowers* it, so both read as "no change" to a sharpness or brightness metric. The note names a detector that does work for each: frame-to-frame correlation for the roll, edge sharpness for the ghost, a temporal-median residual over a static part of the frame for the wave.

None of the five has a magnitude parameter on either the carb or the USD side — they are booleans in the renderer itself, so if one looks weak there is nothing to turn up. Worth stating, because the natural first move is to go looking for the knob.

### One warning that was missing

`exposure.f_stop` now carries the warning `exposure.time` already had. Both are per-camera only — the carb key does not reach the tonemapper in a running sim — and only one of them said so. Measured: a global write left RTSP brightness unchanged at 122.8, while the same value on the camera prim took it to 15.1. The note also says it is the tonemapper's aperture rather than depth of field, since the name invites the other reading.

### Checks

15/15 presets validate, `test_controller` 10/10, `test_animation` 8/8. Docs, one comment and one preset — no code paths changed.
