### PR TITLE
refactor(sil): one reader for scenarios.yaml, not four

### DIFF
--- a/closed-loop-testing/forklift-controller/fleet_config.py
+++ b/closed-loop-testing/forklift-controller/fleet_config.py
@@ -134,35 +134,6 @@ def resolve_topics(robot: Optional[dict], robot_id: str) -> dict:
     return {k: v if v.startswith("/") else f"/{v}" for k, v in names.items()}
 
 
-SCENARIO_KEYS = ("ira", "robots", "cameras", "waypoints", "experimental")
-
-
 def load_scenario(configs_dir: str, scenario_id: str) -> dict:
-    """One entry of `scenarios.yaml`. Unknown id is fatal, and lists what exists.
-
-    A scenario names what to run; the profile env names where. Both Isaac and
-    the controllers read the same id, so a run cannot be half one scenario and
-    half another.
-    """
-    import yaml
-
-    path = os.path.join(configs_dir, "scenarios.yaml")
-    if not os.path.isfile(path):
-        raise SystemExit(f"[scenario] {path} not found")
-    with open(path) as handle:
-        data = yaml.safe_load(handle) or {}
-    if scenario_id not in data:
-        raise SystemExit(
-            f"[scenario] '{scenario_id}' is not in {path}. "
-            f"Known scenarios: {', '.join(sorted(data)) or '(none)'}."
-        )
-    entry = data[scenario_id] or {}
-    if not isinstance(entry, dict):
-        raise SystemExit(f"[scenario] {path}: '{scenario_id}' must be a mapping")
-    unknown = sorted(set(entry) - set(SCENARIO_KEYS))
-    if unknown:
-        raise SystemExit(
-            f"[scenario] {path}: '{scenario_id}' has unknown key(s) "
-            f"{', '.join(unknown)}. Known keys: {', '.join(SCENARIO_KEYS)}."
-        )
-    return entry
+    """One entry of scenarios.yaml, read by the same parser Isaac uses."""
+    return _loader().load_scenario(configs_dir, scenario_id)

--- a/closed-loop-testing/isaac-sim/sil/scripts/action_graphs/forklift_common.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/action_graphs/forklift_common.py
@@ -71,6 +71,35 @@ _MODEL_CONTROL_KEYS = (
 _MODEL_INDICATOR_MESH_KEYS = ("radius", "segments", "height_offset")
 
 
+SCENARIO_KEYS = ("ira", "robots", "cameras", "waypoints", "experimental")
+
+
+def load_scenario(configs_dir: str, scenario_id: str) -> dict:
+    """One entry of scenarios.yaml. An unknown id is fatal and lists what exists."""
+    import yaml
+
+    path = os.path.join(configs_dir, "scenarios.yaml")
+    if not os.path.isfile(path):
+        raise SystemExit(f"[scenario] {path} not found")
+    with open(path) as handle:
+        data = yaml.safe_load(handle) or {}
+    if scenario_id not in data:
+        raise SystemExit(
+            f"[scenario] '{scenario_id}' is not in {path}. "
+            f"Known scenarios: {', '.join(sorted(data)) or '(none)'}."
+        )
+    entry = data[scenario_id] or {}
+    if not isinstance(entry, dict):
+        raise SystemExit(f"[scenario] {path}: '{scenario_id}' must be a mapping")
+    unknown = sorted(set(entry) - set(SCENARIO_KEYS))
+    if unknown:
+        raise SystemExit(
+            f"[scenario] {path}: '{scenario_id}' has unknown key(s) "
+            f"{', '.join(unknown)}. Known keys: {', '.join(SCENARIO_KEYS)}."
+        )
+    return entry
+
+
 def is_number(x) -> bool:
     """A real number from YAML, rejecting bool, NaN and infinity.
 

--- a/closed-loop-testing/isaac-sim/sil/scripts/run_actor_sdg.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/run_actor_sdg.py
@@ -879,15 +879,8 @@ def main():
     scenario = {}
     scenario_id = (args.scenario or os.environ.get("SCENARIO", "")).strip()
     if scenario_id:
-        import yaml as _yaml
-        _path = os.path.join(_configs_dir, "scenarios.yaml")
-        with open(_path) as _fh:
-            _all = _yaml.safe_load(_fh) or {}
-        if scenario_id not in _all:
-            print(f"ERROR: scenario '{scenario_id}' is not in {_path}. "
-                  f"Known: {', '.join(sorted(_all)) or '(none)'}", file=sys.stderr)
-            sys.exit(1)
-        scenario = _all[scenario_id] or {}
+        from action_graphs.forklift_common import load_scenario
+        scenario = load_scenario(_configs_dir, scenario_id)
         print(f"Scenario: {scenario_id}"
               f"{'  [EXPERIMENTAL - no published calibration; do not score this run]' if scenario.get('experimental') else ''}")
 

--- a/deployments/scripts/preflight.py
+++ b/deployments/scripts/preflight.py
@@ -234,8 +234,12 @@ def _scenario_value(svc, key):
     path = next((c for c in candidates if os.path.isfile(c)), None)
     if path is None:
         return None
-    with open(path) as handle:
-        return ((yaml.safe_load(handle) or {}).get(scenario_id) or {}).get(key)
+    # Tolerant on purpose: a checker reports what it found, it does not exit.
+    try:
+        return _load_forklift_common().load_scenario(
+            os.path.dirname(path), scenario_id).get(key)
+    except SystemExit:
+        return None
 
 
 def _check_origin(service_name, robot, waypoint, host_path, baked, baked_reason):


### PR DESCRIPTION
Four places resolved a scenario id, and they did not agree:

| reader | unknown key | unknown id |
|---|---|---|
| `fleet_config.load_scenario` | rejected, listing the known keys | listed the ids that exist |
| `run_actor_sdg.py` (inline) | accepted | listed the ids |
| `preflight._scenario_value` | accepted | returned `None` |

So a scenario one of them accepted was not necessarily one the others would — and `scenarios.yaml` is the file the whole run now hangs off.

The parser moves to `forklift_common`, which the Isaac graph builders and the controller already share, and the other three call it. `fleet_config.load_scenario` stays as a name so its callers do not change.

Behaviour is unchanged where they already agreed. `preflight` still returns `None` rather than exiting: a checker that cannot resolve a scenario should report what it found, not stop before the other checks run.

## Why now

Groundwork. comm-layer needs the same resolution to derive its mute mirrors from the fleet file instead of `COMM_ROBOT_IDS`, and adding a fourth private reader is exactly what this removes. That change follows in its own PR — it needs an image rebuild and a GPU smoke test, this does not.

## Testing

No GPU run: no container behaviour changes.

- the shared parser resolves every shipped scenario, and refuses an unknown id with the same message, from both the controller path and the Isaac import path
- `docker compose config` renders for `base`, `sil`, `hil`
- `preflight.py`: 0 errors on the default profile, and still catches a `--robots-config` the run will not read
- Python compile, `bash -n`, YAML parse across the tree
