### PR TITLE
feat(sil): comm-layer derives its mute mirrors from the fleet file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,24 @@ waypoint set for an existing scene is genuinely the same run driven differently.
   mounts no fleet file and so runs on `fleet_config.DRIVE_DEFAULTS`, which hold
   the same values `robots.yaml` states for `forklift_b`.
 
+### Changed
+
+- **comm-layer derives its mute mirrors from the fleet file.** `COMM_ROBOT_IDS`
+  was a fourth list of robot names kept by hand, and the only way to get it
+  wrong was silent: a truck missing from it listens on a topic nobody publishes,
+  so its disc sits on the alarm colour for the whole run with nothing in any
+  log. comm-layer now mounts the same configs directory the controllers do,
+  reads `SCENARIO`, and mirrors for exactly the robots whose fleet entry asks
+  for a per-robot topic. The variable is gone from both profiles, and
+  `preflight.py` checks three lists rather than four.
+
+  The shipped value was already wrong for the default run: it named two trucks
+  while `robots.yaml` declares one and names the global topic explicitly, so
+  every 20x20 run published two mirrors nobody subscribed to and preflight
+  warned about it each time. Derived, that run asks for none.
+
+  **Needs `up -d --build`** — the comm-layer image changes.
+
 ### Removed
 
 - **The `warehouse_20x20_2fl` scenario, and the scene, IRA config and fleet file

--- a/closed-loop-testing/comm-layer/Dockerfile
+++ b/closed-loop-testing/comm-layer/Dockerfile
@@ -41,7 +41,7 @@ COPY scripts/entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
 
 # Create logs directory
-RUN mkdir -p /app/logs
+RUN mkdir -p /app/logs /app/robots /app/isaac
 
 # Expose ports
 # UDP port for receiving commands from PSF
@@ -55,7 +55,6 @@ ENV OPCUA_ENDPOINT=opc.tcp://0.0.0.0:4840/safety/
 ENV ROS_TOPIC_PREFIX=/safety
 ENV ROS_DOMAIN_ID=0
 # Empty on purpose: no per-robot is_muted mirrors unless a deployment asks for them.
-ENV ROS_ROBOT_IDS=
 
 # Python path for local modules
 ENV PYTHONPATH=/app/comm_layer:/app/ros_bridge

--- a/closed-loop-testing/comm-layer/comm-layer.yml
+++ b/closed-loop-testing/comm-layer/comm-layer.yml
@@ -11,12 +11,16 @@ services:
       - UDP_PORT=${COMM_UDP_PORT}
       - OPCUA_ENDPOINT=${COMM_OPCUA_ENDPOINT:-opc.tcp://0.0.0.0:4840/safety/}
       - ROS_TOPIC_PREFIX=${COMM_ROS_TOPIC_PREFIX:-/safety}
-      - ROS_ROBOT_IDS=${COMM_ROBOT_IDS:-}  # comma-separated; mirrors is_muted to /<id>/safety/is_muted. Empty = global topic only (HIL default). Must match `name` in the scene's robots.yaml.
+      - SCENARIO=${SCENARIO:-}   # its fleet file says which robots want a /<id>/safety/is_muted mirror
       - ROS_DOMAIN_ID=${ROS_DOMAIN_ID:-0}
       - ROS_AUTOMATIC_DISCOVERY_RANGE=${ROS_AUTOMATIC_DISCOVERY_RANGE:-SUBNET}  # SUBNET=LAN multicast (multi-host/HIL) | LOCALHOST=single-host SIL (set in sil.env) | OFF
       - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
     volumes:
       - ${COMM_LOG_DIR:-${MDX_DATA_DIR}/comm-layer}:/app/logs:rw
+      # The fleet file and the loader that reads it, the same two the
+      # forklift-controller mounts.
+      - ${ISAAC_SIL_DIR:-../isaac-sim/sil}/configs:/app/robots:ro
+      - ${ISAAC_SIL_DIR:-../isaac-sim/sil}/scripts:/app/isaac:ro
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "python3", "-c", "from asyncua.sync import Client; c=Client('opc.tcp://localhost:4840/safety/'); c.connect(); c.disconnect()"]

--- a/closed-loop-testing/comm-layer/scripts/entrypoint.sh
+++ b/closed-loop-testing/comm-layer/scripts/entrypoint.sh
@@ -17,7 +17,6 @@ echo "  UDP Port:        $UDP_PORT"
 echo "  OPC UA Endpoint: $OPCUA_ENDPOINT"
 echo "  ROS Topic:       $ROS_TOPIC_PREFIX"
 echo "  ROS Domain ID:   $ROS_DOMAIN_ID"
