### PR TITLE
chore(sil): cut comments that narrate, and stop the two topic rules drifting

### DIFF
--- a/closed-loop-testing/forklift-controller/docker_run.sh
+++ b/closed-loop-testing/forklift-controller/docker_run.sh
@@ -26,10 +26,8 @@ DOCKER_ARGS=(
     docker run --rm --name "$NAME" --network host
     -e ROS_DOMAIN_ID="${ROS_DOMAIN_ID:-0}"
     -e RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
-    # No fleet file is mounted here, so the drive knobs come from
-    # fleet_config.DRIVE_DEFAULTS — which hold the same values robots.yaml
-    # states for forklift_b. Naming a truck other than the default therefore
-    # gets the default's speed and heading; use compose for a real fleet.
+    # No fleet file is mounted, so drive knobs fall back to DRIVE_DEFAULTS —
+    # forklift_b's values. Use compose for a real fleet.
     -e ROBOT_ID="${ROBOT_ID:-forklift_b}"
 )
 

--- a/closed-loop-testing/forklift-controller/fleet_config.py
+++ b/closed-loop-testing/forklift-controller/fleet_config.py
@@ -40,22 +40,28 @@ DRIVE_DEFAULTS = {
 }
 
 
-def load_fleet(robots_config_path: str) -> list[dict]:
-    """Every robot in the config, each already folded with its model."""
+def _loader():
+    """The Isaac-side module both this file and the graph builders read."""
     if ISAAC_SCRIPTS_DIR not in sys.path:
         sys.path.insert(0, ISAAC_SCRIPTS_DIR)
     try:
-        from action_graphs.forklift_common import load_and_validate_robots_yaml
+        from action_graphs import forklift_common
     except ImportError as exc:
         raise RuntimeError(
             f"cannot import the fleet loader from {ISAAC_SCRIPTS_DIR} ({exc}). "
             f"The forklift-controller service mounts the Isaac script tree; check "
             f"that mount, or set ISAAC_SCRIPTS_DIR."
         ) from exc
