### PR TITLE
fix(sil): swap the pallet truck the 3D model to box

### DIFF
--- a/closed-loop-testing/isaac-sim/sil/scenes/indicator_warehouse_20x20_layout_overflow_test.usd
+++ b/closed-loop-testing/isaac-sim/sil/scenes/indicator_warehouse_20x20_layout_overflow_test.usd
@@ -47,8 +47,6 @@
             }
             dictionary "/World/SM_Forklift_B01_Red_01_physics" = {
             }
-            dictionary "/World/SM_HeavyDutyPalletTruck_A01_01" = {
-            }
             dictionary "/World/SM_PrintersBox_A10_01_physics" = {
             }
             dictionary "/World/WarehousePile_A1_physics" = {
@@ -34125,19 +34123,18 @@ def Xform "World"
         }
     }
 
-    def "SM_HeavyDutyPalletTruck_A01_01" (
+    def "SM_CardBox_A1_01" (
         active = true
         prepend apiSchemas = ["SemanticsLabelsAPI:class"]
-        prepend payload = @/isaac-sim/collected-assets/Vehicles/SM_HeavyDutyPalletTruck_A01_01/SM_HeavyDutyPalletTruck_A01_01.usd@
+        prepend payload = @https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/simready_content/common_assets/props/cardbox_a1/cardbox_a1.usd@
     )
     {
-        token[] semantics:labels:class = ["pallettruck"]
+        token[] semantics:labels:class = ["cardbox"]
         token visibility = "inherited"
         double3 xformOp:rotateZYX = (0, 0, -65.30000097304583)
         float3 xformOp:scale = (1, 1, 1)
-        double3 xformOp:scale:unitsResolve = (0.01, 0.01, 0.01)
-        double3 xformOp:translate = (7.5037501880972375, -9.400364645142483, 0.0000014476929663942422)
-        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateZYX", "xformOp:scale", "xformOp:scale:unitsResolve"]
+        double3 xformOp:translate = (7.5037501880972375, -9.400364645142483, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateZYX", "xformOp:scale"]
     }
 
     def "SM_Forklift_A01_Blue_01" (

--- a/closed-loop-testing/isaac-sim/sil/scenes/warehouse_40x20_two_loading_dock.usd
+++ b/closed-loop-testing/isaac-sim/sil/scenes/warehouse_40x20_two_loading_dock.usd
@@ -45,8 +45,6 @@
             }
             dictionary "/World/SM_Forklift_B01_Red_01_physics" = {
             }
-            dictionary "/World/SM_HeavyDutyPalletTruck_A01_01" = {
-            }
             dictionary "/World/SM_PrintersBox_A10_01_physics" = {
             }
             dictionary "/World/WarehousePile_A1_physics" = {
@@ -34625,18 +34623,17 @@ def Xform "World"
         }
     }
 
-    def "SM_HeavyDutyPalletTruck_A01_01" (
+    def "SM_CardBox_A1_01" (
         prepend apiSchemas = ["SemanticsLabelsAPI:class"]
-        prepend payload = @../../collected-assets/Vehicles/SM_HeavyDutyPalletTruck_A01_01/SM_HeavyDutyPalletTruck_A01_01.usd@
+        prepend payload = @https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/simready_content/common_assets/props/cardbox_a1/cardbox_a1.usd@
     )
     {
-        token[] semantics:labels:class = ["pallettruck"]
+        token[] semantics:labels:class = ["cardbox"]
         token visibility = "inherited"
         double3 xformOp:rotateZYX = (0, 0, -65.30000097304583)
         float3 xformOp:scale = (1, 1, 1)
-        double3 xformOp:scale:unitsResolve = (0.01, 0.01, 0.01)
-        double3 xformOp:translate = (7.5037501880972375, -9.400364645142483, 0.0000014476929663942422)
-        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateZYX", "xformOp:scale", "xformOp:scale:unitsResolve"]
+        double3 xformOp:translate = (7.5037501880972375, -9.400364645142483, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateZYX", "xformOp:scale"]
     }
 
     def "SM_Forklift_A01_Blue_01" (


### PR DESCRIPTION

The 3D model misdetects the static pallet truck as a forklift when the fork is hidden, and the post-processing workaround that maps both classes to forklift then leaves a redundant box on a prop that never moves. The 2D model does not see it at all, so the prop earns nothing in either scenario.

cardbox_a1 replaces it in both scenes at the same spot, and the ground-truth label moves to cardbox with it -- leaving it as pallettruck would keep feeding the same confusion from the data side.

The asset is SimReady and already metres, so it carries no unitsResolve op and no metricsAssembler entry; the pallet truck needed both because it is authored in centimetres. Its origin sits at the base of the box, so z stays on the floor.

Rendered from all three production cameras in both scenes to confirm placement, and cleared against the forklift waypoints (2.9 m) and the character loops (1.2 m at the closest walk segment).