-echo "  Robot mirrors:   ${ROS_ROBOT_IDS:-<none>}"
 echo ""
 
 # Create log files
@@ -75,7 +74,7 @@ cd /app/ros_bridge
 python3 scripts/run_ros_bridge.py \
     --opcua $OPCUA_ENDPOINT \
     --topic-prefix $ROS_TOPIC_PREFIX \
-    --robot-ids "$ROS_ROBOT_IDS" \
+    --scenario "${SCENARIO:-}" \
     --rate 10.0 \
     2>&1 | tee /app/logs/ros_bridge.log &
 

--- a/closed-loop-testing/comm-layer/src/ros_bridge/safety_ros_bridge.py
+++ b/closed-loop-testing/comm-layer/src/ros_bridge/safety_ros_bridge.py
@@ -562,6 +562,28 @@ def _parse_robot_ids(raw: str) -> List[str]:
     return ids
 
 
+ISAAC_SCRIPTS_DIR = os.environ.get("ISAAC_SCRIPTS_DIR", "/app/isaac")
+
+
+def _mirrors_from_scenario(configs_dir: str, scenario_id: str) -> List[str]:
+    """Which robots this scenario's fleet wants a mute mirror for."""
+    if ISAAC_SCRIPTS_DIR not in sys.path:
+        sys.path.insert(0, ISAAC_SCRIPTS_DIR)
+    try:
+        from action_graphs.forklift_common import (
+            load_and_validate_robots_yaml, load_scenario, robots_needing_mute_mirror)
+    except ImportError as exc:
+        raise SystemExit(
+            f"cannot import the fleet loader from {ISAAC_SCRIPTS_DIR} ({exc}). "
+            f"The comm-layer service mounts the Isaac script tree; check that "
+            f"mount, or set ISAAC_SCRIPTS_DIR."
+        ) from exc
+    entry = load_scenario(configs_dir, scenario_id)
+    robots, _ = load_and_validate_robots_yaml(
+        os.path.join(configs_dir, entry["robots"]))
+    return robots_needing_mute_mirror(robots)
+
+
 def main():
     """Standalone entry point"""
     import argparse
@@ -571,12 +593,24 @@ def main():
     parser.add_argument('--direct', action='store_true', help='Direct mode (start ESL receiver)')
     parser.add_argument('--topic-prefix', default='/safety', help='ROS2 topic prefix')
     parser.add_argument('--rate', type=float, default=10.0, help='Publish rate (Hz)')
+    parser.add_argument('--scenario', default='',
+                        help='Scenario id; its fleet file says which robots want a '
+                             'mirror. Overridden by --robot-ids.')
+    parser.add_argument('--configs-dir', default='/app/robots',
+                        help='Directory holding scenarios.yaml and the robots configs')
     parser.add_argument('--robot-ids', default='',
-                        help='Comma-separated robots to mirror is_muted to, e.g. '
-                             '"forklift_b,forklift_b2". Empty publishes the global '
-                             'topic only. Must match the robot names in robots.yaml.')
+                        help='Comma-separated robots to mirror is_muted to. Overrides '
+                             '--scenario; empty publishes the global topic only.')
     args = parser.parse_args()
