### PR TITLE
fix(waypoint-generator): give the origin a heading instead of pinning it to 0

### DIFF
--- a/tools/waypoint-generator/README.md
+++ b/tools/waypoint-generator/README.md
@@ -10,8 +10,8 @@ A web-based tool to visually create waypoints for forklift navigation on the war
 - **Multiple maps**, one per Isaac scene, picked from a dropdown; adding one needs
   no code change
 - **Pan/Zoom** navigation (Alt+Drag or Middle Mouse to pan, Scroll to zoom)
-- **Origin point selection** for odom frame reference
-- **Heading control** via Shift+Scroll or slider
+- **Origin pose selection** for odom frame reference — position and start heading
+- **Heading control** via Shift+Scroll or slider, for waypoints and the origin alike
 - **Drag-and-drop** waypoint reordering
 - **Export** to JSON (waypoints plus interpolated poses for curve following)
 - **Import** existing waypoint files (JSON or YAML)
@@ -36,7 +36,7 @@ npm run dev
 
 ### Basic Workflow
 
-1. **Set Origin**: Click "Set Origin" mode and click on the map where the forklift starts (or use "Use Default Forklift Start")
+1. **Set Origin**: Click "Set Origin" mode and click on the map where the forklift starts (or use "Use Default Forklift Start"). Set the start heading the same way as for a waypoint — Shift+Scroll or the sidebar slider — before clicking; the preview body shows what the click will commit. Turning the slider while in this mode re-aims an origin already placed, without discarding the waypoints drawn from it. Leave the heading at 0 unless you know otherwise — see [Which way the truck faces](#which-way-the-truck-faces).
 
 2. **Add Waypoints**: Switch to "Add Waypoint" mode, then click on the map to add waypoints. Use Shift+Scroll to adjust heading before clicking.
 
@@ -61,6 +61,28 @@ npm run dev
 - **World**: Isaac Sim global coordinates (meters)
 - **Odom**: Relative to origin point
 
+### Which way the truck faces
+
+The forklift controller runs with pose inversion on — `invert_poses` defaults to
+true and the compose file sets `NO_INVERT=false` explicitly — so it mirrors the
+whole path 180 degrees about the origin before driving it, and adds
+`HEADING_OFFSET=180` to the truck's measured heading. **A path drawn heading
+east here is driven heading west.** That is not a bug to fix in this tool; it is
+how the forklift asset's forward axis is reconciled with the odom frame, and the
+paths under `forklift-controller/waypoints/` are all drawn that way.
+
+The consequence is that the origin's heading here is **not** the truck's yaw in
+the scene. The maps' `defaultForkliftStart.theta_deg` is 180 because that is
+where the prim points, but the origin heading that makes a path drivable is 0.
+"Use Default Forklift Start" therefore takes only the position from the map
+config and leaves the heading at 0. Setting it to 180 to "match the scene" puts
+the opening pose 180 degrees away from the spawned truck, and it spins on the
+spot instead of pulling away.
+
+Turn the origin off 0 only for a truck that genuinely starts at an angle to the
+aisle, and check the first exported pose against where the truck stands before
+running it.
+
 ## Output Format
 
 The JSON export (including `poses`) is the input format of the SIL forklift controller: `closed-loop-testing/forklift-controller/robot_controller.py` loads it via `--path <file>.json`. In the compose deployment the controller reads `<ROBOT_ID>.json` from the set named by `FORKLIFT_WAYPOINTS_DIR`, which is `closed-loop-testing/forklift-controller/waypoints/<map id>/` — so an exported path replaces the file of the same robot name under the map it was drawn on. The `map` block this tool writes records that id, and `deployments/scripts/preflight.py` checks the file's `origin` against where the truck actually stands.
@@ -74,7 +96,8 @@ The JSON export (including `poses`) is the input format of the SIL forklift cont
   },
   "origin": {
     "world_x": 1.0,
-    "world_y": -13.39
+    "world_y": -13.39,
+    "theta_deg": 0
   },
   "waypoints": [
     {
@@ -109,7 +132,11 @@ The JSON export (including `poses`) is the input format of the SIL forklift cont
   one. The two scenes place their forklift barely a metre apart, so without this
   a path from the wrong warehouse reads as perfectly plausible. Importing a file
   whose `map.id` is not the open map offers to switch first.
-- `origin`: Robot starting position in world coordinates
+- `origin`: Robot starting pose in world coordinates. The controller and
+  `preflight.py` read only `world_x`/`world_y`, but `theta_deg` is what aimed the
+  first Bezier control point, so the opening segment's `poses` cannot be
+  reproduced without it. A file whose `origin` has no `theta_deg` predates the
+  field and is read back as 0, which is how it was written.
 - `waypoints`: User-defined waypoints with odom (x, y) and world coordinates
 - `poses`: Intermediate points for smooth curved path (consumed by the forklift controller)
 - `segments`: Path segment info with reverse flag for each waypoint pair
@@ -121,7 +148,8 @@ The JSON export (including `poses`) is the input format of the SIL forklift cont
 | Pan view | Alt+Drag or Middle Mouse |
 | Zoom | Scroll |
 | Add waypoint | Left Click (in Add mode) |
-| Adjust heading | Shift+Scroll |
+| Set origin | Left Click (in Set Origin mode) |
+| Adjust heading | Shift+Scroll (in Add or Set Origin mode) |
 | Select waypoint | Click on waypoint |
 | Move waypoint | Drag waypoint |
 
@@ -182,7 +210,7 @@ The calibration fields:
 |---|---|
 | `scaleFactor` | Pixels per metre |
 | `translationToGlobalCoordinates` | World origin offset, in metres |
-| `defaultForkliftStart` | Where "Use Default Forklift Start" puts the origin |
+| `defaultForkliftStart` | Where "Use Default Forklift Start" puts the origin. Its `theta_deg` records the prim's yaw for reference only — the button does not apply it, see [Which way the truck faces](#which-way-the-truck-faces) |
 | `forkliftDimensions` | Body drawn on the canvas, in metres |
 | `scene` | The scene USD this plan view was rendered from |
 

--- a/tools/waypoint-generator/src/App.jsx
+++ b/tools/waypoint-generator/src/App.jsx
@@ -170,6 +170,27 @@ function App() {
     setSelectedIndex(-1);
   }, []);
 
+  // Entering Set Origin picks up the heading the origin already has, so the
+  // knob starts where the truck is pointing instead of snapping it to whatever
+  // the last waypoint used.
+  const handleEnterOriginMode = useCallback(() => {
+    if (origin && typeof origin.theta_deg === 'number') {
+      setPreviewHeading(origin.theta_deg);
+    }
+    setMode('origin');
+  }, [origin]);
+
+  // One knob serves both modes: it aims the next waypoint, and in Set Origin it
+  // turns the origin itself. Re-placing the origin is the only other way to
+  // change the start heading, and that clears every waypoint — they are
+  // measured from the origin, so nudging the truck's facing must not bin them.
+  const handleUpdateHeading = useCallback((heading) => {
+    setPreviewHeading(heading);
+    if (mode === 'origin') {
+      setOrigin(prev => (prev ? { ...prev, theta_deg: heading } : prev));
+    }
+  }, [mode]);
+
   // Add waypoint (normal forward)
   const handleAddWaypoint = useCallback((wp) => {
     setWaypoints(prev => [...prev, { ...wp, note: '', reverse: false }]);
@@ -241,7 +262,12 @@ function App() {
     }
 
     if (data.origin) {
-      setOrigin({ x: data.origin.world_x, y: data.origin.world_y });
+      // Files written before the origin carried a heading were exported with it
+      // fixed at 0, so defaulting to 0 reproduces them rather than re-aiming a
+      // path whose poses were already baked that way.
+      const theta = data.origin.theta_deg ?? 0;
+      setOrigin({ x: data.origin.world_x, y: data.origin.world_y, theta_deg: theta });
+      setPreviewHeading(theta);
     }
     if (data.waypoints) {
       setWaypoints(data.waypoints.map(wp => ({
@@ -268,7 +294,13 @@ function App() {
   const handleUseDefaultOrigin = useCallback(() => {
     const defaultStart = mapConfig?.defaultForkliftStart;
     if (!defaultStart) return;
-    setOrigin({ x: defaultStart.world_x, y: defaultStart.world_y });
+    // Only the position comes from the map config. Its theta_deg is the scene
+    // prim's yaw (180 on every map here), which is NOT the heading this file
+    // wants: the controller runs with invert_poses, mirroring the whole path
+    // 180 degrees about the origin, so a truck facing west is driven by a path
+    // drawn heading east. Seeding 180 here puts the opening pose 180 degrees
+    // off the spawned truck and it spins on the spot. See the README.
+    setOrigin({ x: defaultStart.world_x, y: defaultStart.world_y, theta_deg: 0 });
     setMode('waypoint');
     setWaypoints([]);
     setSelectedIndex(-1);
@@ -360,7 +392,7 @@ function App() {
             <div className="mode-buttons">
               <button
                 className={`mode-btn ${mode === 'origin' ? 'active' : ''}`}
-                onClick={() => setMode('origin')}
+                onClick={handleEnterOriginMode}
               >
                 Set Origin
               </button>
@@ -388,19 +420,25 @@ function App() {
               </div>
             )}
             
-            {mode === 'waypoint' && origin && (
+            {(mode === 'origin' || (mode === 'waypoint' && origin)) && (
               <div className="heading-control">
-                <label>Preview Heading: {previewHeading}°</label>
+                <label>
+                  {mode === 'origin' ? 'Start Heading' : 'Preview Heading'}: {previewHeading}°
+                </label>
                 <input
                   type="range"
                   min="-180"
                   max="180"
                   step="5"
                   value={previewHeading}
-                  onChange={(e) => setPreviewHeading(parseInt(e.target.value))}
+                  onChange={(e) => handleUpdateHeading(parseInt(e.target.value))}
                 />
                 <p className="hint">Shift+Scroll to adjust on canvas</p>
-                <p className="hint">Right-click: Add reverse waypoint</p>
+                {mode === 'origin' ? (
+                  <p className="hint">The direction the forklift starts facing</p>
+                ) : (
+                  <p className="hint">Right-click: Add reverse waypoint</p>
+                )}
               </div>
             )}
           </div>
@@ -434,7 +472,7 @@ function App() {
             onAddReverseWaypoint={handleAddReverseWaypoint}
             onSelectWaypoint={handleSelectWaypoint}
             onSetOrigin={handleSetOrigin}
-            onUpdatePreviewHeading={setPreviewHeading}
+            onUpdatePreviewHeading={handleUpdateHeading}
             onMoveWaypoint={handleMoveWaypoint}
           />
         </main>

--- a/tools/waypoint-generator/src/components/ExportPanel.jsx
+++ b/tools/waypoint-generator/src/components/ExportPanel.jsx
@@ -20,7 +20,7 @@ export default function ExportPanel({ mapConfig, waypoints, origin, onImport }) 
       {
         x: origin.x,
         y: origin.y,
-        theta_deg: origin.theta_deg || 0,
+        theta_deg: origin.theta_deg ?? 0,
         reverse: false,  // Origin is never reverse
       },
       // Then all user waypoints
@@ -49,6 +49,10 @@ export default function ExportPanel({ mapConfig, waypoints, origin, onImport }) 
       origin: origin ? {
         world_x: parseFloat(origin.x.toFixed(3)),
         world_y: parseFloat(origin.y.toFixed(3)),
+        // The heading the truck starts at. The controller reads only world_x
+        // and world_y, but this is what shaped the first segment's poses, so
+        // without it re-importing the file would silently redraw them from 0.
+        theta_deg: Math.round(origin.theta_deg ?? 0),
       } : null,
       waypoints: waypoints.map((wp, index) => ({
         // Odom coordinates (relative to origin)

--- a/tools/waypoint-generator/src/components/WaypointCanvas.jsx
+++ b/tools/waypoint-generator/src/components/WaypointCanvas.jsx
@@ -205,7 +205,10 @@ export default function WaypointCanvas({
       ctx.stroke();
       
       // Draw forklift footprint at origin (showing starting position) - NVIDIA green
-      drawForkliftFootprint(ctx, originPixel.x, originPixel.y, 0, zoom, 'rgba(118, 185, 0, 0.25)', '#76b900');
+      drawForkliftFootprint(
+        ctx, originPixel.x, originPixel.y, origin.theta_deg ?? 0, zoom,
+        'rgba(118, 185, 0, 0.25)', '#76b900'
+      );
     }
     
     // Helper function to draw forklift footprint (simple clean design)
@@ -269,7 +272,10 @@ export default function WaypointCanvas({
       const originWaypoint = {
         x: origin.x,
         y: origin.y,
-        theta_deg: 0, // Origin heading (forklift starts pointing right)
+        // The heading the truck starts at. It aims the first Bezier control
+        // point, so a wrong value bends the opening segment out of the truck's
+        // actual facing.
+        theta_deg: origin.theta_deg ?? 0,
         reverse: false,
       };
       
@@ -533,8 +539,15 @@ export default function WaypointCanvas({
       ctx.stroke();
     }
     
-    // Draw origin preview (when in origin mode)
+    // Draw origin preview (when in origin mode). The body and arrow show the
+    // heading the click is about to commit, so the start pose is not placed
+    // blind and then only discovered in the exported poses.
     if (mode === 'origin' && mousePos.x > 0 && mousePos.y > 0) {
+      drawForkliftFootprint(
+        ctx, mousePos.x, mousePos.y, previewHeading, zoom,
+        'rgba(0, 170, 255, 0.15)', 'rgba(0, 170, 255, 0.6)'
+      );
+
       ctx.strokeStyle = 'rgba(0, 170, 255, 0.6)';
       ctx.lineWidth = 2 / zoom;
       ctx.setLineDash([4 / zoom, 4 / zoom]);
@@ -545,6 +558,18 @@ export default function WaypointCanvas({
         ORIGIN_RADIUS * 2
       );
       ctx.setLineDash([]);
+
+      const originHeadingRad = (previewHeading * Math.PI) / 180;
+      const originArrowLen = ARROW_LENGTH / zoom;
+      ctx.beginPath();
+      ctx.moveTo(mousePos.x, mousePos.y);
+      ctx.lineTo(
+        mousePos.x + Math.cos(originHeadingRad) * originArrowLen,
+        mousePos.y - Math.sin(originHeadingRad) * originArrowLen
+      );
+      ctx.strokeStyle = 'rgba(255, 255, 255, 0.7)';
+      ctx.lineWidth = 2 / zoom;
+      ctx.stroke();
     }
     
     ctx.restore();
@@ -607,7 +632,7 @@ export default function WaypointCanvas({
       
       if (mode === 'origin') {
         const world = pixelToWorld(imagePos.x, imagePos.y);
-        onSetOrigin?.({ x: world.x, y: world.y });
+        onSetOrigin?.({ x: world.x, y: world.y, theta_deg: previewHeading });
       } else if (mode === 'waypoint' && origin) {
         // Check if clicking on existing waypoint
         const wpIndex = findWaypointAt(imagePos.x, imagePos.y);
@@ -687,15 +712,11 @@ export default function WaypointCanvas({
   const handleWheel = (e) => {
     e.preventDefault();
     
-    if (e.shiftKey && mode === 'waypoint') {
-      // Shift + scroll = adjust preview heading
+    if (e.shiftKey && (mode === 'waypoint' || mode === 'origin')) {
+      // Shift + scroll = adjust preview heading (the origin's own start heading
+      // while in origin mode)
       const delta = e.deltaY > 0 ? -10 : 10;
-      onUpdatePreviewHeading?.(prev => {
-        let newHeading = prev + delta;
-        while (newHeading > 180) newHeading -= 360;
-        while (newHeading < -180) newHeading += 360;
-        return newHeading;
-      });
+      onUpdatePreviewHeading?.(coords.normalizeAngle(previewHeading + delta));
     } else {
       // Normal scroll = zoom
       const zoomFactor = e.deltaY > 0 ? 0.9 : 1.1;


### PR DESCRIPTION
## Summary

The origin was the only pose in the tool without a heading. It was stored as `{x, y}`, and every consumer that needed an angle substituted 0 — the canvas drew the start forklift pointing east, the path preview built its first waypoint at 0, and `ExportPanel` read `origin.theta_deg`, a field nothing ever set. Set Origin mode offered no way to change it: Shift+Scroll was gated on waypoint mode and the slider was hidden.

That is not cosmetic. The origin's heading aims the first Bezier control point, so the opening segment of every exported path was shaped as if the truck pointed east regardless of where it actually pointed, and those `poses` go to the forklift controller.

- The origin now carries `theta_deg`, and one heading knob serves both modes: Shift+Scroll and the slider set it, the Set Origin preview draws the body and an arrow so the click is not blind, and turning the knob re-aims an origin already placed — re-placing it was previously the only way to change the start heading, and that clears every waypoint.
- The value is written into the exported `origin` block, so a re-import reproduces the same poses instead of silently redrawing them from 0.
- It is deliberately **not** seeded from the map's `defaultForkliftStart.theta_deg`. See below.

## The trap this leaves documented

`defaultForkliftStart.theta_deg` is 180 on every map because that is the scene prim's yaw. It is *not* the heading this file wants: the controller runs with `invert_poses` (default true, and `forklift-controller.yml` sets `NO_INVERT=false` explicitly) plus `HEADING_OFFSET=180`, mirroring the whole path 180 degrees about the origin. That is why the paths in `forklift-controller/waypoints/` are drawn heading east for a truck that faces west.

Measured on the shipped `warehouse_40x20/forklift_b.json`, redrawing the same waypoints through the tool's own Bezier:

| origin `theta_deg` | heading error vs the spawned truck |
|---|---|
| 0 | 0.0 deg |
| 180 | 180.0 deg — the truck spins on the spot |

So "Use Default Forklift Start" takes only the position and leaves the heading at 0, preserving today's behaviour exactly. A new README section, *Which way the truck faces*, explains the mirror so the next reader does not "fix" it back.

## Compatibility

Backward compatible in both directions:

- An `origin` with no `theta_deg` imports as 0, which is how such files were written.
- The controller reads only `world_x`/`world_y` via `.get()`, so the new key is ignored. `preflight.py` likewise.
- The four shipped waypoint files are untouched, so SIL runs are unchanged.

## Test plan

- [x] Verified against the real `RobotController.load_path` (ROS stubbed, only the parsing path runs): the shipped waypoint files load with no error, a fresh export loads with no error, and the export parses to **identical poses with and without** `theta_deg`.
- [x] `preflight.py`'s `_waypoint_origin` parses old and new files alike.
- [x] Browser tests over all three maps: "Use Default Forklift Start" yields `theta_deg` 0; the Set Origin knob appears and re-aims the origin; waypoints survive the rotation; Shift+Scroll adjusts on canvas; a placed origin commits the previewed heading; the value round-trips through export/import; a file with the key stripped reads back as 0.
- [x] `eslint` introduces no new errors (the 4 remaining were verified present on `develop`).
- [ ] Draw and drive a path in SIL to confirm the truck pulls away instead of spinning.