-    # The loader names the knobs, this file gives them values. Two lists that
-    # must agree are worth one assertion rather than a knob that reads as
-    # unknown on one side and as a default on the other.
-    from action_graphs.forklift_common import KNOWN_DRIVE_KEYS
+    return forklift_common
+
+
+def load_fleet(robots_config_path: str) -> list[dict]:
+    """Every robot in the config, each already folded with its model."""
+    common = _loader()
+    load_and_validate_robots_yaml = common.load_and_validate_robots_yaml
+    KNOWN_DRIVE_KEYS = common.KNOWN_DRIVE_KEYS
+    # The loader names the knobs, this file gives them values; the two lists
+    # must not drift.
     if set(KNOWN_DRIVE_KEYS) != set(DRIVE_DEFAULTS):
         raise RuntimeError(
             f"drive knobs disagree: forklift_common knows {sorted(KNOWN_DRIVE_KEYS)}, "
@@ -119,17 +125,13 @@ def resolve_topics(robot: Optional[dict], robot_id: str) -> dict:
     rebuilding the strings is what stops the two sides drifting. Without a fleet
     file — a run started by hand — the namespaced convention still applies.
     """
-    control = (robot or {}).get("control") or {}
-    odometry = (robot or {}).get("odometry") or {}
-
-    def norm(value, fallback):
-        value = value or fallback
-        return value if value.startswith("/") else f"/{value}"
-
-    return {
-        "cmd_vel": norm(control.get("cmd_vel_topic"), f"{robot_id}/cmd_vel"),
-        "odom": norm(odometry.get("odom_topic"), f"{robot_id}/odom"),
-    }
+    if robot is None:
+        names = {"cmd_vel": f"{robot_id}/cmd_vel", "odom": f"{robot_id}/odom"}
+    else:
+        common = _loader()
+        names = {"cmd_vel": common.resolve_cmd_vel_topic(robot),
+                 "odom": common.resolve_odom_topic(robot)}
+    return {k: v if v.startswith("/") else f"/{v}" for k, v in names.items()}
 
 
 SCENARIO_KEYS = ("ira", "robots", "cameras", "waypoints", "experimental")

--- a/closed-loop-testing/forklift-controller/forklift-controller.yml
+++ b/closed-loop-testing/forklift-controller/forklift-controller.yml
@@ -1,22 +1,12 @@
-# Everything every forklift controller shares. A truck differs only in its
-# ROBOT_ID — speed, heading and route all come from its block in the robots
-# config. One container drives one truck, so which truck it is has to be said
-# here; everything else about it is said once, in the fleet file.
+# One container drives one truck, so a service says which truck it is and
+# nothing else about it.
 x-forklift-env: &forklift-env
   ROS_DOMAIN_ID: ${ROS_DOMAIN_ID:-0}
   ROS_AUTOMATIC_DISCOVERY_RANGE: ${ROS_AUTOMATIC_DISCOVERY_RANGE:-SUBNET}  # SUBNET=LAN multicast (multi-host/HIL) | LOCALHOST=single-host SIL (set in sil.env) | OFF
   RMW_IMPLEMENTATION: rmw_cyclonedds_cpp
-  # Isaac reads the same SCENARIO, so the two cannot run different halves of one
-  # run. It names the fleet file and the map; the two below override it per run.
-  SCENARIO: ${SCENARIO:-}
-  # A directory name under waypoints/, overriding the scenario's for one run.
-  # There is no companion override for the fleet file: a different fleet is a
-  # different run, and a run is named by adding an entry to scenarios.yaml.
-  WAYPOINTS_MAP: ${WAYPOINTS_MAP:-}
-  # Passed through only so entrypoint.sh can refuse it. A profile carrying the
-  # old variable is the case the refusal exists for, and a guard compose never
-  # hands the variable to is a guard that cannot fire.
-  FORKLIFT_WAYPOINTS_DIR: ${FORKLIFT_WAYPOINTS_DIR:-}
+  SCENARIO: ${SCENARIO:-}            # Isaac reads the same one, so the two halves cannot disagree
+  WAYPOINTS_MAP: ${WAYPOINTS_MAP:-}   # overrides the scenario's waypoint set for one run
+  FORKLIFT_WAYPOINTS_DIR: ${FORKLIFT_WAYPOINTS_DIR:-}   # passed only so entrypoint.sh can refuse it
 
 x-forklift-volumes: &forklift-volumes
   # The robots config and the loader that reads it. Shared rather than copied:

--- a/closed-loop-testing/forklift-controller/launch_controller.sh
+++ b/closed-loop-testing/forklift-controller/launch_controller.sh
@@ -4,12 +4,9 @@
 # Launch robot controller with common options
 # Usage: ./launch_controller.sh [robot_id] [path_file]
 #
-# CONTRACT: robot_id MUST be a block name in the fleet file this reads — the
-# Isaac graphs only subscribe /<robot_id>/cmd_vel and publish /<robot_id>/odom,
-# and speed, heading and loop all come from that block. ROBOTS_CONFIG picks the
-# file and defaults to configs/robots.yaml, which declares forklift_b alone, so
-# a second truck names its file too. A robot_id the file does not declare is
-# refused by name rather than driven with defaults.
+# CONTRACT: robot_id MUST be a block name in the fleet file, which ROBOTS_CONFIG
+# picks and which defaults to robots.yaml — forklift_b alone, so a second truck
+# names its file too. An undeclared robot_id is refused rather than defaulted.
 #
 # Example (second forklift, 40x20):
 #   ROBOTS_CONFIG=robots-40x20.yaml WAYPOINTS_MAP=warehouse_40x20 \
@@ -47,19 +44,12 @@ echo ""
 
 cd "$SCRIPT_DIR"
 
-# No drive knob is passed as a flag. A flag outranks the fleet file, so a speed
-# hardcoded here would quietly override robots.yaml and this script would drive
-# the truck differently from the deployment it exists to mimic — which is what it
-# used to do: --speed 1 against a fleet file that says 1.5. It reads the same
-# fleet file Isaac reads instead.
-# Both are this script's own variables, not deployment settings: compose has no
-# fleet override, because a different fleet there is a different SCENARIO. Here
-# there is no scenario to name, so the file is named directly.
+# No drive knob is passed as a flag: a flag outranks the fleet file, so one
+# hardcoded here would drive the truck unlike the deployment this mimics.
 CONFIGS_DIR="${CONFIGS_DIR:-$SCRIPT_DIR/../isaac-sim/sil/configs}"
 ROBOTS_CONFIG="${ROBOTS_CONFIG:-robots.yaml}"
 case "$ROBOTS_CONFIG" in /*) ;; *) ROBOTS_CONFIG="$CONFIGS_DIR/$ROBOTS_CONFIG" ;; esac
-# Where fleet_config imports the shared loader from: a mount in the container,
-# the checkout here.
+# fleet_config imports the shared loader from here (a mount in the container).
 export ISAAC_SCRIPTS_DIR="${ISAAC_SCRIPTS_DIR:-$SCRIPT_DIR/../isaac-sim/sil/scripts}"
 
 exec python3 robot_controller.py \

--- a/closed-loop-testing/forklift-controller/robot_controller.py
+++ b/closed-loop-testing/forklift-controller/robot_controller.py
@@ -722,10 +722,8 @@ def main():
 
     args, unknown = parser.parse_known_args()
 
-    # argparse hands what it does not recognise to rclpy, which ignores it. A
-    # flag this release removed would therefore do nothing and say nothing, and
-    # the caller would go on believing it still works. Refuse instead — the same
-    # choice entrypoint.sh makes for the waypoints variable this release removed.
+    # rclpy ignores what argparse did not recognise, so a removed flag would do
+    # nothing and say nothing. Name it instead.
     if any(token.split('=', 1)[0] == '--no-namespace' for token in unknown):
         parser.error(
             "--no-namespace was removed: topic names come from the robot's block "

--- a/closed-loop-testing/isaac-sim/sil/configs/robots-2fl.yaml
+++ b/closed-loop-testing/isaac-sim/sil/configs/robots-2fl.yaml
@@ -1,26 +1,13 @@
 # Halos SIL forklift / robot Action Graph config (6.0) — TWO-FORKLIFT variant.
 #
-# Opt-in multi-robot config (forklift_b + forklift_b2). The default is the
-# single-robot configs/robots.yaml. Two lines in the profile env run this
-# variant, and nothing else:
+# Opt-in multi-robot config (forklift_b + forklift_b2). Two lines run it:
 #   SCENARIO=warehouse_20x20_2fl
 #   COMPOSE_PROFILES=sil,multi-robot     (or hil,multi-robot)
-# The profile decides whether the second controller container exists; the
-# scenario decides what it drives, naming this file together with the IRA
-# config, the cameras config and the waypoint set — see configs/scenarios.yaml.
-# Individual flags (-c, --robots-config) still win, for a one-off run.
 #
-# What that scenario is holding together, and why each half matters:
-#   - The scene must contain /World/forklift_b2 (a clone of /World/forklift_b,
-#     same ForkliftB asset payload). The repo ships one, and
-#     default_config_ros_2fl.yaml points at it. run_actor_sdg fails fast if a
-#     listed articulation prim is missing.
-#   - The waypoint set must be warehouse_20x20. A path is metres in one scene's
-#     world frame and the controller subtracts the file's origin from every
-#     pose, so the 40x20 set runs here without complaint — forklift_b2 4.63 m
-#     off its lane, nothing logged. preflight.py compares each origin against
-#     where the truck stands; pass --scene, since both trucks here are baked
-#     rather than spawned.
+# The waypoint set must be warehouse_20x20: the controller subtracts the file's
+# origin from every pose, so the 40x20 set runs here without complaint —
+# forklift_b2 4.63 m off its lane, nothing logged. preflight.py --scene compares
+# each origin against where the truck stands (both trucks here are baked).
 # The shipped 2FL scene intentionally differs from the stock scene beyond the
 # forklift_b2 clone (multi-forklift test scenario): 4 Loading_Zone_Objects
 # prims deactivated, 2 RectLights repositioned toward the second corridor,

--- a/closed-loop-testing/isaac-sim/sil/configs/scenarios.yaml
+++ b/closed-loop-testing/isaac-sim/sil/configs/scenarios.yaml
@@ -1,10 +1,6 @@
-# What to run. One entry per scenario; the key is the id, and `SCENARIO=<id>` in
-# the profile env picks one. Isaac and every forklift controller read the same
-# id, so they cannot end up on different halves of one run.
-#
-# A scenario says what to run. Where to run it — host IP, data paths, GPU,
-# docker gid — stays in deployments/profiles/*.env. A command-line flag still
-# wins over a scenario, for a one-off run.
+# What to run. One entry per scenario; `SCENARIO=<id>` in the profile env picks
+# one, and Isaac and every controller read the same id. Where to run it — host
+# IP, data paths, GPU — stays in the profile env. A flag wins over a scenario.
 #
 #   ira        IRA config. The scene USD is named inside it, so it is not repeated here
 #   robots     fleet file: which trucks exist and how each drives

--- a/closed-loop-testing/isaac-sim/sil/scripts/run_actor_sdg.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/run_actor_sdg.py
@@ -1017,12 +1017,8 @@ def main():
     # not pass --robots-config, mirroring the cameras.yaml default above.
     robots_config_path = None
     configs_dir = _configs_dir
-    # SCENARIO names the fleet file for BOTH this process and the
-    # forklift-controller containers, so the two cannot be launched against
-    # different fleets. There is deliberately no environment override for the
-    # fleet alone: it would pair one scenario's trucks with another's scene,
-    # unnamed and unrecorded. A different fleet is a different scenario. The
-    # flag still wins, for a one-off run that is not worth a scenario id.
+    # SCENARIO names the fleet file for this process and for every controller,
+    # so the two halves cannot run against different fleets. The flag still wins.
     env_robots = scenario.get("robots", "")
     robots_source = f"SCENARIO={args.scenario or os.environ.get('SCENARIO', '')}"
 

--- a/closed-loop-testing/scripts/setup.sh
+++ b/closed-loop-testing/scripts/setup.sh
@@ -13,13 +13,15 @@
 # sil-data (nvidia/halos-outside-in/sample-sil-data) is a SIL-only prerequisite — pull separately.
 #
 # Usage:
-#   ./scripts/setup.sh <base|sil|hil>     # reads ../../deployments/profiles/<profile>.env
+#   ./scripts/setup.sh <profile>          # reads ../../deployments/profiles/<profile>.env
+#                                         # any name; what it sets up follows from
+#                                         # COMPOSE_PROFILES inside that file
 
 set -e
 
 PROFILE="${1:-}"
 if [ -z "$PROFILE" ]; then
-    echo "ERROR: profile required. Usage: ./scripts/setup.sh <base|sil|hil>"
+    echo "ERROR: profile required. Usage: ./scripts/setup.sh <profile>  (e.g. sil)"
     exit 1
 fi
 
@@ -31,14 +33,6 @@ echo "============================================================"
 echo "  Halos Outside-In Safety — setup (profile: $PROFILE)"
 echo "============================================================"
 
-# Which services' data dirs does this profile need?
-case "$PROFILE" in
-    base) NEED_PSF=1 ;;
-    sil)  NEED_PSF=1; NEED_COMM=1; NEED_ISAAC=1 ;;
-    hil)  NEED_COMM=1; NEED_ISAAC=1 ;;
-    *) echo "ERROR: unknown profile '$PROFILE' (base|sil|hil)"; exit 1 ;;
-esac
-
 # Load profile env
 if [ ! -f "$ENV_FILE" ]; then
     echo "ERROR: env file not found: $ENV_FILE"
@@ -46,6 +40,18 @@ if [ ! -f "$ENV_FILE" ]; then
 fi
 echo "Loading $ENV_FILE"
 set -a; source "$ENV_FILE"; set +a
+
+# Which services' data dirs to prepare, taken from the profile's own
+# COMPOSE_PROFILES rather than from its file name — so a profile copied to any
+# name is set up for what it will actually start.
+case ",${COMPOSE_PROFILES}," in *,base,*) NEED_PSF=1 ;; esac
+case ",${COMPOSE_PROFILES}," in *,sil,*)  NEED_PSF=1; NEED_COMM=1; NEED_ISAAC=1 ;; esac
+case ",${COMPOSE_PROFILES}," in *,hil,*)  NEED_COMM=1; NEED_ISAAC=1 ;; esac
+if [ -z "${NEED_PSF}${NEED_COMM}${NEED_ISAAC}" ]; then
+    echo "ERROR: COMPOSE_PROFILES in $ENV_FILE is '${COMPOSE_PROFILES:-<empty>}',"
+    echo "       which names none of base|sil|hil, so there is nothing to set up."
+    exit 1
+fi
 
 # Validate MDX_DATA_DIR (catch unedited template)
 if [ -z "$MDX_DATA_DIR" ]; then

--- a/deployments/profiles/hil.env
+++ b/deployments/profiles/hil.env
@@ -17,13 +17,9 @@ COMPOSE_PROFILES=hil
 #   warehouse_20x20_1fl  (default)  |  warehouse_20x20_2fl  |  warehouse_40x20
 SCENARIO=warehouse_20x20_1fl
 
-# One-off override of the scenario's waypoint set. Leave empty in normal use.
-# There is no companion override for the fleet file: a different fleet is a
-# different run, and a run is named by adding an entry to scenarios.yaml.
-# WAYPOINTS_MAP names a directory under forklift-controller/waypoints/, and its
-# coordinates are metres in ONE warehouse's world frame — a map from a different
-# warehouse than the scenario's scene drives a lane nobody validated, and the
-# truck moves the whole time. preflight.py --scene catches it; nothing else does.
+# Overrides the scenario's waypoint set for one run. A set from a different
+# warehouse drives a lane nobody validated, and the truck moves the whole time
+# — preflight.py --scene catches it, nothing else does.
 #WAYPOINTS_MAP=warehouse_20x20
 
 MDX_SAMPLE_APPS_DIR=/path/to/halos-outside-in-safety # change me

--- a/deployments/profiles/sil.env
+++ b/deployments/profiles/sil.env
@@ -14,13 +14,9 @@ COMPOSE_PROFILES=sil
 #   warehouse_20x20_1fl  (default)  |  warehouse_20x20_2fl  |  warehouse_40x20
 SCENARIO=warehouse_20x20_1fl
 
-# One-off override of the scenario's waypoint set. Leave empty in normal use.
-# There is no companion override for the fleet file: a different fleet is a
-# different run, and a run is named by adding an entry to scenarios.yaml.
-# WAYPOINTS_MAP names a directory under forklift-controller/waypoints/, and its
-# coordinates are metres in ONE warehouse's world frame — a map from a different
-# warehouse than the scenario's scene drives a lane nobody validated, and the
-# truck moves the whole time. preflight.py --scene catches it; nothing else does.
+# Overrides the scenario's waypoint set for one run. A set from a different
+# warehouse drives a lane nobody validated, and the truck moves the whole time
+# — preflight.py --scene catches it, nothing else does.
 #WAYPOINTS_MAP=warehouse_20x20
 
 MDX_SAMPLE_APPS_DIR=/path/to/halos-outside-in-safety # change me — repo checkout root


### PR DESCRIPTION
Three cleanups against #63, no behaviour change. Split out so the functional work could land first.

## Comments

The branch commented at the same weight everywhere, so a block warning about a real trap read like a block restating the line under it — and the warnings are the ones that matter. Net **−50 comment lines**. What went:

- prose that belongs in a changelog and is already there (why there is no fleet-file override, what a flag outranks)
- restatements of the line below (`launch_controller.sh` explaining its own two variables in eight lines)
- the same fact said twice in one header (`scenarios.yaml` opening with "what to run" in both paragraphs)

What stayed: the waypoint-set warning (a set from another warehouse drives an unvalidated lane and the truck moves the whole time), why the fleet file and its loader are shared rather than copied, and why `FORKLIFT_WAYPOINTS_DIR` is passed through at all.

## One topic rule, not two

`fleet_config.resolve_topics` rebuilt the rule that `forklift_common.resolve_cmd_vel_topic` / `resolve_odom_topic` already implement, and dropped their validation on the way: an empty `cmd_vel_topic` silently became the namespaced default. It calls them now.

```
robots.yaml: 'forklift_b'.control.cmd_vel_topic must be a non-empty topic name, got ''
```

Resolved names are byte-identical before and after for all three shipped fleet files and for a run with no fleet file:

```
robots.yaml        forklift_b   cmd_vel=/forklift_b/cmd_vel    odom=/forklift_b/odom
robots-2fl.yaml    forklift_b2  cmd_vel=/forklift_b2/cmd_vel   odom=/forklift_b2/odom
robots-40x20.yaml  forklift_b2  cmd_vel=/forklift_b2/cmd_vel   odom=/forklift_b2/odom
(no fleet file)    forklift_x   cmd_vel=/forklift_x/cmd_vel    odom=/forklift_x/odom
```

## setup.sh takes any profile name

It picked the services to prepare from the profile's **file name**, so a profile copied to any other name was refused — while the docs suggest copying one. It now reads `COMPOSE_PROFILES` from inside the file, which is what compose will act on, so the set-up matches what will start. `base`, `sil` and `hil` resolve exactly as before; `sil,multi-robot` and a renamed profile now work.

## Testing

No GPU run: nothing here changes what a container does. Checked locally — Python compile, `bash -n`, YAML parse, compose renders for all three profiles, `preflight.py` still reports 0 errors, and the before/after topic comparison above.