-    robot_ids = _parse_robot_ids(args.robot_ids)
+    if args.robot_ids:
+        robot_ids = _parse_robot_ids(args.robot_ids)
+        source = 'flag'
+    elif args.scenario:
+        robot_ids = _mirrors_from_scenario(args.configs_dir, args.scenario)
+        source = f'SCENARIO={args.scenario}'
+    else:
+        robot_ids, source = [], 'nothing named a fleet'
+    print(f"[mirrors] {', '.join(robot_ids) or '<none>'}  ({source})", flush=True)
     
     print("""
 ╔══════════════════════════════════════════════════════════╗

--- a/closed-loop-testing/isaac-sim/sil/configs/robots-40x20.yaml
+++ b/closed-loop-testing/isaac-sim/sil/configs/robots-40x20.yaml
@@ -14,11 +14,8 @@
 #        --cameras-config /isaac-sim/sil/configs/cameras-40x20.yaml
 #   3. COMPOSE_PROFILES must include `multi-robot` so the second controller
 #      container (forklift-controller-b2) starts.
-#   4. COMM_ROBOT_IDS (sil.env) must list the same names, or comm-layer never
-#      publishes the /<name>/safety/is_muted the indicators here listen to and
-#      the discs sit on their alarm colour with nothing in the log. comm-layer
-#      also runs in HIL, where this file does not exist, so it cannot read the
-#      names from here — the list is duplicated on purpose. Verify with:
+#   4. comm-layer reads this file too and mirrors the mute onto
+#      /<name>/safety/is_muted for every robot that wants one. Verify with:
 #        ros2 topic info /forklift_b2/safety/is_muted   # want Publisher count: 1
 #   5. The scenario's `waypoints:` must be warehouse_40x20. A path is
 #      metres in one scene's world frame and the controller subtracts the file's
@@ -48,8 +45,8 @@
 # one prim.
 #
 # One block per robot. Add a robot = add a block here (including `spawn:`) + a
-# controller service (forklift-controller.yml) + the name in COMM_ROBOT_IDS. The
-# scene USD is no longer touched. The TGS rebalance list in
+# controller service (forklift-controller.yml). The scene USD is no longer
+# touched. The TGS rebalance list in
 # runtime_patches/halos_runtime_patches.py is derived from this file.
 
 # What follows from the asset, stated once. Two trucks built from one ForkliftB
@@ -147,9 +144,8 @@ robots:
     safety_indicator:
       enabled: true
       # No muted_topic here: it defaults to /<name>/safety/is_muted, which is what
-      # comm-layer publishes for every robot listed in COMM_ROBOT_IDS (sil.env).
-      # Both halves derive the name from the robot name, so it is never typed
-      # twice. Name it explicitly to point a robot at the global /safety/is_muted.
+      # comm-layer publishes for every robot that wants a mirror. Name it
+      # explicitly to point a robot at the global /safety/is_muted instead.
       #
       # No indicator_prim either: the model's parent_prim_rel puts the disc at
       # /World/forklift_b/body/body/safety_indicator, which is what this said.

--- a/closed-loop-testing/isaac-sim/sil/configs/robots.yaml
+++ b/closed-loop-testing/isaac-sim/sil/configs/robots.yaml
@@ -95,7 +95,7 @@ robots:
       enabled: true
       # Explicit on purpose: the default is now the per-robot
       # /<name>/safety/is_muted, which only exists where comm-layer is told to
-      # mirror it (COMM_ROBOT_IDS). This scene stays on the global topic.
+      # mirror it. This scene stays on the global topic.
       muted_topic: /safety/is_muted   # std_msgs/Bool subscriber
       # indicator_prim comes from the model: /World/forklift_b/body/body/safety_indicator
 

--- a/closed-loop-testing/isaac-sim/sil/scripts/action_graphs/README.md
+++ b/closed-loop-testing/isaac-sim/sil/scripts/action_graphs/README.md
@@ -54,9 +54,9 @@ Each builder:
 
 ## Mute topic contract
 
-`forklift_safety_indicator.py` subscribes to `/<name>/safety/is_muted`, derived from the robot's `name` by `forklift_common.resolve_muted_topic()`. comm-layer builds the same string in `SafetyRosBridge._robot_muted_topic()` for every robot listed in its `ROS_ROBOT_IDS` (set from `COMM_ROBOT_IDS` in the deployment profile).
+`forklift_safety_indicator.py` subscribes to `/<name>/safety/is_muted`, derived from the robot's `name` by `forklift_common.resolve_muted_topic()`. comm-layer builds the same string in `SafetyRosBridge._robot_muted_topic()` for every robot `forklift_common.robots_needing_mute_mirror()` returns.
 
-The two sides agree by convention, not by sharing a file: **comm-layer also runs in HIL, where `robots.yaml` does not exist**, so it cannot read the robot list from Isaac's config. That leaves exactly one thing duplicated — the list of robot names — and adding a robot means editing both `robots.yaml` and `COMM_ROBOT_IDS`.
+The two sides agree because they read one file: comm-layer mounts the same configs directory the controllers do, in `hil` as well as `sil`, and asks the shared loader which robots want a mirror. Adding a robot is a block in `robots.yaml`; nothing else lists it.
 
 Forgetting the second edit is silent. Isaac subscribes to a topic nobody publishes, the disc stays on its alarm colour, and nothing is logged as an error.
 

--- a/closed-loop-testing/isaac-sim/sil/scripts/action_graphs/forklift_common.py
+++ b/closed-loop-testing/isaac-sim/sil/scripts/action_graphs/forklift_common.py
@@ -354,13 +354,8 @@ def resolve_indicator_prim(robot: dict) -> str:
     )
 
 
-# Must stay in step with SafetyRosBridge._robot_muted_topic() in comm-layer, which
-# builds the same name from the same robot name. The two systems agree by
-# convention rather than by sharing a file: comm-layer also runs in HIL, where
-# robots.yaml does not exist. Deriving it on both sides means the string is
-# written once per system and never typed into a config file, so the halves
-# cannot drift through a typo — only through someone changing one of these two
-# functions.
+# Must stay in step with SafetyRosBridge._robot_muted_topic() in comm-layer,
+# which builds the same name from the same robot name.
 DEFAULT_SAFETY_TOPIC_PREFIX = "/safety"
 
 
@@ -368,8 +363,8 @@ def resolve_muted_topic(robot: dict) -> str:
     """Which topic this robot's indicator listens on.
 
     Defaults to `/<name>/safety/is_muted`, the per-robot mirror comm-layer
-    publishes when its ROS_ROBOT_IDS lists this robot. Scenes that predate the
-    mirrors keep working by naming the global `/safety/is_muted` explicitly.
+    publishes for every robot this fleet asks a mirror for. Scenes that predate
+    the mirrors keep working by naming the global `/safety/is_muted` explicitly.
     """
     cfg = robot.get("safety_indicator", {}) or {}
     topic = cfg.get(
@@ -381,6 +376,18 @@ def resolve_muted_topic(robot: dict) -> str:
             f"must be an absolute topic name starting with '/', got {topic!r}"
         )
     return topic
+
+
+def robots_needing_mute_mirror(robots: list[dict]) -> list[str]:
+    """Robots whose indicator listens on its own mirror, not the global topic.
+
+    comm-layer publishes a mirror for exactly these; a scene that names the
+    global topic needs none.
+    """
+    global_topic = f"{DEFAULT_SAFETY_TOPIC_PREFIX}/is_muted"
+    return [r["name"] for r in robots
+            if is_section_enabled(r, "safety_indicator")
+            and resolve_muted_topic(r) != global_topic]
 
 
 def _resolve_namespaced_topic(robot: dict, section: str, key: str, suffix: str) -> str:

--- a/deployments/profiles/sil.env
+++ b/deployments/profiles/sil.env
@@ -45,8 +45,6 @@ COMM_LOG_DIR=${MDX_DATA_DIR}/comm-layer
 # expensive mistake: that truck's disc then sits on its alarm colour with
 # nothing in any log. Verify with
 #   ros2 topic info /forklift_b2/safety/is_muted   # want Publisher count: 1
-#COMM_ROBOT_IDS=forklift_b
-COMM_ROBOT_IDS=forklift_b,forklift_b2
 
 # === ROS2 ===
 ROS_DOMAIN_ID=0

--- a/deployments/profiles/sil.env
+++ b/deployments/profiles/sil.env
@@ -32,19 +32,9 @@ COMM_UDP_PORT=12346
 COMM_OPCUA_ENDPOINT=opc.tcp://0.0.0.0:4840/safety/
 COMM_ROS_TOPIC_PREFIX=/safety
 COMM_LOG_DIR=${MDX_DATA_DIR}/comm-layer
-# Robots that get their own /<id>/safety/is_muted alongside the global topic.
-# The names must match `name` in the robots config the scenario names, and the
-# list is extended by hand when a robot is added: comm-layer mounts only its log
-# directory and bakes its source into the image, so it cannot read the fleet
-# file the way the controllers do. Deriving it is a change to that service.
-# Every mirror carries the same value: PSF decides for a camera-covered zone,
-# not for a named truck.
-#
-# Listing a robot the run does not have costs nothing but a topic with no
-# subscriber, so both names are left on by default. Leaving one OUT is the
-# expensive mistake: that truck's disc then sits on its alarm colour with
-# nothing in any log. Verify with
-#   ros2 topic info /forklift_b2/safety/is_muted   # want Publisher count: 1
+# comm-layer mirrors the mute onto /<id>/safety/is_muted for the robots the
+# SCENARIO's fleet file asks for; nothing here lists them. Every mirror carries
+# the same value: PSF decides for a camera-covered zone, not for a named truck.
 
 # === ROS2 ===
 ROS_DOMAIN_ID=0

--- a/deployments/scripts/preflight.py
+++ b/deployments/scripts/preflight.py
@@ -9,7 +9,9 @@ four files that never see each other:
   1. `robots.yaml`          — Isaac builds the prim and the graphs from it
   2. the controller service — publishes that robot's cmd_vel
   3. `waypoints/<id>.json`  — the path the controller follows
-  4. `COMM_ROBOT_IDS`       — tells comm-layer to mirror the mute topic
+
+comm-layer's mute mirrors used to be a fourth list, kept by hand; it now derives
+them from the same fleet file, so they cannot disagree.
 
 Two more decide whether a passing run means anything, and are not checked here:
 `cameras.yaml` places the sensors, and VSS's `calibration.json` states where
@@ -18,15 +20,14 @@ produces frames, detections and PSF verdicts, all of them about the wrong
 warehouse. That pair is asserted by hand — see the scene<->calibration table in
 skills/hoisa-deploy-profile/references/test_scenario.md.
 
-The four cannot be collapsed into one file: comm-layer also runs in HIL, where
-`robots.yaml` does not exist, and the controller is a container the simulator
-knows nothing about. What makes the duplication dangerous is that **every way
-of getting it wrong is silent**. Miss the controller and the truck stands
-still. Miss the waypoint file and it stands still for a different reason. Miss
-`COMM_ROBOT_IDS` and its disc sits on the alarm colour forever. Nothing logs an
-error, because from inside each container nothing is wrong.
+The three cannot be collapsed into one file: the controller is a container the
+simulator knows nothing about, and a waypoint file is drawn by hand. What makes
+the duplication dangerous is that **every way of getting it wrong is silent**.
+Miss the controller and the truck stands still. Miss the waypoint file and it
+stands still for a different reason. Nothing logs an error, because from inside
+each container nothing is wrong.
 
-So this reads all four and says which one disagrees, before Isaac spends three
+So this reads all three and says which one disagrees, before Isaac spends three
 minutes booting. It answers "did I finish adding the robot", not "is the system
 healthy" — it starts nothing and talks to nothing that is running.
 
@@ -201,12 +202,8 @@ def collect(robots_yaml: str, env_file: str):
         name: svc for name, svc in services.items()
         if "ROBOT_ID" in (svc.get("environment") or {})
     }
-    comm_ids: list[str] = []
-    for svc in services.values():
-        raw = (svc.get("environment") or {}).get("ROS_ROBOT_IDS")
-        if raw:
-            comm_ids = [x.strip() for x in raw.split(",") if x.strip()]
-            break
+    # Derived from the fleet, the way comm-layer derives it.
+    comm_ids = common.robots_needing_mute_mirror(robots)
     return common, robots, controllers, comm_ids
 
 
@@ -356,25 +353,6 @@ def check(common, robots, controllers, comm_ids, scene_path=None,
                 f"ROBOT_ID={name}, and put its profile in COMPOSE_PROFILES."
             )))
 
-        if common.is_section_enabled(robot, "safety_indicator"):
-            topic = common.resolve_muted_topic(robot)
-            # A scene naming the global topic opted out of the mirrors and needs
-            # no entry; only a derived per-robot topic depends on the list.
-            if topic != "/safety/is_muted" and name not in comm_ids:
-                findings.append((ERROR, (
-                    f"'{name}' listens on {topic}, which comm-layer is not publishing: "
-                    f"COMM_ROBOT_IDS is {', '.join(comm_ids) or '<empty>'}. Its disc will "
-                    f"sit on the alarm colour for the whole run with nothing in any log. "
-                    f"Add {name} to COMM_ROBOT_IDS in the env file."
-                )))
-
-    for name in comm_ids:
-        if name not in robot_names:
-            findings.append((WARN, (
-                f"COMM_ROBOT_IDS lists '{name}', which this robots config does not have. "
-                f"Harmless — a topic with no subscriber — and expected if the list is "
-                f"shared across scenes."
-            )))
 
     for service_name, svc in sorted(controllers.items()):
         env = svc["environment"]
@@ -417,7 +395,7 @@ def check(common, robots, controllers, comm_ids, scene_path=None,
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Check a robot is wired the same in robots.yaml, the controller "
-                    "service, its waypoint file and COMM_ROBOT_IDS.")
+                    "service and its waypoint file.")
     parser.add_argument("--robots-config", required=True,
                         help="the robots.yaml Isaac will be launched with (no default: "
                              "checking the wrong one is the failure this catches)")
@@ -446,12 +424,12 @@ def main() -> int:
         for name, svc in sorted(controllers.items())
     )
     print(f"controllers   : {listed or '<none>'}")
-    print(f"COMM_ROBOT_IDS: {', '.join(comm_ids) or '<empty>'}")
+    print(f"mute mirrors  : {', '.join(comm_ids) or '<none>'}")
     print()
 
     findings = check(common, robots, controllers, comm_ids, scene_path, robots_yaml)
     if not findings:
-        print("OK — all four lists agree, and every waypoint origin matches its truck.")
+        print("OK — all three lists agree, and every waypoint origin matches its truck.")
         return 0
 
     for level, message in findings:

--- a/skills/hoisa-deploy-profile/SKILL.md
+++ b/skills/hoisa-deploy-profile/SKILL.md
@@ -134,7 +134,7 @@ Deploy in strict order. **Stack 1 (VSS) must be running before Stack 2 (Halos).*
 - [ ] 10. Monitor until sim-driven safety transitions appear (the "complete" signal)
 ```
 
-Step 8 exists because a robot has to be listed in four places — `robots.yaml`, a controller service, its waypoint file, and `COMM_ROBOT_IDS` — and **every way of getting it half-right is silent**. Two of the four produce the same symptom, a truck that sits there; the third produces a disc that looks like a working indicator reporting danger. The check takes a second and runs on the host; Isaac takes three minutes to boot before showing you any of it. Pass the config you will actually launch with — it has no default on purpose.
+Step 8 exists because a robot has to be listed in three places — `robots.yaml`, a controller service, and its waypoint file — and **every way of getting it half-right is silent**. Two of the three produce the same symptom, a truck that sits there. The check takes a second and runs on the host; Isaac takes three minutes to boot before showing you any of it. Pass the config you will actually launch with — it has no default on purpose.
 
 It also compares each waypoint file's `origin` against where its truck stands, which is a different kind of mistake: the names all agree, the truck drives, and only the lane is wrong. Waypoints are per scene (`waypoints/<map id>/<ROBOT_ID>.json`, the map chosen by `SCENARIO`) because the coordinates are metres in one warehouse's world frame. The scene<->config<->waypoints<->calibration pairings are tabulated in `references/test_scenario.md`; the 40x20 scene has no published calibration and is experimental.
 


### PR DESCRIPTION
> Depends on #66 (one scenario reader), already merged.

`COMM_ROBOT_IDS` was a fourth list of robot names kept by hand, next to `robots.yaml`, the controller service and the waypoint file. It was also the one whose failure is quietest: a truck missing from it listens on a topic nobody publishes, so **its disc sits on the alarm colour for the whole run and nothing logs an error** — from inside each container the wiring is complete.

comm-layer now mounts the same configs directory and script tree the controllers mount, reads `SCENARIO`, and mirrors for exactly the robots whose fleet entry asks for a per-robot topic. `forklift_common.resolve_muted_topic()` already decided that per robot; this only asks it for the whole fleet.

```
[mirrors] <none>                     (SCENARIO=warehouse_20x20_1fl)
[mirrors] forklift_b, forklift_b2    (SCENARIO=warehouse_40x20)
```

`--robot-ids` still overrides, for a run with no scenario.

## The shipped value was already wrong

`sil.env` named two trucks, while `robots.yaml` declares one and names the global `/safety/is_muted` explicitly. So every 20x20 run published two mirrors nobody subscribed to, and preflight warned about it every time:

```
[warn] COMM_ROBOT_IDS lists 'forklift_b2', which this robots config does not have.
```

Derived, that run asks for no mirrors and the warning is gone — 20x20 preflight goes from 2 warnings to 1.

## preflight checks three lists, not four

The two `COMM_ROBOT_IDS` findings are removed rather than rewritten: neither can happen once both sides read one file.

## A wrong claim, in three places

The stated reason the list had to be duplicated was that *comm-layer also runs in HIL, where `robots.yaml` does not exist*. It does exist — `isaac-sim` runs on the same x86 host from the same checkout, in both profiles — so the mount works in `hil` too. Corrected in `forklift_common`, `action_graphs/README.md` and preflight's own header.

## Testing

- the resolver returns no mirrors for the single-forklift scenario and both trucks for the two-forklift one, run through **comm-layer's own code path** with `ISAAC_SCRIPTS_DIR` pointed at the checkout
- `docker compose config` renders both mounts and `SCENARIO` into the service, for `base`, `sil` and `hil`
- `preflight.py`: 0 errors for both scenarios
- Python compile, `bash -n`, YAML parse

**Not verified: the container itself.** The comm-layer image changes (`ROS_ROBOT_IDS` default dropped, mountpoints added), so this needs `up -d --build` and a smoke test that the mirrors appear on the two-forklift run and are absent on the single one. Happy to run that before merge — say the word.
